### PR TITLE
Clean up usage

### DIFF
--- a/cayley.go
+++ b/cayley.go
@@ -64,8 +64,7 @@ var (
 )
 
 func usage() {
-	fmt.Fprintln(os.Stderr, `Cayley is a graph store and graph query layer.
-
+	fmt.Fprintln(os.Stderr, `
 Usage:
   cayley COMMAND [flags]
 
@@ -87,6 +86,7 @@ func init() {
 func main() {
 	// No command? It's time for usage.
 	if len(os.Args) == 1 {
+		fmt.Fprintln(os.Stderr, "Cayley is a graph store and graph query layer.")
 		usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Use raw strings.
- Hook usage into flag.
- Print banner to stderr as flag.PrintDefaults does.
- Use the cayley usage rather than the flag ussage when command is unknown.
- Simplify args handling.
