### PR TITLE
Optimize iterators

### DIFF
--- a/graph/iterator/and_iterator_optimize.go
+++ b/graph/iterator/and_iterator_optimize.go
@@ -50,8 +50,7 @@ func (it *And) Optimize() (graph.Iterator, bool) {
 	// changed.
 	its := optimizeSubIterators(old)
 
-	// Close the replaced iterators (they ought to close themselves, but Close()
-	// is idempotent, so this just protects against any machinations).
+	// Close the replaced iterators.
 	closeIteratorList(old, nil)
 
 	// If we can find only one subiterator which is equivalent to this whole and,

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -90,6 +90,7 @@ func (it *HasA) Direction() graph.Direction { return it.dir }
 func (it *HasA) Optimize() (graph.Iterator, bool) {
 	newPrimary, changed := it.primaryIt.Optimize()
 	if changed {
+		it.primaryIt.Close()
 		it.primaryIt = newPrimary
 		if it.primaryIt.Type() == graph.Null {
 			return it.primaryIt, true

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -117,6 +117,7 @@ func (it *LinksTo) SubIterators() []graph.Iterator {
 func (it *LinksTo) Optimize() (graph.Iterator, bool) {
 	newPrimary, changed := it.primaryIt.Optimize()
 	if changed {
+		it.primaryIt.Close()
 		it.primaryIt = newPrimary
 		if it.primaryIt.Type() == graph.Null {
 			it.nextIt.Close()

--- a/graph/iterator/optional_iterator.go
+++ b/graph/iterator/optional_iterator.go
@@ -135,3 +135,7 @@ func (it *Optional) Stats() graph.IteratorStats {
 		Size:      subStats.Size,
 	}
 }
+
+func (it *Optional) SubIterators() []graph.Iterator {
+	return []graph.Iterator{it.subIt}
+}

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -235,8 +235,7 @@ func (it *Or) Close() {
 func (it *Or) Optimize() (graph.Iterator, bool) {
 	old := it.SubIterators()
 	optIts := optimizeSubIterators(old)
-	// Close the replaced iterators (they ought to close themselves, but Close()
-	// is idempotent, so this just protects against any machinations).
+	// Close the replaced iterators.
 	closeIteratorList(old, nil)
 	newOr := NewOr()
 	newOr.isShortCircuiting = it.isShortCircuiting

--- a/graph/memstore/triplestore_iterator_optimize.go
+++ b/graph/memstore/triplestore_iterator_optimize.go
@@ -46,6 +46,7 @@ func (ts *TripleStore) optimizeLinksTo(it *iterator.LinksTo) (graph.Iterator, bo
 			for _, tag := range primary.Tags() {
 				newIt.AddFixedTag(tag, val)
 			}
+			it.Close()
 			return newIt, true
 		}
 	}

--- a/graph/sexp/session.go
+++ b/graph/sexp/session.go
@@ -69,6 +69,12 @@ func (s *Session) ExecInput(input string, out chan interface{}, limit int) {
 	it := BuildIteratorTreeForQuery(s.ts, input)
 	newIt, changed := it.Optimize()
 	if changed {
+		it.Close()
+		it = newIt
+	}
+	newIt, changed = s.ts.OptimizeIterator(it)
+	if changed {
+		it.Close()
 		it = newIt
 	}
 
@@ -99,6 +105,7 @@ func (s *Session) ExecInput(input string, out chan interface{}, limit int) {
 		}
 	}
 	close(out)
+	it.Close()
 }
 
 func (s *Session) ToText(result interface{}) string {

--- a/graph/triplestore.go
+++ b/graph/triplestore.go
@@ -76,7 +76,9 @@ type TripleStore interface {
 	// Optimize an iterator in the context of the triple store.
 	// Suppose we have a better index for the passed tree; this
 	// gives the TripleStore the opportunity to replace it
-	// with a more efficient iterator.
+	// with a more efficient iterator. If optimization is done,
+	// the calling code is responsible for Close()-ing the
+	// returned iterator.
 	OptimizeIterator(it Iterator) (Iterator, bool)
 
 	// Close the triple store and clean up. (Flush to disk, cleanly

--- a/query/gremlin/finals.go
+++ b/query/gremlin/finals.go
@@ -146,7 +146,16 @@ func tagsToValueMap(m map[string]graph.Value, ses *Session) map[string]string {
 func runIteratorToArray(it graph.Iterator, ses *Session, limit int) []map[string]string {
 	output := make([]map[string]string, 0)
 	count := 0
-	it, _ = it.Optimize()
+	newIt, changed := it.Optimize()
+	if changed {
+		it.Close()
+		it = newIt
+	}
+	newIt, changed = ses.ts.OptimizeIterator(it)
+	if changed {
+		it.Close()
+		it = newIt
+	}
 	for {
 		if ses.doHalt {
 			return nil
@@ -182,7 +191,16 @@ func runIteratorToArray(it graph.Iterator, ses *Session, limit int) []map[string
 func runIteratorToArrayNoTags(it graph.Iterator, ses *Session, limit int) []string {
 	output := make([]string, 0)
 	count := 0
-	it, _ = it.Optimize()
+	newIt, changed := it.Optimize()
+	if changed {
+		it.Close()
+		it = newIt
+	}
+	newIt, changed = ses.ts.OptimizeIterator(it)
+	if changed {
+		it.Close()
+		it = newIt
+	}
 	for {
 		if ses.doHalt {
 			return nil
@@ -203,7 +221,16 @@ func runIteratorToArrayNoTags(it graph.Iterator, ses *Session, limit int) []stri
 
 func runIteratorWithCallback(it graph.Iterator, ses *Session, callback otto.Value, this otto.FunctionCall, limit int) {
 	count := 0
-	it, _ = it.Optimize()
+	newIt, changed := it.Optimize()
+	if changed {
+		it.Close()
+		it = newIt
+	}
+	newIt, changed = ses.ts.OptimizeIterator(it)
+	if changed {
+		it.Close()
+		it = newIt
+	}
 	for {
 		if ses.doHalt {
 			return
@@ -242,7 +269,16 @@ func runIteratorOnSession(it graph.Iterator, ses *Session) {
 		iterator.OutputQueryShapeForIterator(it, ses.ts, ses.queryShape)
 		return
 	}
-	it, _ = it.Optimize()
+	newIt, changed := it.Optimize()
+	if changed {
+		it.Close()
+		it = newIt
+	}
+	newIt, changed = ses.ts.OptimizeIterator(it)
+	if changed {
+		it.Close()
+		it = newIt
+	}
 	glog.V(2).Infoln(it.DebugString(0))
 	for {
 		// TODO(barakmich): Better halting.

--- a/query/mql/session.go
+++ b/query/mql/session.go
@@ -83,7 +83,18 @@ func (s *Session) ExecInput(input string, c chan interface{}, limit int) {
 	if s.currentQuery.isError() {
 		return
 	}
-	it, _ := s.currentQuery.it.Optimize()
+	newIt, changed := s.currentQuery.it.Optimize()
+	if changed {
+		s.currentQuery.it.Close()
+		s.currentQuery.it = newIt
+	}
+	newIt, changed = s.ts.OptimizeIterator(s.currentQuery.it)
+	if changed {
+		s.currentQuery.it.Close()
+		s.currentQuery.it = newIt
+	}
+	it := s.currentQuery.it
+
 	if glog.V(2) {
 		glog.V(2).Infoln(it.DebugString(0))
 	}
@@ -101,6 +112,7 @@ func (s *Session) ExecInput(input string, c chan interface{}, limit int) {
 			c <- tags
 		}
 	}
+	it.Close()
 }
 
 func (s *Session) ToText(result interface{}) string {


### PR DESCRIPTION
Simple updates. 1) Always Close() an interator when replaced, and 2) Give TripleStore a chance to optimize things.

(I've signed CLA)
