### PR TITLE
Bump to Go 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.2
   - 1.3
+  - 1.3.1
   - tip
 
 install:


### PR DESCRIPTION
Looks like our dependency on [GoLevelDB](https://github.com/syndtr/goleveldb) now takes 1.3 So we should do the same. Maybe even grab the sync.Pool around hashers, but that's not really a big slowdown right now. Right now, fix .travis.yml
