### PR TITLE
graph: Add transaction err for sql

### DIFF
--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"hash"
 	"sync"
@@ -222,7 +221,7 @@ func (qs *QuadStore) runTxPostgres(tx *sql.Tx, in []graph.Delta, opts graph.Igno
 				glog.Errorf("couldn't get DELETE RowsAffected: %v", err)
 			}
 			if affected != 1 && !opts.IgnoreMissing {
-				return errors.New("deleting non-existent triple; rolling back")
+				return graph.ErrTransactionFailed
 			}
 		default:
 			panic("unknown action")
@@ -248,7 +247,11 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, opts graph.IgnoreOpts) error 
 	default:
 		panic("no support for flavor: " + qs.sqlFlavor)
 	}
-	return tx.Commit()
+	err = tx.Commit()
+	if err == pq.ErrInFailedTransaction {
+		return graph.ErrTransactionFailed
+	}
+	return err
 }
 
 func (qs *QuadStore) Quad(val graph.Value) quad.Quad {

--- a/graph/transaction.go
+++ b/graph/transaction.go
@@ -14,7 +14,13 @@
 
 package graph
 
-import "github.com/google/cayley/quad"
+import (
+	"errors"
+
+	"github.com/google/cayley/quad"
+)
+
+var ErrTransactionFailed = errors.New("graph: transaction failed")
 
 // Transaction stores a bunch of Deltas to apply atomatically on the database.
 type Transaction struct {


### PR DESCRIPTION
Really, it'd be nice to have a multi-error for backends -- determining whether the backend connection is what's dead or if the ApplyDeltas call failed semantically (ie, which of the class ErrQuadExists)
