### PR TITLE
Removed .gz from example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ cayley> graph.Vertex("dani").Out("follows").All()
 For somewhat more interesting data, a sample of 30k movies from Freebase comes in the checkout.
 
 ```
-./cayley repl --dbpath=30kmoviedata.nt.gz
+./cayley repl --dbpath=30kmoviedata.nt
 ```
 
 To run the web frontend, replace the "repl" command with "http"
 
 ```
-./cayley http --dbpath=30kmoviedata.nt.gz
+./cayley http --dbpath=30kmoviedata.nt
 ```
 
 And visit port 64210 on your machine, commonly [http://localhost:64210](http://localhost:64210)


### PR DESCRIPTION
Running with `.gz`:

``` sh
$ ./cayley repl --dbpath=testdata.nt.gz
F0724 00:29:19.795367 10052 load.go:55] Couldn't open file testdata.nt.gz
goroutine 22 [running]:
github.com/barakmich/glog.stacks(0x18cba400, 0x0, 0x0, 0x0)
    /home/barak/src/all-cayley/barakmich-cayley/src/github.com/barakmich/glog/glog.go:810 +0xc7
github.com/barakmich/glog.(*loggingT).output(0x89b5b60, 0x3, 0x18c028c0)
    /home/barak/src/all-cayley/barakmich-cayley/src/github.com/barakmich/glog/glog.go:761 +0x3ad
github.com/barakmich/glog.(*loggingT).println(0x89b5b60, 0x3, 0xf74c6fac, 0x2, 0x2)
    /home/barak/src/all-cayley/barakmich-cayley/src/github.com/barakmich/glog/glog.go:677 +0x9a
github.com/barakmich/glog.Fatalln(0xf74c6fac, 0x2, 0x2)
```
