### PR TITLE
simplify the signature of NextLogOut

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -101,7 +101,7 @@ type Iterator interface {
 	//  	}
 	//  }
 	//
-	// All of them should set iterator.Last to be the last returned value, to
+	// All of them should set iterator.result to be the last returned value, to
 	// make results work.
 	//
 	// NextPath() advances iterators that may have more than one valid result,

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -352,10 +352,10 @@ func NextLogIn(it Iterator) {
 	}
 }
 
-func NextLogOut(it Iterator, val Value, ok bool) bool {
+func NextLogOut(it Iterator, ok bool) bool {
 	if glog.V(4) {
 		if ok {
-			glog.V(4).Infof("%s %d NEXT IS %d", strings.ToUpper(it.Type().String()), it.UID(), val)
+			glog.V(4).Infof("%s %d NEXT IS %d", strings.ToUpper(it.Type().String()), it.UID(), it.Result())
 		} else {
 			glog.V(4).Infof("%s %d NEXT DONE", strings.ToUpper(it.Type().String()), it.UID())
 		}

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -130,7 +130,7 @@ func (it *Int64) Size() (int64, bool) {
 }
 
 // Contains() for an Int64 is merely seeing if the passed value is
-// withing the range, assuming the value is an int64.
+// within the range, assuming the value is an int64.
 func (it *Int64) Contains(tsv graph.Value) bool {
 	graph.ContainsLogIn(it, tsv)
 	it.runstats.Contains += 1

--- a/graph/iterator/all_iterator.go
+++ b/graph/iterator/all_iterator.go
@@ -94,7 +94,7 @@ func (it *Int64) Next() bool {
 	graph.NextLogIn(it)
 	it.runstats.Next += 1
 	if it.at == -1 {
-		return graph.NextLogOut(it, nil, false)
+		return graph.NextLogOut(it, false)
 	}
 	val := it.at
 	it.at = it.at + 1
@@ -102,7 +102,7 @@ func (it *Int64) Next() bool {
 		it.at = -1
 	}
 	it.result = val
-	return graph.NextLogOut(it, val, true)
+	return graph.NextLogOut(it, true)
 }
 
 func (it *Int64) Err() error {

--- a/graph/iterator/and_iterator.go
+++ b/graph/iterator/and_iterator.go
@@ -144,11 +144,11 @@ func (it *And) Next() bool {
 		curr := it.primaryIt.Result()
 		if it.subItsContain(curr, nil) {
 			it.result = curr
-			return graph.NextLogOut(it, curr, true)
+			return graph.NextLogOut(it, true)
 		}
 	}
 	it.err = it.primaryIt.Err()
-	return graph.NextLogOut(it, nil, false)
+	return graph.NextLogOut(it, false)
 }
 
 func (it *And) Err() error {

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -137,12 +137,12 @@ func (it *Fixed) Contains(v graph.Value) bool {
 func (it *Fixed) Next() bool {
 	graph.NextLogIn(it)
 	if it.lastIndex == len(it.values) {
-		return graph.NextLogOut(it, nil, false)
+		return graph.NextLogOut(it, false)
 	}
 	out := it.values[it.lastIndex]
 	it.result = out
 	it.lastIndex++
-	return graph.NextLogOut(it, out, true)
+	return graph.NextLogOut(it, true)
 }
 
 func (it *Fixed) Err() error {

--- a/graph/iterator/fixed_iterator.go
+++ b/graph/iterator/fixed_iterator.go
@@ -181,10 +181,11 @@ func (it *Fixed) Size() (int64, bool) {
 // As we right now have to scan the entire list, Next and Contains are linear with the
 // size. However, a better data structure could remove these limits.
 func (it *Fixed) Stats() graph.IteratorStats {
+	s, _ := it.Size()
 	return graph.IteratorStats{
-		ContainsCost: int64(len(it.values)),
-		NextCost:     int64(len(it.values)),
-		Size:         int64(len(it.values)),
+		ContainsCost: s,
+		NextCost:     s,
+		Size:         s,
 	}
 }
 

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -210,12 +210,12 @@ func (it *HasA) Next() bool {
 
 	if !graph.Next(it.primaryIt) {
 		it.err = it.primaryIt.Err()
-		return graph.NextLogOut(it, 0, false)
+		return graph.NextLogOut(it, false)
 	}
 	tID := it.primaryIt.Result()
 	val := it.qs.QuadDirection(tID, it.dir)
 	it.result = val
-	return graph.NextLogOut(it, val, true)
+	return graph.NextLogOut(it, true)
 }
 
 func (it *HasA) Err() error {

--- a/graph/iterator/linksto_iterator.go
+++ b/graph/iterator/linksto_iterator.go
@@ -156,7 +156,7 @@ func (it *LinksTo) Next() bool {
 	if graph.Next(it.nextIt) {
 		it.runstats.ContainsNext += 1
 		it.result = it.nextIt.Result()
-		return graph.NextLogOut(it, it.nextIt, true)
+		return graph.NextLogOut(it, true)
 	}
 
 	// If there's an error in the 'next' iterator, we save it and we're done.
@@ -171,7 +171,7 @@ func (it *LinksTo) Next() bool {
 		it.err = it.primaryIt.Err()
 
 		// We're out of nodes in our subiterator, so we're done as well.
-		return graph.NextLogOut(it, 0, false)
+		return graph.NextLogOut(it, false)
 	}
 	it.nextIt.Close()
 	it.nextIt = it.qs.QuadIterator(it.dir, it.primaryIt.Result())

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -206,9 +206,9 @@ func (it *Materialize) Next() bool {
 	it.index++
 	it.subindex = 0
 	if it.index >= len(it.values) {
-		return graph.NextLogOut(it, nil, false)
+		return graph.NextLogOut(it, false)
 	}
-	return graph.NextLogOut(it, it.Result(), true)
+	return graph.NextLogOut(it, true)
 }
 
 func (it *Materialize) Err() error {

--- a/graph/iterator/not_iterator.go
+++ b/graph/iterator/not_iterator.go
@@ -77,11 +77,11 @@ func (it *Not) Next() bool {
 		if curr := it.allIt.Result(); !it.primaryIt.Contains(curr) {
 			it.result = curr
 			it.runstats.ContainsNext += 1
-			return graph.NextLogOut(it, curr, true)
+			return graph.NextLogOut(it, true)
 		}
 	}
 	it.err = it.allIt.Err()
-	return graph.NextLogOut(it, nil, false)
+	return graph.NextLogOut(it, false)
 }
 
 func (it *Not) Err() error {

--- a/graph/iterator/or_iterator.go
+++ b/graph/iterator/or_iterator.go
@@ -136,12 +136,12 @@ func (it *Or) Next() bool {
 
 		if graph.Next(curIt) {
 			it.result = curIt.Result()
-			return graph.NextLogOut(it, it.result, true)
+			return graph.NextLogOut(it, true)
 		}
 
 		it.err = curIt.Err()
 		if it.err != nil {
-			return graph.NextLogOut(it, nil, false)
+			return graph.NextLogOut(it, false)
 		}
 
 		if it.isShortCircuiting && !first {
@@ -153,7 +153,7 @@ func (it *Or) Next() bool {
 		}
 	}
 
-	return graph.NextLogOut(it, nil, false)
+	return graph.NextLogOut(it, false)
 }
 
 func (it *Or) Err() error {

--- a/graph/iterator/unique_iterator.go
+++ b/graph/iterator/unique_iterator.go
@@ -75,11 +75,11 @@ func (it *Unique) Next() bool {
 		if ok := it.seen[curr]; !ok {
 			it.result = curr
 			it.seen[curr] = true
-			return graph.NextLogOut(it, it.result, true)
+			return graph.NextLogOut(it, true)
 		}
 	}
 	it.err = it.subIt.Err()
-	return graph.NextLogOut(it, nil, false)
+	return graph.NextLogOut(it, false)
 }
 
 func (it *Unique) Err() error {

--- a/graph/memstore/iterator.go
+++ b/graph/memstore/iterator.go
@@ -114,20 +114,20 @@ func (it *Iterator) Next() bool {
 	graph.NextLogIn(it)
 
 	if it.iter == nil {
-		return graph.NextLogOut(it, nil, false)
+		return graph.NextLogOut(it, false)
 	}
 	result, _, err := it.iter.Next()
 	if err != nil {
 		if err != io.EOF {
 			it.err = err
 		}
-		return graph.NextLogOut(it, nil, false)
+		return graph.NextLogOut(it, false)
 	}
 	if !it.checkValid(result) {
 		return it.Next()
 	}
 	it.result = result
-	return graph.NextLogOut(it, it.result, true)
+	return graph.NextLogOut(it, true)
 }
 
 func (it *Iterator) Err() error {

--- a/graph/mongo/indexed_linksto.go
+++ b/graph/mongo/indexed_linksto.go
@@ -123,7 +123,7 @@ func (it *LinksTo) Next() bool {
 			return it.Next()
 		}
 		it.result = result.ID
-		return graph.NextLogOut(it, it.result, true)
+		return graph.NextLogOut(it, true)
 	}
 
 	if it.nextIt != nil {
@@ -140,7 +140,7 @@ func (it *LinksTo) Next() bool {
 		it.err = it.primaryIt.Err()
 
 		// We're out of nodes in our subiterator, so we're done as well.
-		return graph.NextLogOut(it, 0, false)
+		return graph.NextLogOut(it, false)
 	}
 	if it.nextIt != nil {
 		it.nextIt.Close()


### PR DESCRIPTION
by getting the value from `it.Result()` rather than passing it directly, this
reduces the number of things which need to be passed and may help identify
cases where the value was passed to `NextLogOut` but was not set in a way to
make `it.Result()` work as it should. in those cases, the logging would
include a result different to what you would get from `it.Result()` but lead
you to believe that `it.Result()` would return the logged value.

this is based on seeing a lot of this pattern repeated:

```go
graph.NextLogOut(it, nil, false)
  ...
it.result = value
graph.NextLogOut(it, value, true)
```