### PR TITLE
Unique iterator doesn't work with BoltDB

### DIFF
--- a/graph/iterator/unique_iterator.go
+++ b/graph/iterator/unique_iterator.go
@@ -72,9 +72,18 @@ func (it *Unique) Next() bool {
 
 	for graph.Next(it.subIt) {
 		curr := it.subIt.Result()
-		if ok := it.seen[curr]; !ok {
+		key := curr
+		if k, ok := curr.(interface {
+			Key() interface{}
+		}); ok {
+			key = k.Key()
+		}
+		if ok := it.seen[key]; !ok {
 			it.result = curr
-			it.seen[curr] = true
+			it.seen[key] = true
+			return graph.NextLogOut(it, it.result, true)
+		}
+
 			return graph.NextLogOut(it, it.result, true)
 		}
 	}


### PR DESCRIPTION
With BoltDB the graph.Value can be two different pointers with the same contents. This causes the unique iterator to fail.