### PR TITLE
Remove terminal newline from quad.Quad stringer

### DIFF
--- a/db/open.go
+++ b/db/open.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Open(cfg *config.Config) (graph.TripleStore, error) {
-	glog.Infof("Opening database \"%s\" at %s", cfg.DatabaseType, cfg.DatabasePath)
+	glog.Infof("Opening database %q at %s", cfg.DatabaseType, cfg.DatabasePath)
 	ts, err := graph.NewTripleStore(cfg.DatabaseType, cfg.DatabasePath, cfg.DatabaseOptions)
 	if err != nil {
 		return nil, err

--- a/graph/memstore/triplestore.go
+++ b/graph/memstore/triplestore.go
@@ -25,6 +25,12 @@ import (
 	"github.com/petar/GoLLRB/llrb"
 )
 
+func init() {
+	graph.RegisterTripleStore("memstore", func(string, graph.Options) (graph.TripleStore, error) {
+		return newTripleStore(), nil
+	}, nil)
+}
+
 type TripleDirectionIndex struct {
 	subject   map[int64]*llrb.LLRB
 	predicate map[int64]*llrb.LLRB
@@ -240,7 +246,7 @@ func (ts *TripleStore) DebugPrint() {
 		if i == 0 {
 			continue
 		}
-		glog.V(2).Infoln("%d: %s", i, t)
+		glog.V(2).Infof("%d: %s", i, t)
 	}
 }
 
@@ -269,9 +275,3 @@ func (ts *TripleStore) NodesAllIterator() graph.Iterator {
 	return NewMemstoreAllIterator(ts)
 }
 func (ts *TripleStore) Close() {}
-
-func init() {
-	graph.RegisterTripleStore("memstore", func(string, graph.Options) (graph.TripleStore, error) {
-		return newTripleStore(), nil
-	}, nil)
-}

--- a/graph/result_tree_evaluator_test.go
+++ b/graph/result_tree_evaluator_test.go
@@ -26,7 +26,7 @@ func TestSingleIterator(t *testing.T) {
 	result := StringResultTreeEvaluator(all)
 	expected := "(1)\n(2)\n(3)\n"
 	if expected != result {
-		t.Errorf("Expected \"%s\" got \"%s\"", expected, result)
+		t.Errorf("Expected %q got %q", expected, result)
 	}
 }
 
@@ -40,6 +40,6 @@ func TestAndIterator(t *testing.T) {
 	result := StringResultTreeEvaluator(and)
 	expected := "(3 (3) (3))\n"
 	if expected != result {
-		t.Errorf("Expected \"%s\" got \"%s\"", expected, result)
+		t.Errorf("Expected %q got %q", expected, result)
 	}
 }

--- a/quad/quad.go
+++ b/quad/quad.go
@@ -125,8 +125,7 @@ func (q *Quad) Equals(o *Quad) bool {
 
 // Pretty-prints a triple.
 func (q *Quad) String() string {
-	// TODO(kortschak) String methods should generally not terminate in '\n'.
-	return fmt.Sprintf("%s -- %s -> %s\n", q.Subject, q.Predicate, q.Object)
+	return fmt.Sprintf("%s -- %s -> %s", q.Subject, q.Predicate, q.Object)
 }
 
 func (q *Quad) IsValid() bool {


### PR DESCRIPTION
This is the conventional implementation of a fmt.Stringer.

Also went through and fixed up some lint and moved registration init() functions to top of files so they are immediately obvious.
