### PR TITLE
Adding protocol to the address:port reference

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -163,7 +163,7 @@ func SetupRoutes(handle *graph.Handle, cfg *config.Config) {
 func Serve(handle *graph.Handle, cfg *config.Config) {
 	SetupRoutes(handle, cfg)
 	glog.Infof("Cayley now listening on %s:%s\n", cfg.ListenHost, cfg.ListenPort)
-	fmt.Printf("Cayley now listening on %s:%s\n", cfg.ListenHost, cfg.ListenPort)
+	fmt.Printf("Cayley now listening on http://%s:%s\n", cfg.ListenHost, cfg.ListenPort)
 	err := http.ListenAndServe(fmt.Sprintf("%s:%s", cfg.ListenHost, cfg.ListenPort), nil)
 	if err != nil {
 		glog.Fatal("ListenAndServe: ", err)


### PR DESCRIPTION
When clicking a naked address:port in a terminal window, the OS may or may not understand that it should be opened in a web browser. Adding the protocol to the address:port reference makes the link more click friendly in the terminal.