### PR TITLE
Allow memstore instances to be started empty

### DIFF
--- a/cayley.go
+++ b/cayley.go
@@ -193,6 +193,9 @@ func load(ts graph.TripleStore, cfg *config.Config, path, typ string) error {
 	if path == "" {
 		path = cfg.DatabasePath
 	}
+	if path == "" {
+		return nil
+	}
 	u, err := url.Parse(path)
 	if err != nil || u.Scheme == "file" || u.Scheme == "" {
 		// Don't alter relative URL path or non-URL path parameter.


### PR DESCRIPTION
This allows easier debugging of web UI problem.

I was able to reproduce the defect described in #106 using memstore with this change to get to an empty db (otherwise not possible AFAICS).
