### PR TITLE
fix non-pointer uintptr -> uint64, export NextUID

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -114,7 +114,7 @@ type Iterator interface {
 	Close()
 
 	// UID returns the unique identifier of the iterator.
-	UID() uintptr
+	UID() uint64
 }
 
 // FixedIterator wraps iterators that are modifiable by addition of fixed value sets.

--- a/graph/iterator/iterator.go
+++ b/graph/iterator/iterator.go
@@ -27,10 +27,10 @@ import (
 	"github.com/google/cayley/graph"
 )
 
-var nextIteratorID uintptr
+var nextIteratorID uint64
 
-func nextID() uintptr {
-	return atomic.AddUintptr(&nextIteratorID, 1) - 1
+func NextUID() uint64 {
+	return atomic.AddUint64(&nextIteratorID, 1) - 1
 }
 
 // The Base iterator is the iterator other iterators inherit from to get some
@@ -40,7 +40,7 @@ type Base struct {
 	tags      []string
 	fixedTags map[string]graph.Value
 	canNext   bool
-	uid       uintptr
+	uid       uint64
 }
 
 // Called by subclases.
@@ -48,11 +48,11 @@ func BaseInit(it *Base) {
 	// Your basic iterator is nextable
 	it.canNext = true
 	if glog.V(2) {
-		it.uid = nextID()
+		it.uid = NextUID()
 	}
 }
 
-func (it *Base) UID() uintptr {
+func (it *Base) UID() uint64 {
 	return it.uid
 }
 


### PR DESCRIPTION
A trivial tweak. Fixes type semantics for UID, and allows other iterator implementations to use global UID namespace.

(I've signed CLA)
