### PR TITLE
implement the -cpuprofile flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alexander Peters <info@alexanderpeters.de>
 Google Inc.
 Jay Graves <jaywgraves@gmail.com>
 Jeremy Jay <jeremy@pbnjay.com>
+Martin Czygan <martin.czygan@gmail.com>
 Pius Uzamere <pius+github@alum.mit.edu>
 Robert Daniel Kortschak <dan.kortschak@adelaide.edu.au>
 Timothy Armstrong <armstrong.timothy@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Alexander Peters <info@alexanderpeters.de>
 Barak Michener <barakmich@google.com> <barak@cayley.io> <me@barakmich.com>
 Jay Graves <jaywgraves@gmail.com>
 Jeremy Jay <jeremy@pbnjay.com>
+Martin Czygan <martin.czygan@gmail.com>
 Pius Uzamere <pius+github@alum.mit.edu>
 Robert Daniel Kortschak <dan.kortschak@adelaide.edu.au>
 Timothy Armstrong <armstrong.timothy@gmail.com>

--- a/cayley.go
+++ b/cayley.go
@@ -19,6 +19,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	nethttp "net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 
@@ -36,9 +38,9 @@ import (
 )
 
 var tripleFile = flag.String("triples", "", "Triple File to load before going to REPL.")
-var cpuprofile = flag.String("prof", "", "Output profiling file.")
 var queryLanguage = flag.String("query_lang", "gremlin", "Use this parser as the query language.")
 var configFile = flag.String("config", "", "Path to an explicit configuration file.")
+var profile = flag.Bool("profile", false, "Always start cpu profiling server (not required with http command)")
 
 func Usage() {
 	fmt.Println("Cayley is a graph store and graph query layer.")
@@ -77,6 +79,11 @@ func main() {
 		glog.Infoln("GOMAXPROCS currently", os.Getenv("GOMAXPROCS"), " -- not adjusting")
 	}
 
+	if *profile && cmd != "http" {
+		go func() {
+			glog.Info(nethttp.ListenAndServe(fmt.Sprintf("localhost:%s", cfg.ListenPort), nil))
+		}()
+	}
 	var (
 		ts  graph.TripleStore
 		err error


### PR DESCRIPTION
Noticed the `-prof` flag was there, but the profiling was missing.

Added profiling as described in [Profiling Go Programs](http://blog.golang.org/profiling-go-programs).

Example output for the load operation (with leveldb) of `30kmoviesdata.nt`:

![cpu](https://cloud.githubusercontent.com/assets/53705/3541482/b5359388-084c-11e4-9005-9d9ccdfdf976.jpg)

----

I signed the [CLA](https://developers.google.com/open-source/cla/individual).