### PR TITLE
Implementation of the PrimaryKey type

### DIFF
--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/keys"
 	"github.com/google/cayley/quad"
 )
 
@@ -124,8 +125,8 @@ func (qs *QuadStore) Size() int64 {
 	return qs.size
 }
 
-func (qs *QuadStore) Horizon() int64 {
-	return qs.horizon
+func (qs *QuadStore) Horizon() graph.PrimaryKey {
+	return keys.NewSequentialKey(qs.horizon)
 }
 
 func (qs *QuadStore) createDeltaKeyFor(id int64) []byte {
@@ -195,13 +196,13 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 			if err != nil {
 				return err
 			}
-			err = b.Put(qs.createDeltaKeyFor(d.ID), bytes)
+			err = b.Put(qs.createDeltaKeyFor(d.ID.Int()), bytes)
 			if err != nil {
 				return err
 			}
 		}
 		for _, d := range deltas {
-			err := qs.buildQuadWrite(tx, d.Quad, d.ID, d.Action == graph.Add)
+			err := qs.buildQuadWrite(tx, d.Quad, d.ID.Int(), d.Action == graph.Add)
 			if err != nil {
 				return err
 			}
@@ -216,7 +217,7 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 				resizeMap[d.Quad.Label] += delta
 			}
 			sizeChange += delta
-			qs.horizon = d.ID
+			qs.horizon = d.ID.Int()
 		}
 		for k, v := range resizeMap {
 			if v != 0 {

--- a/graph/iterator/mock_ts_test.go
+++ b/graph/iterator/mock_ts_test.go
@@ -16,6 +16,7 @@ package iterator
 
 import (
 	"github.com/google/cayley/graph"
+	"github.com/google/cayley/keys"
 	"github.com/google/cayley/quad"
 )
 
@@ -56,7 +57,7 @@ func (qs *store) NameOf(v graph.Value) string {
 
 func (qs *store) Size() int64 { return 0 }
 
-func (qs *store) Horizon() int64 { return 0 }
+func (qs *store) Horizon() graph.PrimaryKey { return keys.NewSequentialKey(0) }
 
 func (qs *store) DebugPrint() {}
 

--- a/graph/leveldb/leveldb_test.go
+++ b/graph/leveldb/leveldb_test.go
@@ -168,12 +168,22 @@ func TestLoadDatabase(t *testing.T) {
 		t.Errorf("Could not convert from generic to LevelDB QuadStore")
 	}
 
+	//Test horizon
+	horizon := qs.Horizon()
+	if horizon.Int() != 1 {
+		t.Errorf("Unexpected horizon value, got:%d expect:1", horizon.Int())
+	}
+
 	w.AddQuadSet(makeQuadSet())
 	if s := qs.Size(); s != 11 {
 		t.Errorf("Unexpected quadstore size, got:%d expect:11", s)
 	}
 	if s := ts2.SizeOf(qs.ValueOf("B")); s != 5 {
 		t.Errorf("Unexpected quadstore size, got:%d expect:5", s)
+	}
+	horizon = qs.Horizon()
+	if horizon.Int() != 12 {
+		t.Errorf("Unexpected horizon value, got:%d expect:12", horizon.Int())
 	}
 
 	w.RemoveQuad(quad.Quad{

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/keys"
 	"github.com/google/cayley/quad"
 )
 
@@ -135,8 +136,8 @@ func (qs *QuadStore) Size() int64 {
 	return qs.size
 }
 
-func (qs *QuadStore) Horizon() int64 {
-	return qs.horizon
+func (qs *QuadStore) Horizon() graph.PrimaryKey {
+	return keys.NewSequentialKey(qs.horizon)
 }
 
 func hashOf(s string) []byte {
@@ -190,7 +191,7 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 			return err
 		}
 		batch.Put(keyFor(d), bytes)
-		err = qs.buildQuadWrite(batch, d.Quad, d.ID, d.Action == graph.Add)
+		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
 		if err != nil {
 			return err
 		}
@@ -205,7 +206,7 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 			resizeMap[d.Quad.Label] += delta
 		}
 		sizeChange += delta
-		qs.horizon = d.ID
+		qs.horizon = d.ID.Int()
 	}
 	for k, v := range resizeMap {
 		if v != 0 {
@@ -227,7 +228,7 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta) error {
 func keyFor(d graph.Delta) []byte {
 	key := make([]byte, 0, 19)
 	key = append(key, 'd')
-	key = append(key, []byte(fmt.Sprintf("%018x", d.ID))...)
+	key = append(key, []byte(fmt.Sprintf("%018x", d.ID.Int()))...)
 	return key
 }
 

--- a/graph/primarykey.go
+++ b/graph/primarykey.go
@@ -1,0 +1,28 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+// Defines the PrimaryKey interface, this abstracts the generation of IDs
+
+type PrimaryKey interface {
+	// Returns a new unique primary key
+	Next() PrimaryKey
+
+	// Get the integer format if possible, otherwise logs an error and returns -1
+	Int() int64
+
+	// Get the string format
+	String() string
+}

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -70,7 +70,7 @@ type QuadStore interface {
 	Size() int64
 
 	// The last replicated transaction ID that this quadstore has verified.
-	Horizon() int64
+	Horizon() PrimaryKey
 
 	// Creates a fixed iterator which can compare Values
 	FixedIterator() FixedIterator

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -37,7 +37,7 @@ const (
 )
 
 type Delta struct {
-	ID        int64
+	ID        PrimaryKey
 	Quad      quad.Quad
 	Action    Procedure
 	Timestamp time.Time

--- a/keys/sequentialkey.go
+++ b/keys/sequentialkey.go
@@ -1,0 +1,51 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"github.com/google/cayley/graph"
+	"strconv"
+	"sync"
+)
+
+type Sequential struct {
+	nextID int64
+	mut    sync.Mutex
+}
+
+func NewSequentialKey(horizon int64) graph.PrimaryKey {
+	if horizon <= 0 {
+		horizon = 1
+	}
+	return &Sequential{nextID: horizon}
+}
+
+func (s *Sequential) Next() graph.PrimaryKey {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	s.nextID++
+	if s.nextID <= 0 {
+		s.nextID = 1
+	}
+	return s
+}
+
+func (s *Sequential) Int() int64 {
+	return s.nextID
+}
+
+func (s *Sequential) String() string {
+	return strconv.FormatInt(s.nextID, 10)
+}


### PR DESCRIPTION
This pull request partially fulfills https://github.com/google/cayley/issues/185 

I've implemented a PrimaryKey type that refactors the IDs used for Deltas and the associated quadstore horizons. 

I need to abstract this so UUID based primary keys can be implemented for the App Engine datastore backend.
