### PR TITLE
Add go generate directive

### DIFF
--- a/quad/cquads/cquads.go
+++ b/quad/cquads/cquads.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate ragel -Z -G2 parse.rl
+
 // Package cquads implements parsing N-Quads like line-based syntax
 // for RDF datasets.
 //

--- a/quad/nquads/nquads.go
+++ b/quad/nquads/nquads.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate ragel -Z -G2 parse.rl
+
 // Package nquads implements parsing the RDF 1.1 N-Quads line-based syntax
 // for RDF datasets.
 //


### PR DESCRIPTION
At this stage this is just a comment for users. The directive will have effect at go tip when go CL125580044 is submitted. When that happens, at tip parser code generation can be acheived in the default case with:

```
go generate
```

in the relevant package directory.
