### PR TITLE
Claim to require Golang 1.2+ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rough performance testing shows that, on consumer hardware and an average disk, 
 \* Note that while it's not exactly Gremlin, it certainly takes inspiration from that API. For this flavor, [see the documentation](docs/GremlinAPI.md).
 
 ## Building
-Make sure you have the right packages installed. Mostly, this is just Go as a dependency, and different ways of pulling packages.
+Make sure you have the right packages installed. Mostly, this is just Go 1.2+ as a dependency, and different ways of pulling packages.
 
 ### Linux
 **Ubuntu / Debian**


### PR DESCRIPTION
in https://github.com/google/cayley/blob/master/make.sh#L28

```
go get -u -t github.com/smartystreets/goconvey
```

-t option is added in Golang 1.2 http://golang.org/doc/go1.2#gocmd

Considering that old Ubuntu and RHEL may still use go1.1 or go1.0, we'd better make it clear that we requires Goland 1.2 here
