### PR TITLE
Switch to the latest mgo path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
   - go get github.com/syndtr/goleveldb/leveldb/iterator
   - go get github.com/syndtr/goleveldb/leveldb/opt
   - go get github.com/syndtr/goleveldb/leveldb/util
-  - go get labix.org/v2/mgo
-  - go get labix.org/v2/mgo/bson
+  - go get gopkg.in/mgo.v2
+  - go get gopkg.in/mgo.v2/bson

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 
 	"github.com/barakmich/glog"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"

--- a/graph/mongo/triplestore.go
+++ b/graph/mongo/triplestore.go
@@ -20,8 +20,8 @@ import (
 	"hash"
 	"log"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"github.com/barakmich/glog"
 	"github.com/google/cayley/graph"


### PR DESCRIPTION
This is not only the right thing to do, as per the documentation of the
latest release (yesterday) but it should now be backed by git and not
bzr, which is a big plus and won't break our build so much.
