### PR TITLE
support or-equals in mql

### DIFF
--- a/docs/MQL.md
+++ b/docs/MQL.md
@@ -84,3 +84,30 @@ A some_predicate C .
 exist.
 
 This combines with the reversal rule to create paths like ``"@a:!some_predicate"``
+
+## Union Queries (aka or-equals)
+
+To query for predicates that match one of a number of constraints the suffix `"|="` can be used along with an array of subqueries.  Subqueries can be simple strings to match against specific values or they can also be objects that describe constraints to match against.
+
+```json
+[{
+  "id|=": ["A", "B"]
+}]
+```
+
+Will match *either* A or B.
+
+```json
+[{
+  "id|=": [
+    {
+      "follows": "F"
+    },
+    {
+      "status": "cool"
+    }
+  ]
+}]
+```
+
+Will match everyone who follows F or is cool.

--- a/query/mql/mql_test.go
+++ b/query/mql/mql_test.go
@@ -187,6 +187,18 @@ var testQueries = []struct {
 			]
 		`,
 	},
+	{
+		message: "get correct or-equals reversal",
+		query:   `[{"id": null, "!follows|=": ["F", { "id": null, "status": "cool" }]}]`,
+		expect: `
+			[
+				{"id": "G"}
+				{"id": "D"},
+				{"id": "B"},
+				{"id": "F"}
+			]
+		`,
+	},
 }
 
 func runQuery(g []quad.Quad, query string) interface{} {

--- a/query/mql/mql_test.go
+++ b/query/mql/mql_test.go
@@ -167,6 +167,7 @@ var testQueries = []struct {
 	},
 	{
 		message: "get correct or-equals id",
+		// ids of nodes that have id A or B
 		query:   `[{"id": null, "id|=": ["A", "B"]}]`,
 		expect: `
 			[
@@ -176,26 +177,54 @@ var testQueries = []struct {
 		`,
 	},
 	{
+		message: "get correct or-equals follows",
+		// id of nodes that follow B or D
+		query:   `[{"id": null, "follows|=": ["B", "D"]}]`,
+		expect: `
+			[
+				{"id": "A"},
+				{"id": "C"},
+				{"id": "D"}
+			]
+		`,
+	},
+	{
 		message: "get correct or-equals object subquery",
-		query:   `[{"id": null, "id|=": [{ "follows": "F" }, { "status": "cool" }]}]`,
+		// ids of nodes which follow someone that follows F or follows someone who is cool
+		query:   `[{"id": null, "follows|=": [{ "follows": "F" }, { "status": "cool" }]}]`,
 		expect: `
 			[
 				{"id": "B"},
 				{"id": "E"},
-				{"id": "D"},
-				{"id": "G"}
+				{"id": "A"},
+				{"id": "C"},
+				{"id": "F"},
+				{"id": "D"}
 			]
 		`,
 	},
 	{
 		message: "get correct or-equals reversal",
-		query:   `[{"id": null, "!follows|=": ["F", { "id": null, "status": "cool" }]}]`,
+		// ids of nodes which are followed by F or by someone cool
+		query:   `[{"id": null, "!follows|=": ["F", { "status": "cool" }]}]`,
 		expect: `
 			[
+				{"id": "F"},
 				{"id": "G"}
+			]
+		`,
+	},
+	{
+		message: "get correct nested or-equals",
+		// ids of nodes which have an id of someone who follows F or G or is cool
+		query:   `[{"id": null, "id|=": [{ "follows|=": ["F", "G"] }, { "status": "cool" }]}]`,
+		expect: `
+			[
 				{"id": "D"},
 				{"id": "B"},
-				{"id": "F"}
+				{"id": "F"},
+				{"id": "E"},
+				{"id": "G"}
 			]
 		`,
 	},

--- a/query/mql/mql_test.go
+++ b/query/mql/mql_test.go
@@ -165,6 +165,28 @@ var testQueries = []struct {
 			]
 		`,
 	},
+	{
+		message: "get correct or-equals id",
+		query:   `[{"id": null, "id|=": ["A", "B"]}]`,
+		expect: `
+			[
+				{"id": "A"},
+				{"id": "B"}
+			]
+		`,
+	},
+	{
+		message: "get correct or-equals object subquery",
+		query:   `[{"id": null, "id|=": [{ "follows": "F" }, { "status": "cool" }]}]`,
+		expect: `
+			[
+				{"id": "B"},
+				{"id": "E"},
+				{"id": "D"},
+				{"id": "G"}
+			]
+		`,
+	},
 }
 
 func runQuery(g []quad.Quad, query string) interface{} {


### PR DESCRIPTION
@barakmich i think i have a general idea of what needs to happen here:
- right after where [`reverse`](https://github.com/google/cayley/blob/84375200183f13816ae02c88f0da3ac559909289/query/mql/build_iterator.go#L122-L125) is determined i need to use a similar pattern - determine if the suffix is `"|="`, set a flag, strip the suffix from `pred`
- then somewhere a few lines later (i'm not exactly certain where) if the flag i set indicates an or-equals then i need to have a block of code something like what's [already in gremlin](https://github.com/google/cayley/blob/84375200183f13816ae02c88f0da3ac559909289/query/gremlin/build_iterator.go#L259-L270) to use `iterator.NewOr()`

the details are probably what will take me some time so i'll take any further advice you can give.
