### PR TITLE
path: Concrete types (for optimization and serialization)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -68,6 +68,10 @@
 			"ImportPath": "gopkg.in/mgo.v2",
 			"Comment": "r2015.01.24",
 			"Rev": "c6a7dce14133ccac2dcac3793f1d6e2ef048503a"
+		},
+		{
+			"ImportPath": "github.com/fsouza/go-dockerclient",
+			"Rev": "25bc220b299845ae5489fd19bf89c5278864b050"
 		}
 	]
 }

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/graph/path2"
 	"github.com/google/cayley/graph/proto"
 	"github.com/google/cayley/quad"
 )
@@ -557,6 +558,28 @@ func (qs *QuadStore) QuadIterator(d quad.Direction, val graph.Value) graph.Itera
 		panic("unreachable " + d.String())
 	}
 	return NewIterator(bucket, d, val, qs)
+}
+
+func (qs *QuadStore) LinksToValuePath(d quad.Direction, value string) path.Links {
+	var bucket []byte
+	switch d {
+	case quad.Subject:
+		bucket = spoBucket
+	case quad.Predicate:
+		bucket = posBucket
+	case quad.Object:
+		bucket = ospBucket
+	case quad.Label:
+		bucket = cpsBucket
+	default:
+		panic("unreachable " + d.String())
+	}
+	return pathLinksTo{
+		qs:     qs,
+		bucket: bucket,
+		d:      d,
+		val:    qs.ValueOf(value).(*Token),
+	}
 }
 
 func (qs *QuadStore) NodesAllIterator() graph.Iterator {

--- a/graph/bolt/quadstore_iterator_optimize.go
+++ b/graph/bolt/quadstore_iterator_optimize.go
@@ -17,6 +17,8 @@ package bolt
 import (
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/graph/path2"
+	"github.com/google/cayley/quad"
 )
 
 func (qs *QuadStore) OptimizeIterator(it graph.Iterator) (graph.Iterator, bool) {
@@ -52,4 +54,37 @@ func (qs *QuadStore) optimizeLinksTo(it *iterator.LinksTo) (graph.Iterator, bool
 		}
 	}
 	return it, false
+}
+
+var _ path.PathOptimizer = (*QuadStore)(nil)
+
+func (qs *QuadStore) OptimizeLinksPath(p path.Links) (path.Links, bool) {
+	switch tp := p.(type) {
+	case path.LinksTo:
+		return qs.optimizePathLinksTo(tp)
+	}
+	return p, false
+}
+func (qs *QuadStore) OptimizeNodesPath(p path.Nodes) (path.Nodes, bool) {
+	return p, false
+}
+
+type pathLinksTo struct {
+	qs     *QuadStore
+	bucket []byte
+	d      quad.Direction
+	val    *Token
+}
+
+func (p pathLinksTo) Optimize() (path.Links, bool)                                { return p, false }
+func (p pathLinksTo) Replace(_ path.NodesWrapper, _ path.LinksWrapper) path.Links { return p }
+func (p pathLinksTo) BuildIterator() graph.Iterator                               { return NewIterator(p.bucket, p.d, p.val, p.qs) }
+func (qs *QuadStore) optimizePathLinksTo(p path.LinksTo) (path.Links, bool) {
+	switch t := p.Nodes.(type) {
+	case path.Fixed:
+		if len(t) == 1 {
+			return qs.LinksToValuePath(p.Dir, t[0]), true
+		}
+	}
+	return p, false
 }

--- a/graph/iterator/unique_iterator.go
+++ b/graph/iterator/unique_iterator.go
@@ -72,9 +72,15 @@ func (it *Unique) Next() bool {
 
 	for graph.Next(it.subIt) {
 		curr := it.subIt.Result()
-		if ok := it.seen[curr]; !ok {
+		key := curr
+		if k, ok := key.(interface {
+			Key() interface{}
+		}); ok {
+			key = k.Key()
+		}
+		if ok := it.seen[key]; !ok {
 			it.result = curr
-			it.seen[curr] = true
+			it.seen[key] = true
 			return graph.NextLogOut(it, it.result, true)
 		}
 	}

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/graph/path2"
 	"github.com/google/cayley/quad"
 )
 
@@ -494,6 +495,28 @@ func (qs *QuadStore) QuadIterator(d quad.Direction, val graph.Value) graph.Itera
 		panic("unreachable " + d.String())
 	}
 	return NewIterator(prefix, d, val, qs)
+}
+
+func (qs *QuadStore) LinksToValuePath(d quad.Direction, value string) path.Links {
+	var prefix string
+	switch d {
+	case quad.Subject:
+		prefix = "sp"
+	case quad.Predicate:
+		prefix = "po"
+	case quad.Object:
+		prefix = "os"
+	case quad.Label:
+		prefix = "cp"
+	default:
+		panic("unreachable " + d.String())
+	}
+	return pathLinksTo{
+		qs:     qs,
+		prefix: prefix,
+		d:      d,
+		val:    qs.ValueOf(value).(Token),
+	}
 }
 
 func (qs *QuadStore) NodesAllIterator() graph.Iterator {

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -262,7 +262,7 @@ func (qs *QuadStore) LinksToValuePath(d quad.Direction, value string) path.Links
 		return nil
 	}
 	return pathLinksTo{
-		qs: qs, index: index, data: fmt.Sprintf("dir:%s val:%d", d, id),
+		qs: qs, index: index,
 	}
 }
 

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/graph/memstore/b"
+	"github.com/google/cayley/graph/path2"
 	"github.com/google/cayley/quad"
 )
 
@@ -249,6 +250,20 @@ func (qs *QuadStore) QuadIterator(d quad.Direction, value graph.Value) graph.Ite
 		return NewIterator(index, qs, d, value)
 	}
 	return &iterator.Null{}
+}
+
+func (qs *QuadStore) LinksToValuePath(d quad.Direction, value string) path.Links {
+	id, ok := qs.idMap[value]
+	if !ok {
+		return nil
+	}
+	index, ok := qs.index.Get(d, id)
+	if !ok {
+		return nil
+	}
+	return pathLinksTo{
+		qs: qs, index: index, data: fmt.Sprintf("dir:%s val:%d", d, id),
+	}
 }
 
 func (qs *QuadStore) Horizon() graph.PrimaryKey {

--- a/graph/memstore/quadstore_iterator_optimize.go
+++ b/graph/memstore/quadstore_iterator_optimize.go
@@ -72,12 +72,11 @@ func (qs *QuadStore) OptimizeNodesPath(p path.Nodes) (path.Nodes, bool) {
 type pathLinksTo struct {
 	qs    *QuadStore
 	index *b.Tree
-	data  string
 }
 
 func (p pathLinksTo) Optimize() (path.Links, bool)                                { return p, false }
 func (p pathLinksTo) Replace(_ path.NodesWrapper, _ path.LinksWrapper) path.Links { return p }
-func (p pathLinksTo) BuildIterator() graph.Iterator                               { return NewIterator(p.index, p.data, p.qs) }
+func (p pathLinksTo) BuildIterator() graph.Iterator                               { return NewIterator(p.index, p.qs, 0, nil) }
 func (qs *QuadStore) optimizePathLinksTo(p path.LinksTo) (path.Links, bool) {
 	switch t := p.Nodes.(type) {
 	case path.Fixed:

--- a/graph/memstore/quadstore_iterator_optimize.go
+++ b/graph/memstore/quadstore_iterator_optimize.go
@@ -17,6 +17,8 @@ package memstore
 import (
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/graph/memstore/b"
+	"github.com/google/cayley/graph/path2"
 )
 
 func (qs *QuadStore) OptimizeIterator(it graph.Iterator) (graph.Iterator, bool) {
@@ -52,4 +54,36 @@ func (qs *QuadStore) optimizeLinksTo(it *iterator.LinksTo) (graph.Iterator, bool
 	}
 	it.Close()
 	return it, false
+}
+
+var _ path.PathOptimizer = (*QuadStore)(nil)
+
+func (qs *QuadStore) OptimizeLinksPath(p path.Links) (path.Links, bool) {
+	switch tp := p.(type) {
+	case path.LinksTo:
+		return qs.optimizePathLinksTo(tp)
+	}
+	return p, false
+}
+func (qs *QuadStore) OptimizeNodesPath(p path.Nodes) (path.Nodes, bool) {
+	return p, false
+}
+
+type pathLinksTo struct {
+	qs    *QuadStore
+	index *b.Tree
+	data  string
+}
+
+func (p pathLinksTo) Optimize() (path.Links, bool)                                  { return p, false }
+func (p pathLinksTo) Replace(_ path.WrapNodesFunc, _ path.WrapLinksFunc) path.Links { return p }
+func (p pathLinksTo) BuildIterator() graph.Iterator                                 { return NewIterator(p.index, p.data, p.qs) }
+func (qs *QuadStore) optimizePathLinksTo(p path.LinksTo) (path.Links, bool) {
+	switch t := p.Nodes.(type) {
+	case path.Fixed:
+		if len(t) == 1 {
+			return qs.LinksToValuePath(p.Dir, t[0]), true
+		}
+	}
+	return p, false
 }

--- a/graph/memstore/quadstore_iterator_optimize.go
+++ b/graph/memstore/quadstore_iterator_optimize.go
@@ -75,9 +75,9 @@ type pathLinksTo struct {
 	data  string
 }
 
-func (p pathLinksTo) Optimize() (path.Links, bool)                                  { return p, false }
-func (p pathLinksTo) Replace(_ path.WrapNodesFunc, _ path.WrapLinksFunc) path.Links { return p }
-func (p pathLinksTo) BuildIterator() graph.Iterator                                 { return NewIterator(p.index, p.data, p.qs) }
+func (p pathLinksTo) Optimize() (path.Links, bool)                                { return p, false }
+func (p pathLinksTo) Replace(_ path.NodesWrapper, _ path.LinksWrapper) path.Links { return p }
+func (p pathLinksTo) BuildIterator() graph.Iterator                               { return NewIterator(p.index, p.data, p.qs) }
 func (qs *QuadStore) optimizePathLinksTo(p path.LinksTo) (path.Links, bool) {
 	switch t := p.Nodes.(type) {
 	case path.Fixed:

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/graph/path2/pathtest"
 	"github.com/google/cayley/quad"
 	"github.com/google/cayley/writer"
 )
@@ -232,4 +233,8 @@ func TestTransaction(t *testing.T) {
 	if size != qs.Size() {
 		t.Error("Appended a new quad in a failed transaction")
 	}
+}
+
+func TestMorphisms(t *testing.T) {
+	pathtest.TestMorphisms(t, func() graph.QuadStore { return newQuadStore() })
 }

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/google/cayley/writer"
 )
 
+func makeStore(t testing.TB) (graph.QuadStore, func()) {
+	return newQuadStore(), func() {}
+}
+
 // This is a simple test graph.
 //
 //    +---+                        +---+
@@ -236,5 +240,5 @@ func TestTransaction(t *testing.T) {
 }
 
 func TestMorphisms(t *testing.T) {
-	pathtest.TestMorphisms(t, func() graph.QuadStore { return newQuadStore() })
+	pathtest.TestMorphisms(t, makeStore)
 }

--- a/graph/mongo/mongo_test.go
+++ b/graph/mongo/mongo_test.go
@@ -1,0 +1,54 @@
+package mongo
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/graph/path2/pathtest"
+	"testing"
+)
+
+func runMongo(t testing.TB) (string, func()) {
+	cl, err := docker.NewClient("unix:///var/run/docker.sock")
+	if err != nil {
+		t.Skip(err)
+	}
+	cont, err := cl.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			OpenStdin: true, Tty: true,
+			Image: `mongo:3`,
+		},
+		HostConfig: &docker.HostConfig{},
+	})
+	if err != nil {
+		t.Skip(err)
+	}
+
+	closer := func() {
+		cl.RemoveContainer(docker.RemoveContainerOptions{ID: cont.ID, Force: true})
+	}
+
+	if err := cl.StartContainer(cont.ID, &docker.HostConfig{}); err != nil {
+		closer()
+		t.Skip(err)
+	}
+
+	info, err := cl.InspectContainer(cont.ID)
+	if err != nil {
+		closer()
+		t.Skip(err)
+	}
+	return info.NetworkSettings.IPAddress, closer
+}
+
+func makeStore(t testing.TB) (graph.QuadStore, func()) {
+	ip, closer := runMongo(t)
+	qs, err := newQuadStore(ip+":27017", nil)
+	if err != nil {
+		t.Fatal("Failed to create MongoDB database.")
+	}
+	return qs, closer
+}
+
+func TestMorphisms(t *testing.T) {
+	pathtest.TestMorphisms(t, makeStore)
+}

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -319,6 +319,9 @@ func (qs *QuadStore) ValueOf(s string) graph.Value {
 }
 
 func (qs *QuadStore) NameOf(v graph.Value) string {
+	if v == nil {
+		return ""
+	}
 	val, ok := qs.ids.Get(v.(string))
 	if ok {
 		return val.(string)

--- a/graph/path2/abstract.go
+++ b/graph/path2/abstract.go
@@ -214,8 +214,6 @@ func (p LinksTo) Optimize() (Links, bool) {
 		return nil, true
 	} else if _, ok := n.(AllNodes); ok {
 		return AllLinks{}, true
-	} else if x, ok := n.(HasA); ok && x.Dir == p.Dir {
-		return x.Links, true
 	}
 	return LinksTo{
 		Nodes: n,

--- a/graph/path2/abstract.go
+++ b/graph/path2/abstract.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"
+	"sort"
 )
 
 var (
@@ -49,8 +50,56 @@ var (
 	_ NodesAbstract = Fixed{}
 )
 
+func uniqueStrings(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	np := make([]string, len(s))
+	copy(np, s)
+	sort.Strings([]string(np))
+	off := 0
+	for i := 1; i < len(np); i++ {
+		if np[i-1] == np[i] {
+			off++
+		} else if off > 0 {
+			np[i-off] = np[i]
+		}
+	}
+	return np[:len(s)-off]
+}
+
 type Fixed []string
 
+func (p Fixed) Unique() Fixed {
+	return Fixed(uniqueStrings([]string(p)))
+}
+func (p Fixed) Intersect(n Fixed) Fixed {
+	p, n = p.Unique(), n.Unique()
+	if len(n) == 0 {
+		return nil
+	}
+	if len(p) < len(n) {
+		return n.Intersect(p)
+	} else if len(n) == 1 {
+		for _, v := range p {
+			if v == n[0] {
+				return n
+			}
+		}
+		return nil
+	}
+	m := make(map[string]struct{}, len(n))
+	for _, v := range n {
+		m[v] = struct{}{}
+	}
+	out := make(Fixed, 0, len(m))
+	for _, v := range p {
+		if _, ok := m[v]; ok {
+			out = append(out, v)
+		}
+	}
+	return out
+}
 func (p Fixed) BuildIterator() graph.Iterator                  { panic("build on abstract path: FixedValues") }
 func (p Fixed) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return p }
 func (p Fixed) BindTo(qs graph.QuadStore) Nodes {
@@ -93,6 +142,12 @@ func (p HasA) Replace(_ WrapNodesFunc, lf WrapLinksFunc) Nodes {
 }
 func (p HasA) BindTo(qs graph.QuadStore) Nodes {
 	np := OptimizeOn(p.Links, qs)
+	if np == nil {
+		return NodeIteratorBuilder{
+			Path:    p,
+			Builder: func() graph.Iterator { return iterator.NewNull() },
+		}
+	}
 	return NodeIteratorBuilder{
 		Path: p,
 		Builder: func() graph.Iterator {
@@ -105,15 +160,17 @@ func (p HasA) Optimize() (Nodes, bool) {
 		return nil, true
 	}
 	n, opt := p.Links.Optimize()
-	if !opt {
-		return p, false
-	} else if n == nil {
+	if n == nil {
 		return nil, true
+	} else if _, ok := n.(AllLinks); ok {
+		return AllNodes{}, true
+	} else if x, ok := n.(LinksTo); ok && x.Dir == p.Dir {
+		return x.Nodes, true
 	}
 	return HasA{
 		Links: n,
 		Dir:   p.Dir,
-	}, true
+	}, opt
 }
 
 var (
@@ -135,6 +192,12 @@ func (p LinksTo) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Links {
 }
 func (p LinksTo) BindTo(qs graph.QuadStore) Links {
 	np := OptimizeOn(p.Nodes, qs)
+	if np == nil {
+		return LinkIteratorBuilder{
+			Path:    p,
+			Builder: func() graph.Iterator { return iterator.NewNull() },
+		}
+	}
 	return LinkIteratorBuilder{
 		Path: p,
 		Builder: func() graph.Iterator {
@@ -147,15 +210,17 @@ func (p LinksTo) Optimize() (Links, bool) {
 		return nil, true
 	}
 	n, opt := p.Nodes.Optimize()
-	if !opt {
-		return p, false
-	} else if n == nil {
+	if n == nil {
 		return nil, true
+	} else if _, ok := n.(AllNodes); ok {
+		return AllLinks{}, true
+	} else if x, ok := n.(HasA); ok && x.Dir == p.Dir {
+		return x.Links, true
 	}
 	return LinksTo{
 		Nodes: n,
 		Dir:   p.Dir,
-	}, true
+	}, opt
 }
 
 var (
@@ -176,6 +241,12 @@ func (p NotNodes) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
 }
 func (p NotNodes) BindTo(qs graph.QuadStore) Nodes {
 	np := OptimizeOn(p.Nodes, qs)
+	if np == nil {
+		return NodeIteratorBuilder{
+			Path:    p,
+			Builder: func() graph.Iterator { return qs.NodesAllIterator() },
+		}
+	}
 	return NodeIteratorBuilder{
 		Path: p,
 		Builder: func() graph.Iterator {
@@ -188,6 +259,9 @@ func (p NotNodes) Optimize() (Nodes, bool) {
 		return AllNodes{}, true
 	}
 	n, opt := p.Nodes.Optimize()
+	if n == nil {
+		return AllNodes{}, true
+	}
 	switch t := n.(type) {
 	case AllNodes:
 		return nil, true

--- a/graph/path2/abstract.go
+++ b/graph/path2/abstract.go
@@ -1,0 +1,199 @@
+package path
+
+import (
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/graph/iterator"
+	"github.com/google/cayley/quad"
+)
+
+var (
+	_ Nodes         = AllNodes{}
+	_ NodesAbstract = AllNodes{}
+)
+
+type AllNodes struct{}
+
+func (p AllNodes) BuildIterator() graph.Iterator                  { panic("build on abstract path: AllNodes") }
+func (p AllNodes) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return p }
+func (p AllNodes) BindTo(qs graph.QuadStore) Nodes {
+	return NodeIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			return qs.NodesAllIterator()
+		},
+	}
+}
+func (p AllNodes) Optimize() (Nodes, bool) { return p, false }
+
+var (
+	_ Links         = AllLinks{}
+	_ LinksAbstract = AllLinks{}
+)
+
+type AllLinks struct{}
+
+func (p AllLinks) BuildIterator() graph.Iterator                  { panic("build on abstract path: AllLinks") }
+func (p AllLinks) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Links { return p }
+func (p AllLinks) BindTo(qs graph.QuadStore) Links {
+	return LinkIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			return qs.QuadsAllIterator()
+		},
+	}
+}
+func (p AllLinks) Optimize() (Links, bool) { return p, false }
+
+var (
+	_ Nodes         = Fixed{}
+	_ NodesAbstract = Fixed{}
+)
+
+type Fixed []string
+
+func (p Fixed) BuildIterator() graph.Iterator                  { panic("build on abstract path: FixedValues") }
+func (p Fixed) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return p }
+func (p Fixed) BindTo(qs graph.QuadStore) Nodes {
+	return NodeIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			it := qs.FixedIterator()
+			for _, v := range p {
+				if gv := qs.ValueOf(v); gv != nil {
+					it.Add(gv)
+				}
+			}
+			return it
+		},
+	}
+}
+func (p Fixed) Optimize() (Nodes, bool) {
+	if len(p) == 0 {
+		return nil, true
+	}
+	return p, false
+}
+
+var (
+	_ Nodes         = HasA{}
+	_ NodesAbstract = HasA{}
+)
+
+type HasA struct {
+	Links Links
+	Dir   quad.Direction
+}
+
+func (p HasA) BuildIterator() graph.Iterator { panic("build on abstract path: HasA") }
+func (p HasA) Replace(_ WrapNodesFunc, lf WrapLinksFunc) Nodes {
+	if lf == nil {
+		return p
+	}
+	return HasA{Links: lf(p.Links), Dir: p.Dir}
+}
+func (p HasA) BindTo(qs graph.QuadStore) Nodes {
+	np := OptimizeOn(p.Links, qs)
+	return NodeIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			return iterator.NewHasA(qs, np.BuildIterator(), p.Dir)
+		},
+	}
+}
+func (p HasA) Optimize() (Nodes, bool) {
+	if p.Links == nil {
+		return nil, true
+	}
+	n, opt := p.Links.Optimize()
+	if !opt {
+		return p, false
+	} else if n == nil {
+		return nil, true
+	}
+	return HasA{
+		Links: n,
+		Dir:   p.Dir,
+	}, true
+}
+
+var (
+	_ Links         = LinksTo{}
+	_ LinksAbstract = LinksTo{}
+)
+
+type LinksTo struct {
+	Nodes Nodes
+	Dir   quad.Direction
+}
+
+func (p LinksTo) BuildIterator() graph.Iterator { panic("build on abstract path: LinksTo") }
+func (p LinksTo) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Links {
+	if nf == nil {
+		return p
+	}
+	return LinksTo{Nodes: nf(p.Nodes), Dir: p.Dir}
+}
+func (p LinksTo) BindTo(qs graph.QuadStore) Links {
+	np := OptimizeOn(p.Nodes, qs)
+	return LinkIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			return iterator.NewLinksTo(qs, np.BuildIterator(), p.Dir)
+		},
+	}
+}
+func (p LinksTo) Optimize() (Links, bool) {
+	if p.Nodes == nil {
+		return nil, true
+	}
+	n, opt := p.Nodes.Optimize()
+	if !opt {
+		return p, false
+	} else if n == nil {
+		return nil, true
+	}
+	return LinksTo{
+		Nodes: n,
+		Dir:   p.Dir,
+	}, true
+}
+
+var (
+	_ Nodes         = NotNodes{}
+	_ NodesAbstract = NotNodes{}
+)
+
+type NotNodes struct {
+	Nodes Nodes
+}
+
+func (p NotNodes) BuildIterator() graph.Iterator { panic("build on abstract path: NotNodes") }
+func (p NotNodes) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+	if nf == nil {
+		return p
+	}
+	return NotNodes{Nodes: nf(p.Nodes)}
+}
+func (p NotNodes) BindTo(qs graph.QuadStore) Nodes {
+	np := OptimizeOn(p.Nodes, qs)
+	return NodeIteratorBuilder{
+		Path: p,
+		Builder: func() graph.Iterator {
+			return iterator.NewNot(np.BuildIterator(), qs.NodesAllIterator())
+		},
+	}
+}
+func (p NotNodes) Optimize() (Nodes, bool) {
+	if p.Nodes == nil {
+		return AllNodes{}, true
+	}
+	n, opt := p.Nodes.Optimize()
+	switch t := n.(type) {
+	case AllNodes:
+		return nil, true
+	case NotNodes:
+		n, _ := t.Nodes.Optimize()
+		return n, true
+	}
+	return NotNodes{Nodes: n}, opt
+}

--- a/graph/path2/abstract.go
+++ b/graph/path2/abstract.go
@@ -14,8 +14,8 @@ var (
 
 type AllNodes struct{}
 
-func (p AllNodes) BuildIterator() graph.Iterator                  { panic("build on abstract path: AllNodes") }
-func (p AllNodes) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return p }
+func (p AllNodes) BuildIterator() graph.Iterator                { panic("build on abstract path: AllNodes") }
+func (p AllNodes) Replace(_ NodesWrapper, _ LinksWrapper) Nodes { return p }
 func (p AllNodes) BindTo(qs graph.QuadStore) Nodes {
 	return NodeIteratorBuilder{
 		Path: p,
@@ -33,8 +33,8 @@ var (
 
 type AllLinks struct{}
 
-func (p AllLinks) BuildIterator() graph.Iterator                  { panic("build on abstract path: AllLinks") }
-func (p AllLinks) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Links { return p }
+func (p AllLinks) BuildIterator() graph.Iterator                { panic("build on abstract path: AllLinks") }
+func (p AllLinks) Replace(_ NodesWrapper, _ LinksWrapper) Links { return p }
 func (p AllLinks) BindTo(qs graph.QuadStore) Links {
 	return LinkIteratorBuilder{
 		Path: p,
@@ -100,8 +100,8 @@ func (p Fixed) Intersect(n Fixed) Fixed {
 	}
 	return out
 }
-func (p Fixed) BuildIterator() graph.Iterator                  { panic("build on abstract path: FixedValues") }
-func (p Fixed) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return p }
+func (p Fixed) BuildIterator() graph.Iterator                { panic("build on abstract path: FixedValues") }
+func (p Fixed) Replace(_ NodesWrapper, _ LinksWrapper) Nodes { return p }
 func (p Fixed) BindTo(qs graph.QuadStore) Nodes {
 	return NodeIteratorBuilder{
 		Path: p,
@@ -134,7 +134,7 @@ type HasA struct {
 }
 
 func (p HasA) BuildIterator() graph.Iterator { panic("build on abstract path: HasA") }
-func (p HasA) Replace(_ WrapNodesFunc, lf WrapLinksFunc) Nodes {
+func (p HasA) Replace(_ NodesWrapper, lf LinksWrapper) Nodes {
 	if lf == nil {
 		return p
 	}
@@ -184,7 +184,7 @@ type LinksTo struct {
 }
 
 func (p LinksTo) BuildIterator() graph.Iterator { panic("build on abstract path: LinksTo") }
-func (p LinksTo) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Links {
+func (p LinksTo) Replace(nf NodesWrapper, _ LinksWrapper) Links {
 	if nf == nil {
 		return p
 	}
@@ -231,7 +231,7 @@ type NotNodes struct {
 }
 
 func (p NotNodes) BuildIterator() graph.Iterator { panic("build on abstract path: NotNodes") }
-func (p NotNodes) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p NotNodes) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}

--- a/graph/path2/basic.go
+++ b/graph/path2/basic.go
@@ -1,0 +1,263 @@
+package path
+
+import "github.com/google/cayley/quad"
+
+var _ NodePath = AllNodes{}
+
+type AllNodes struct{}
+
+func (p AllNodes) Simplify() (NodePath, bool) { return p, false }
+func (p AllNodes) Optimize() (NodePath, bool) { return p, false }
+
+var _ LinkPath = AllLinks{}
+
+type AllLinks struct{}
+
+func (p AllLinks) Simplify() (LinkPath, bool) { return p, false }
+func (p AllLinks) Optimize() (LinkPath, bool) { return p, false }
+
+var _ NodePath = FixedValues{}
+
+type FixedValues struct {
+	Values []string
+}
+
+func (p FixedValues) Simplify() (NodePath, bool) { return p, false }
+func (p FixedValues) Optimize() (NodePath, bool) {
+	if len(p.Values) == 0 {
+		return nil, true
+	}
+	return p, false
+}
+
+var _ NodePath = HasA{}
+
+type HasA struct {
+	Links LinkPath
+	Dir   quad.Direction
+}
+
+func (p HasA) Simplify() (NodePath, bool) { return p, false }
+func (p HasA) Optimize() (NodePath, bool) {
+	if p.Links == nil {
+		return nil, true
+	}
+	n, opt := p.Links.Optimize()
+	if !opt {
+		return p, false
+	} else if n == nil {
+		return nil, true
+	}
+	return HasA{
+		Links: n,
+		Dir:   p.Dir,
+	}, true
+}
+
+var _ LinkPath = LinksTo{}
+
+type LinksTo struct {
+	Nodes NodePath
+	Dir   quad.Direction
+}
+
+func (p LinksTo) Simplify() (LinkPath, bool) { return p, false }
+func (p LinksTo) Optimize() (LinkPath, bool) {
+	if p.Nodes == nil {
+		return nil, true
+	}
+	n, opt := p.Nodes.Optimize()
+	if !opt {
+		return p, false
+	} else if n == nil {
+		return nil, true
+	}
+	return LinksTo{
+		Nodes: n,
+		Dir:   p.Dir,
+	}, true
+}
+
+var _ NodePath = NotNodes{}
+
+type NotNodes struct {
+	Nodes NodePath
+}
+
+func (p NotNodes) Simplify() (NodePath, bool) { return p, false }
+func (p NotNodes) Optimize() (NodePath, bool) {
+	if p.Nodes == nil {
+		return AllNodes{}, true
+	}
+	n, opt := p.Nodes.Optimize()
+	switch t := n.(type) {
+	case AllNodes:
+		return nil, true
+	case NotNodes:
+		n, _ := t.Nodes.Optimize()
+		return n, true
+	}
+	return NotNodes{Nodes: n}, opt
+}
+
+var _ NodePath = Tag{}
+
+type Tag struct {
+	Nodes NodePath
+	Tags  []string
+}
+
+func (p Tag) Simplify() (NodePath, bool) { return p, false }
+func (p Tag) Optimize() (NodePath, bool) {
+	if p.Nodes == nil {
+		return nil, true
+	}
+	n, opt := p.Nodes.Optimize()
+	if len(p.Tags) == 0 {
+		return n, true
+	} else if !opt {
+		return p, false
+	} else if n == nil {
+		return nil, true
+	}
+	return Tag{
+		Nodes: n,
+		Tags:  p.Tags, // TODO: unique tags
+	}, true
+}
+
+var _ NodePath = IntersectNodes{}
+
+type IntersectNodes []NodePath
+
+func (p IntersectNodes) Simplify() (NodePath, bool) { return p, false }
+func (p IntersectNodes) Optimize() (NodePath, bool) {
+	if len(p) == 0 {
+		return nil, true
+	} else if len(p) == 1 {
+		n, _ := p[0].Optimize()
+		return n, true
+	}
+	nsets := make([]NodePath, 0, len(p))
+	var optg bool
+	for _, sp := range p {
+		n, opt := sp.Optimize()
+		if n == nil { // intersect with zero = zero
+			return nil, true
+		} else if _, ok := n.(AllNodes); ok { // remove 'all' sets
+			optg = true
+			continue
+		}
+		optg = optg || opt
+		nsets = append(nsets, n)
+	}
+	if len(nsets) == 0 {
+		return nil, true
+	} else if len(nsets) == 1 {
+		return nsets[0], true
+	}
+	// TODO: intersect FixedValues into a single one
+	return IntersectNodes(nsets), optg
+}
+
+var _ NodePath = UnionNodes{}
+
+type UnionNodes []NodePath
+
+func (p UnionNodes) Simplify() (NodePath, bool) { return p, false }
+func (p UnionNodes) Optimize() (NodePath, bool) {
+	if len(p) == 0 {
+		return nil, true
+	} else if len(p) == 1 {
+		n, _ := p[0].Optimize()
+		return n, true
+	}
+	nsets := make([]NodePath, 0, len(p))
+	var optg bool
+	for _, sp := range p {
+		n, opt := sp.Optimize()
+		if _, ok := n.(AllNodes); ok { // intersect with all = all
+			return AllNodes{}, true
+		} else if n == nil { // remove empty sets
+			optg = true
+			continue
+		}
+		optg = optg || opt
+		nsets = append(nsets, n)
+	}
+	if len(nsets) == 0 {
+		return nil, true
+	} else if len(nsets) == 1 {
+		return nsets[0], true
+	}
+	// TODO: deduplicate FixedValues into a single one
+	return UnionNodes(nsets), optg
+}
+
+var _ LinkPath = IntersectLinks{}
+
+type IntersectLinks []LinkPath
+
+func (p IntersectLinks) Simplify() (LinkPath, bool) { return p, false }
+func (p IntersectLinks) Optimize() (LinkPath, bool) {
+	if len(p) == 0 {
+		return nil, true
+	} else if len(p) == 1 {
+		n, _ := p[0].Optimize()
+		return n, true
+	}
+	nsets := make([]LinkPath, 0, len(p))
+	var optg bool
+	for _, sp := range p {
+		n, opt := sp.Optimize()
+		if n == nil { // intersect with zero = zero
+			return nil, true
+		} else if _, ok := n.(AllLinks); ok { // remove 'all' sets
+			optg = true
+			continue
+		}
+		optg = optg || opt
+		nsets = append(nsets, n)
+	}
+	if len(nsets) == 0 {
+		return nil, true
+	} else if len(nsets) == 1 {
+		return nsets[0], true
+	}
+	// TODO: intersect FixedValues into a single one
+	return IntersectLinks(nsets), optg
+}
+
+var _ LinkPath = UnionLinks{}
+
+type UnionLinks []LinkPath
+
+func (p UnionLinks) Simplify() (LinkPath, bool) { return p, false }
+func (p UnionLinks) Optimize() (LinkPath, bool) {
+	if len(p) == 0 {
+		return nil, true
+	} else if len(p) == 1 {
+		n, _ := p[0].Optimize()
+		return n, true
+	}
+	nsets := make([]LinkPath, 0, len(p))
+	var optg bool
+	for _, sp := range p {
+		n, opt := sp.Optimize()
+		if _, ok := n.(AllLinks); ok { // intersect with all = all
+			return AllLinks{}, true
+		} else if n == nil { // remove empty sets
+			optg = true
+			continue
+		}
+		optg = optg || opt
+		nsets = append(nsets, n)
+	}
+	if len(nsets) == 0 {
+		return nil, true
+	} else if len(nsets) == 1 {
+		return nsets[0], true
+	}
+	// TODO: deduplicate FixedValues into a single one
+	return UnionLinks(nsets), optg
+}

--- a/graph/path2/basic.go
+++ b/graph/path2/basic.go
@@ -12,7 +12,7 @@ type Tag struct {
 	Tags  []string
 }
 
-func (p Tag) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Tag) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -49,7 +49,7 @@ var (
 
 type IntersectNodes []Nodes
 
-func (p IntersectNodes) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p IntersectNodes) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -130,7 +130,7 @@ var _ Nodes = UnionNodes{}
 
 type UnionNodes []Nodes
 
-func (p UnionNodes) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p UnionNodes) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -196,7 +196,7 @@ var (
 
 type IntersectLinks []Links
 
-func (p IntersectLinks) Replace(_ WrapNodesFunc, lf WrapLinksFunc) Links {
+func (p IntersectLinks) Replace(_ NodesWrapper, lf LinksWrapper) Links {
 	if lf == nil {
 		return p
 	}
@@ -250,7 +250,7 @@ var _ Links = UnionLinks{}
 
 type UnionLinks []Links
 
-func (p UnionLinks) Replace(_ WrapNodesFunc, lf WrapLinksFunc) Links {
+func (p UnionLinks) Replace(_ NodesWrapper, lf LinksWrapper) Links {
 	if lf == nil {
 		return p
 	}
@@ -305,7 +305,7 @@ type Unique struct {
 	Nodes Nodes
 }
 
-func (p Unique) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Unique) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}

--- a/graph/path2/basic.go
+++ b/graph/path2/basic.go
@@ -115,7 +115,7 @@ func (p IntersectNodes) Optimize() (Nodes, bool) {
 		nsets = append(nsets, n)
 	}
 	if !first {
-		nsets = append(nsets, fixed.Unique())
+		nsets = append([]Nodes{fixed.Unique()}, nsets...)
 	}
 	if len(nsets) == 0 {
 		return nil, true

--- a/graph/path2/compat.go
+++ b/graph/path2/compat.go
@@ -52,7 +52,7 @@ type context struct {
 	// A nil in this field represents all labels.
 	//
 	// Claimed by the withLabel morphism
-	labelSet *Path
+	labelSet Nodes
 }
 
 func (c context) copy() context {
@@ -168,10 +168,14 @@ func (p *Path) Tag(tags ...string) *Path {
 //  // to "F" labelled "follows".
 //  StartPath(qs, "A").Out("follows")
 func (p *Path) Out(via ...interface{}) *Path {
+	labels := p.baseContext.labelSet
+	if labels == nil {
+		labels = AllNodes{}
+	}
 	p.nodes = Out{
 		From:   p.nodes,
 		Via:    buildViaPath(via...),
-		Labels: AllNodes{}, // TODO: from context
+		Labels: labels,
 	}
 	return p
 }
@@ -186,10 +190,14 @@ func (p *Path) Out(via ...interface{}) *Path {
 //  // edges from those nodes to "B" labelled "follows".
 //  StartPath(qs, "B").In("follows")
 func (p *Path) In(via ...interface{}) *Path {
+	labels := p.baseContext.labelSet
+	if labels == nil {
+		labels = AllNodes{}
+	}
 	p.nodes = Out{
 		From:   p.nodes,
 		Via:    buildViaPath(via...),
-		Labels: AllNodes{}, // TODO: from context
+		Labels: labels,
 		Rev:    true,
 	}
 	return p
@@ -198,11 +206,15 @@ func (p *Path) In(via ...interface{}) *Path {
 // InWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
+	labels := p.baseContext.labelSet
+	if labels == nil {
+		labels = AllNodes{}
+	}
 	p.nodes = Out{
 		From:   p.nodes,
 		Via:    buildViaPath(via...),
 		Tags:   tags,
-		Labels: AllNodes{}, // TODO: from context
+		Labels: labels,
 		Rev:    true,
 	}
 	return p
@@ -211,10 +223,14 @@ func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
 // OutWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
+	labels := p.baseContext.labelSet
+	if labels == nil {
+		labels = AllNodes{}
+	}
 	p.nodes = Out{
 		From:   p.nodes,
 		Via:    buildViaPath(via...),
-		Labels: AllNodes{}, // TODO: from context
+		Labels: labels,
 		Tags:   tags,
 	}
 	return p
@@ -362,16 +378,14 @@ func (p *Path) Has(via interface{}, nodes ...string) *Path {
 // LabelContext restricts the following operations (such as In, Out) to only
 // traverse edges that match the given set of labels.
 func (p *Path) LabelContext(via ...interface{}) *Path {
-	panic("not implemented yet") // TODO
-	//	p.stack = append(p.stack, labelContextMorphism(nil, via...))
+	p.baseContext.labelSet = buildViaPath(via...)
 	return p
 }
 
 // LabelContextWithTags is exactly like LabelContext, except it tags the value
 // of the label used in the traversal with the tags provided.
 func (p *Path) LabelContextWithTags(tags []string, via ...interface{}) *Path {
-	panic("not implemented yet") // TODO
-	//	p.stack = append(p.stack, labelContextMorphism(tags, via...))
+	p.baseContext.labelSet = Tag{Nodes: buildViaPath(via...), Tags: tags}
 	return p
 }
 

--- a/graph/path2/compat.go
+++ b/graph/path2/compat.go
@@ -1,0 +1,459 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package path
+
+import (
+	"fmt"
+	"github.com/google/cayley/graph"
+	"reflect"
+)
+
+type applyMorphism func(graph.QuadStore, graph.Iterator, *context) (graph.Iterator, *context)
+
+type morphism struct {
+	Name     string
+	Reversal func(*context) (morphism, *context)
+	Apply    applyMorphism
+	tags     []string
+}
+
+// context allows a high-level change to the way paths are constructed. Some
+// functions may change the context, causing following chained calls to act
+// cdifferently.
+//
+// In a sense, this is a global state which can be changed as the path
+// continues. And as with dealing with any global state, care should be taken:
+//
+// When modifying the context in Apply(), please copy the passed struct,
+// modifying the relevant fields if need be (or pass the given context onward).
+//
+// Under Reversal(), any functions that wish to change the context should
+// appropriately change the passed context (that is, the context that came after
+// them will now be what the application of the function would have been) and
+// then yield a pointer to their own member context as the return value.
+//
+// For more examples, look at the morphisms which claim the individual fields.
+type context struct {
+	// Represents the path to the limiting set of labels that should be considered under traversal.
+	// inMorphism, outMorphism, et al should constrain edges by this set.
+	// A nil in this field represents all labels.
+	//
+	// Claimed by the withLabel morphism
+	labelSet *Path
+}
+
+func (c context) copy() context {
+	return context{
+		labelSet: c.labelSet,
+	}
+}
+
+var (
+	_ PathObj = (*Path)(nil)
+
+//	_ Nodes = (*Path)(nil)
+)
+
+// Path represents either a morphism (a pre-defined path stored for later use),
+// or a concrete path, consisting of a morphism and an underlying QuadStore.
+type Path struct {
+	nodes       Nodes
+	qs          graph.QuadStore // Optionally. A nil qs is equivalent to a morphism.
+	baseContext context
+}
+
+// IsMorphism returns whether this Path is a morphism.
+func (p *Path) IsMorphism() bool { return p.qs == nil }
+
+// StartMorphism creates a new Path with no underlying QuadStore.
+func StartMorphism(nodes ...string) *Path {
+	return StartPath(nil, nodes...)
+}
+
+// StartPath creates a new Path from a set of nodes and an underlying QuadStore.
+func StartPath(qs graph.QuadStore, nodes ...string) *Path {
+	var p Nodes
+	if len(nodes) == 0 {
+		p = AllNodes{}
+	} else {
+		p = Fixed(nodes)
+	}
+	if qs == nil {
+		p = IntersectNodes{
+			Start{}, p,
+		}
+	}
+	return &Path{
+		nodes: p,
+		qs:    qs,
+	}
+}
+
+func PathFromIterator(qs graph.QuadStore, it graph.Iterator) *Path {
+	return &Path{
+		nodes: NodeIteratorBuilder{Builder: func() graph.Iterator { return it.Clone() }},
+		qs:    qs,
+	}
+}
+
+// NewPath creates a new, empty Path.
+func NewPath(qs graph.QuadStore) *Path {
+	return &Path{
+		qs: qs,
+	}
+}
+
+// Reverse returns a new Path that is the reverse of the current one.
+func (p *Path) Reverse() *Path {
+	panic("not implemented yet") // TODO
+	//	newPath := NewPath(p.qs)
+	//	ctx := &newPath.baseContext
+	//	for i := len(p.stack) - 1; i >= 0; i-- {
+	//		var revMorphism morphism
+	//		revMorphism, ctx = p.stack[i].Reversal(ctx)
+	//		newPath.stack = append(newPath.stack, revMorphism)
+	//	}
+	//	return newPath
+}
+
+// Is declares that the current nodes in this path are only the nodes
+// passed as arguments.
+func (p *Path) Is(nodes ...string) *Path {
+	if p.nodes == nil {
+		p.nodes = Fixed(nodes)
+	} else {
+		p.nodes = IntersectNodes{
+			p.nodes,
+			Fixed(nodes),
+		}
+	}
+	return p
+}
+
+// Tag adds tag strings to the nodes at this point in the path for each result
+// path in the set.
+func (p *Path) Tag(tags ...string) *Path {
+	p.nodes = Tag{
+		Nodes: p.nodes,
+		Tags:  tags,
+	}
+	return p
+}
+
+// Out updates this Path to represent the nodes that are adjacent to the
+// current nodes, via the given outbound predicate.
+//
+// For example:
+//  // Returns the list of nodes that "B" follows.
+//  //
+//  // Will return []string{"F"} if there is a predicate (edge) from "B"
+//  // to "F" labelled "follows".
+//  StartPath(qs, "A").Out("follows")
+func (p *Path) Out(via ...interface{}) *Path {
+	p.nodes = Out{
+		From: p.nodes,
+		Via:  buildViaPath(via...),
+	}
+	return p
+}
+
+// In updates this Path to represent the nodes that are adjacent to the
+// current nodes, via the given inbound predicate.
+//
+// For example:
+//  // Return the list of nodes that follow "B".
+//  //
+//  // Will return []string{"A", "C", "D"} if there are the appropriate
+//  // edges from those nodes to "B" labelled "follows".
+//  StartPath(qs, "B").In("follows")
+func (p *Path) In(via ...interface{}) *Path {
+	p.nodes = Out{
+		From: p.nodes,
+		Via:  buildViaPath(via...),
+		Rev:  true,
+	}
+	return p
+}
+
+// InWithTags is exactly like In, except it tags the value of the predicate
+// traversed with the tags provided.
+func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
+	p.nodes = Out{
+		From: p.nodes,
+		Via:  buildViaPath(via...),
+		Tags: tags,
+		Rev:  true,
+	}
+	return p
+}
+
+// OutWithTags is exactly like In, except it tags the value of the predicate
+// traversed with the tags provided.
+func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
+	p.nodes = Out{
+		From: p.nodes,
+		Via:  buildViaPath(via...),
+		Tags: tags,
+	}
+	return p
+}
+
+// Both updates this path following both inbound and outbound predicates.
+//
+// For example:
+//  // Return the list of nodes that follow or are followed by "B".
+//  //
+//  // Will return []string{"A", "C", "D", "F} if there are the appropriate
+//  // edges from those nodes to "B" labelled "follows", in either direction.
+//  StartPath(qs, "B").Both("follows")
+func (p *Path) Both(via ...interface{}) *Path {
+	panic("not implemented yet") // TODO
+	//	p.stack = append(p.stack, bothMorphism(nil, via...))
+	return p
+}
+
+// InPredicates updates this path to represent the nodes of the valid inbound
+// predicates from the current nodes.
+//
+// For example:
+//  // Returns a list of predicates valid from "bob"
+//  //
+//  // Will return []string{"follows"} if there are any things that "follow" Bob
+//  StartPath(qs, "bob").InPredicates()
+func (p *Path) InPredicates() *Path {
+	p.nodes = Predicates{
+		From: p.nodes,
+		Rev:  true,
+	}
+	return p
+}
+
+// OutPredicates updates this path to represent the nodes of the valid inbound
+// predicates from the current nodes.
+//
+// For example:
+//  // Returns a list of predicates valid from "bob"
+//  //
+//  // Will return []string{"follows", "status"} if there are edges from "bob"
+//  // labelled "follows", and edges from "bob" that describe his "status".
+//  StartPath(qs, "bob").OutPredicates()
+func (p *Path) OutPredicates() *Path {
+	p.nodes = Predicates{
+		From: p.nodes,
+	}
+	return p
+}
+
+// And updates the current Path to represent the nodes that match both the
+// current Path so far, and the given Path.
+func (p *Path) And(path *Path) *Path {
+	p.nodes = IntersectNodes{
+		p.nodes,
+		path.nodes,
+	}
+	return p
+}
+
+// Or updates the current Path to represent the nodes that match either the
+// current Path so far, or the given Path.
+func (p *Path) Or(path *Path) *Path {
+	p.nodes = UnionNodes{
+		p.nodes,
+		path.nodes,
+	}
+	return p
+}
+
+// Except updates the current Path to represent the all of the current nodes
+// except those in the supplied Path.
+//
+// For example:
+//  // Will return []string{"B"}
+//  StartPath(qs, "A", "B").Except(StartPath(qs, "A"))
+func (p *Path) Except(path *Path) *Path {
+	p.nodes = Except{
+		From:  p.nodes,
+		Nodes: path.nodes,
+	}
+	return p
+}
+
+// Follow allows you to stitch two paths together. The resulting path will start
+// from where the first path left off and continue iterating down the path given.
+func (p *Path) Follow(path *Path) *Path {
+	p.nodes = Follow(p.nodes, path.nodes)
+	return p
+}
+
+// FollowReverse is the same as follow, except it will iterate backwards up the
+// path given as argument.
+func (p *Path) FollowReverse(path *Path) *Path {
+	panic("not implemented yet") // TODO
+	//	p.stack = append(p.stack, followMorphism(path.Reverse()))
+	return p
+}
+
+// Save will, from the current nodes in the path, retrieve the node
+// one linkage away (given by either a path or a predicate), add the given
+// tag, and propagate that to the result set.
+//
+// For example:
+//  // Will return []map[string]string{{"social_status: "cool"}}
+//  StartPath(qs, "B").Save("status", "social_status"
+func (p *Path) Save(via interface{}, tag string) *Path {
+	p.nodes = Save{
+		From: p.nodes,
+		Via:  buildViaPath(via),
+		Tags: []string{tag},
+	}
+	return p
+}
+
+// SaveReverse is the same as Save, only in the reverse direction
+// (the subject of the linkage should be tagged, instead of the object).
+func (p *Path) SaveReverse(via interface{}, tag string) *Path {
+	p.nodes = Save{
+		From: p.nodes,
+		Via:  buildViaPath(via),
+		Tags: []string{tag},
+		Rev:  true,
+	}
+	return p
+}
+
+// Has limits the paths to be ones where the current nodes have some linkage
+// to some known node.
+func (p *Path) Has(via interface{}, nodes ...string) *Path {
+	var n Nodes
+	if len(nodes) == 0 {
+		n = AllNodes{}
+	} else {
+		n = Fixed(nodes)
+	}
+	p.nodes = Has{
+		From:  p.nodes,
+		Via:   buildViaPath(via),
+		Nodes: n,
+	}
+	return p
+}
+
+// LabelContext restricts the following operations (such as In, Out) to only
+// traverse edges that match the given set of labels.
+func (p *Path) LabelContext(via ...interface{}) *Path {
+	panic("not implemented yet") // TODO
+	//	p.stack = append(p.stack, labelContextMorphism(nil, via...))
+	return p
+}
+
+// LabelContextWithTags is exactly like LabelContext, except it tags the value
+// of the label used in the traversal with the tags provided.
+func (p *Path) LabelContextWithTags(tags []string, via ...interface{}) *Path {
+	panic("not implemented yet") // TODO
+	//	p.stack = append(p.stack, labelContextMorphism(tags, via...))
+	return p
+}
+
+// Back returns to a previously tagged place in the path. Any constraints applied after the Tag will remain in effect, but traversal continues from the tagged point instead, not from the end of the chain.
+//
+// For example:
+//  // Will return "bob" iff "bob" is cool
+//  StartPath(qs, "bob").Tag("person_tag").Out("status").Is("cool").Back("person_tag")
+func (p *Path) Back(tag string) *Path {
+	panic("not implemented yet") // TODO
+	//	newPath := NewPath(p.qs)
+	//	i := len(p.stack) - 1
+	//	ctx := &newPath.baseContext
+	//	for {
+	//		if i < 0 {
+	//			return p.Reverse()
+	//		}
+	//		if p.stack[i].Name == "tag" {
+	//			for _, x := range p.stack[i].tags {
+	//				if x == tag {
+	//					// Found what we're looking for.
+	//					p.stack = p.stack[:i+1]
+	//					return p.And(newPath)
+	//				}
+	//			}
+	//		}
+	//		var revMorphism morphism
+	//		revMorphism, ctx = p.stack[i].Reversal(ctx)
+	//		newPath.stack = append(newPath.stack, revMorphism)
+	//		i--
+	//	}
+}
+
+// BuildIterator returns an iterator from this given Path.  Note that you must
+// call this with a full path (not a morphism), since a morphism does not have
+// the ability to fetch the underlying quads.  This function will panic if
+// called with a morphism (i.e. if p.IsMorphism() is true).
+func (p *Path) BuildIterator() graph.Iterator {
+	if p.IsMorphism() {
+		panic("Building an iterator from a morphism. Bind a QuadStore with BuildIteratorOn(qs)")
+	}
+	return p.BuildIteratorOn(p.qs)
+}
+
+// BuildIteratorOn will return an iterator for this path on the given QuadStore.
+func (p *Path) BuildIteratorOn(qs graph.QuadStore) graph.Iterator {
+	return OptimizeOn(p.nodes, qs).BuildIterator()
+}
+
+// Morphism returns the morphism of this path.  The returned value is a
+// function that, when given a QuadStore and an existing Iterator, will
+// return a new Iterator that yields the subset of values from the existing
+// iterator matched by the current Path.
+func (p *Path) Morphism() graph.ApplyMorphism {
+	panic("not implemented yet") // TODO
+	return func(qs graph.QuadStore, it graph.Iterator) graph.Iterator {
+		//		ctx := &p.baseContext
+		var path PathObj = IntersectNodes{
+			p.nodes,
+			NodeIteratorBuilder{Builder: func() graph.Iterator { return it.Clone() }},
+		}
+		path = OptimizeOn(path, qs)
+		return path.BuildIterator()
+	}
+}
+
+func buildViaPath(via ...interface{}) Nodes {
+	if len(via) == 0 {
+		return AllNodes{}
+	} else if len(via) == 1 {
+		v := via[0]
+		switch p := v.(type) {
+		case nil:
+			return AllNodes{}
+		case *Path:
+			return p.nodes
+		case Nodes:
+			return p
+		case string:
+			return Fixed{p}
+		default:
+			panic(fmt.Sprintln("Invalid type passed to buildViaPath.", reflect.TypeOf(v), p))
+		}
+	}
+	var strings []string
+	for _, s := range via {
+		if str, ok := s.(string); ok {
+			strings = append(strings, str)
+		} else {
+			panic("Non-string type passed to long Via path")
+		}
+	}
+	return Fixed(strings)
+}

--- a/graph/path2/compat.go
+++ b/graph/path2/compat.go
@@ -75,6 +75,10 @@ type Path struct {
 	baseContext context
 }
 
+func (p *Path) PathObj() Nodes {
+	return p.nodes
+}
+
 // IsMorphism returns whether this Path is a morphism.
 func (p *Path) IsMorphism() bool { return p.qs == nil }
 
@@ -112,7 +116,8 @@ func PathFromIterator(qs graph.QuadStore, it graph.Iterator) *Path {
 // NewPath creates a new, empty Path.
 func NewPath(qs graph.QuadStore) *Path {
 	return &Path{
-		qs: qs,
+		nodes: AllNodes{},
+		qs:    qs,
 	}
 }
 

--- a/graph/path2/compat.go
+++ b/graph/path2/compat.go
@@ -358,6 +358,29 @@ func (p *Path) SaveReverse(via interface{}, tag string) *Path {
 	return p
 }
 
+// SaveOptional is the same as Save, but does not require linkage to exist.
+func (p *Path) SaveOptional(via interface{}, tag string) *Path {
+	p.nodes = Save{
+		From: p.nodes,
+		Via:  buildViaPath(via),
+		Tags: []string{tag},
+		Opt:  true,
+	}
+	return p
+}
+
+// SaveOptionalReverse is the same as SaveReverse, but does not require linkage to exist.
+func (p *Path) SaveOptionalReverse(via interface{}, tag string) *Path {
+	p.nodes = Save{
+		From: p.nodes,
+		Via:  buildViaPath(via),
+		Tags: []string{tag},
+		Rev:  true,
+		Opt:  true,
+	}
+	return p
+}
+
 // Has limits the paths to be ones where the current nodes have some linkage
 // to some known node.
 func (p *Path) Has(via interface{}, nodes ...string) *Path {

--- a/graph/path2/compat.go
+++ b/graph/path2/compat.go
@@ -300,8 +300,7 @@ func (p *Path) Follow(path *Path) *Path {
 // FollowReverse is the same as follow, except it will iterate backwards up the
 // path given as argument.
 func (p *Path) FollowReverse(path *Path) *Path {
-	panic("not implemented yet") // TODO
-	//	p.stack = append(p.stack, followMorphism(path.Reverse()))
+	p.nodes = FollowReverse(p.nodes, path.nodes)
 	return p
 }
 

--- a/graph/path2/helpers.go
+++ b/graph/path2/helpers.go
@@ -47,3 +47,14 @@ func Follow(from Nodes, via Nodes) Nodes {
 		return p, true
 	}, nil).(Nodes)
 }
+
+func FollowReverse(from Nodes, via Nodes) Nodes {
+	return Replace(via, func(p Nodes) (Nodes, bool) {
+		if _, ok := p.(Start); ok {
+			return from, false
+		} else if rev, ok := p.(NodesReverser); ok {
+			return rev.Reverse(), true
+		}
+		return p, true
+	}, nil).(Nodes)
+}

--- a/graph/path2/helpers.go
+++ b/graph/path2/helpers.go
@@ -5,14 +5,9 @@ import (
 )
 
 var (
-	_ Nodes         = NodeIteratorBuilder{}
-	_ NodesReplacer = NodeIteratorBuilder{}
-
-	_ Links         = LinkIteratorBuilder{}
-	_ LinksReplacer = LinkIteratorBuilder{}
-
-	_ Nodes         = Start{}
-	_ NodesReplacer = Start{}
+	_ Nodes = NodeIteratorBuilder{}
+	_ Links = LinkIteratorBuilder{}
+	_ Nodes = Start{}
 )
 
 type NodeIteratorBuilder struct {
@@ -20,24 +15,24 @@ type NodeIteratorBuilder struct {
 	Builder func() graph.Iterator
 }
 
-func (f NodeIteratorBuilder) Optimize() (Nodes, bool)                        { return f, false }
-func (f NodeIteratorBuilder) BuildIterator() graph.Iterator                  { return f.Builder() }
-func (f NodeIteratorBuilder) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return f }
+func (f NodeIteratorBuilder) Optimize() (Nodes, bool)                      { return f, false }
+func (f NodeIteratorBuilder) BuildIterator() graph.Iterator                { return f.Builder() }
+func (f NodeIteratorBuilder) Replace(_ NodesWrapper, _ LinksWrapper) Nodes { return f }
 
 type LinkIteratorBuilder struct {
 	Path    Links
 	Builder func() graph.Iterator
 }
 
-func (f LinkIteratorBuilder) Optimize() (Links, bool)                        { return f, false }
-func (f LinkIteratorBuilder) BuildIterator() graph.Iterator                  { return f.Builder() }
-func (f LinkIteratorBuilder) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Links { return f }
+func (f LinkIteratorBuilder) Optimize() (Links, bool)                      { return f, false }
+func (f LinkIteratorBuilder) BuildIterator() graph.Iterator                { return f.Builder() }
+func (f LinkIteratorBuilder) Replace(_ NodesWrapper, _ LinksWrapper) Links { return f }
 
 type Start struct{}
 
-func (f Start) Optimize() (Nodes, bool)                        { return f, false }
-func (f Start) BuildIterator() graph.Iterator                  { panic("build on morphism") }
-func (f Start) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return f }
+func (f Start) Optimize() (Nodes, bool)                      { return f, false }
+func (f Start) BuildIterator() graph.Iterator                { panic("build on morphism") }
+func (f Start) Replace(_ NodesWrapper, _ LinksWrapper) Nodes { return f }
 
 func Follow(from Nodes, via Nodes) Nodes {
 	return Replace(via, func(p Nodes) (Nodes, bool) {

--- a/graph/path2/helpers.go
+++ b/graph/path2/helpers.go
@@ -1,0 +1,49 @@
+package path
+
+import (
+	"github.com/google/cayley/graph"
+)
+
+var (
+	_ Nodes         = NodeIteratorBuilder{}
+	_ NodesReplacer = NodeIteratorBuilder{}
+
+	_ Links         = LinkIteratorBuilder{}
+	_ LinksReplacer = LinkIteratorBuilder{}
+
+	_ Nodes         = Start{}
+	_ NodesReplacer = Start{}
+)
+
+type NodeIteratorBuilder struct {
+	Path    Nodes
+	Builder func() graph.Iterator
+}
+
+func (f NodeIteratorBuilder) Optimize() (Nodes, bool)                        { return f, false }
+func (f NodeIteratorBuilder) BuildIterator() graph.Iterator                  { return f.Builder() }
+func (f NodeIteratorBuilder) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return f }
+
+type LinkIteratorBuilder struct {
+	Path    Links
+	Builder func() graph.Iterator
+}
+
+func (f LinkIteratorBuilder) Optimize() (Links, bool)                        { return f, false }
+func (f LinkIteratorBuilder) BuildIterator() graph.Iterator                  { return f.Builder() }
+func (f LinkIteratorBuilder) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Links { return f }
+
+type Start struct{}
+
+func (f Start) Optimize() (Nodes, bool)                        { return f, false }
+func (f Start) BuildIterator() graph.Iterator                  { panic("build on morphism") }
+func (f Start) Replace(_ WrapNodesFunc, _ WrapLinksFunc) Nodes { return f }
+
+func Follow(from Nodes, via Nodes) Nodes {
+	return Replace(via, func(p Nodes) (Nodes, bool) {
+		if _, ok := p.(Start); ok {
+			return from, false
+		}
+		return p, true
+	}, nil).(Nodes)
+}

--- a/graph/path2/morph.go
+++ b/graph/path2/morph.go
@@ -1,0 +1,99 @@
+package path
+
+import "github.com/google/cayley/quad"
+
+type Except struct {
+	Nodes NodePath
+	From  NodePath
+}
+
+func (p Except) Simplify() (NodePath, bool) {
+	return IntersectNodes{
+		p.From,
+		NotNodes{
+			Nodes: p.Nodes,
+		},
+	}, true
+}
+func (p Except) Optimize() (NodePath, bool) {
+	if p.From == nil {
+		return nil, true
+	}
+	nf, optf := p.From.Optimize()
+	if nf == nil {
+		return nil, true
+	} else if p.Nodes == nil {
+		return nf, true
+	}
+	n, opt := p.Nodes.Optimize()
+	if n == nil {
+		return nf, true
+	} else if _, ok := n.(AllNodes); ok { // except all = zero
+		return nil, true
+	} else if _, ok = nf.(AllNodes); ok { // except from all = not nodes
+		return NotNodes{Nodes: n}, true
+	}
+	return Except{
+		Nodes: n,
+		From:  nf,
+	}, opt || optf
+}
+
+type Out struct {
+	From NodePath
+	Via  NodePath
+	Rev  bool
+	Tags []string
+}
+
+func (p Out) Simplify() (NodePath, bool) {
+	start, goal := quad.Subject, quad.Object
+	if p.Rev {
+		start, goal = goal, start
+	}
+	source := LinksTo{
+		Nodes: p.From,
+		Dir:   start,
+	}
+	trail := LinksTo{
+		Nodes: Tag{
+			Nodes: p.Via,
+			Tags:  p.Tags,
+		},
+		Dir: quad.Predicate,
+	}
+	var label LinkPath
+	// TODO: labels
+	//	if ctx != nil {
+	//		if ctx.labelSet != nil {
+	//			labeliter := ctx.labelSet.BuildIteratorOn(viaPath.qs)
+	//			label = iterator.NewLinksTo(viaPath.qs, labeliter, quad.Label)
+	//		}
+	//	}
+	return HasA{
+		Links: IntersectLinks{
+			source,
+			trail,
+			label,
+		},
+		Dir: goal,
+	}, true
+}
+func (p Out) Optimize() (NodePath, bool) {
+	if p.From == nil || p.Via == nil {
+		return nil, true
+	}
+	nf, fopt := p.From.Optimize()
+	if p.From == nil {
+		return nil, true
+	}
+	nv, vopt := p.Via.Optimize()
+	if p.Via == nil {
+		return nil, true
+	}
+	return Out{
+		From: nf, Via: nv,
+		Rev:  p.Rev,
+		Tags: p.Tags, // TODO: unique tags
+	}, fopt || vopt
+}

--- a/graph/path2/morph.go
+++ b/graph/path2/morph.go
@@ -15,7 +15,7 @@ type Except struct {
 	From  Nodes
 }
 
-func (p Except) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Except) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -81,7 +81,7 @@ func (p Out) Reverse() Nodes {
 		Tags:   p.Tags,
 	}
 }
-func (p Out) Replace(nf WrapNodesFunc, nl WrapLinksFunc) Nodes {
+func (p Out) Replace(nf NodesWrapper, nl LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -161,7 +161,7 @@ type Has struct {
 	Rev   bool
 }
 
-func (p Has) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Has) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -237,7 +237,7 @@ type Predicates struct {
 func (P Predicates) Reverse() Nodes {
 	panic("not implemented: need a function from predicates to their associated edges")
 }
-func (p Predicates) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Predicates) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}
@@ -288,7 +288,7 @@ type Save struct {
 	// TODO: optional
 }
 
-func (p Save) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
+func (p Save) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 	if nf == nil {
 		return p
 	}

--- a/graph/path2/morph.go
+++ b/graph/path2/morph.go
@@ -61,6 +61,7 @@ func (p Except) Optimize() (Nodes, bool) {
 var (
 	_ Nodes           = Out{}
 	_ NodesSimplifier = Out{}
+	_ NodesReverser   = Out{}
 )
 
 type Out struct {
@@ -70,6 +71,14 @@ type Out struct {
 	Tags []string
 }
 
+func (p Out) Reverse() Nodes {
+	return Out{
+		From: p.From,
+		Via:  p.Via,
+		Rev:  !p.Rev,
+		Tags: p.Tags,
+	}
+}
 func (p Out) Replace(nf WrapNodesFunc, nl WrapLinksFunc) Nodes {
 	if nf == nil {
 		return p
@@ -211,8 +220,9 @@ func (p Has) Optimize() (Nodes, bool) {
 }
 
 var (
-	_ Nodes           = Has{}
-	_ NodesSimplifier = Has{}
+	_ Nodes           = Predicates{}
+	_ NodesSimplifier = Predicates{}
+	_ NodesReverser   = Predicates{}
 )
 
 type Predicates struct {
@@ -220,6 +230,9 @@ type Predicates struct {
 	Rev  bool
 }
 
+func (P Predicates) Reverse() Nodes {
+	panic("not implemented: need a function from predicates to their associated edges")
+}
 func (p Predicates) Replace(nf WrapNodesFunc, _ WrapLinksFunc) Nodes {
 	if nf == nil {
 		return p

--- a/graph/path2/morph.go
+++ b/graph/path2/morph.go
@@ -285,7 +285,7 @@ type Save struct {
 	Via  Nodes
 	Tags []string
 	Rev  bool
-	// TODO: optional
+	Opt  bool
 }
 
 func (p Save) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
@@ -297,6 +297,7 @@ func (p Save) Replace(nf NodesWrapper, _ LinksWrapper) Nodes {
 		Via:  nf(p.Via),
 		Tags: p.Tags,
 		Rev:  p.Rev,
+		Opt:  p.Opt,
 	}
 }
 func (p Save) BuildIterator() graph.Iterator {
@@ -322,9 +323,12 @@ func (p Save) Simplify() Nodes {
 		trail,
 		dest,
 	}
-	save := HasA{
+	save := Nodes(HasA{
 		Links: route,
 		Dir:   start,
+	})
+	if p.Opt {
+		save = Optional{Nodes: save}
 	}
 	return IntersectNodes{
 		p.From,
@@ -346,6 +350,6 @@ func (p Save) Optimize() (Nodes, bool) {
 		return nil, true
 	}
 	return Save{
-		From: nf, Via: nv, Tags: p.Tags, Rev: p.Rev,
+		From: nf, Via: nv, Tags: p.Tags, Rev: p.Rev, Opt: p.Opt,
 	}, fopt || vopt
 }

--- a/graph/path2/optimize_test.go
+++ b/graph/path2/optimize_test.go
@@ -1,0 +1,141 @@
+package path
+
+import (
+	"github.com/google/cayley/quad"
+	"reflect"
+	"testing"
+)
+
+var casesOptimize = []struct {
+	message  string
+	simplify bool
+	path     PathObj
+	expect   PathObj
+}{
+	{
+		"unique fixed",
+		false,
+		Unique{Fixed{"c", "b", "a", "b", "c", "b", "b"}},
+		Fixed{"a", "b", "c"},
+	},
+	{
+		"hasA with all",
+		false,
+		HasA{Links: AllLinks{}, Dir: quad.Object},
+		AllNodes{},
+	},
+	{
+		"linksTo with all",
+		false,
+		LinksTo{Nodes: AllNodes{}, Dir: quad.Object},
+		AllLinks{},
+	},
+	{
+		"linksTo over hasA",
+		false,
+		HasA{
+			Links: LinksTo{
+				Nodes: Fixed{"bob"},
+				Dir:   quad.Object,
+			},
+			Dir: quad.Object,
+		},
+		Fixed{"bob"},
+	},
+	{
+		"intersect fixed",
+		false,
+		IntersectNodes{
+			Fixed{"a", "c"},
+			Fixed{"b", "a", "d"},
+			Fixed{"a", "b"},
+		},
+		Fixed{"a"},
+	},
+	//	{
+	//		"intersect fixed and not",
+	//		false,
+	//		IntersectNodes{
+	//			Fixed{"a","c","d"},
+	//			NotNodes{Fixed{"d"}},
+	//			Fixed{"a","d"},
+	//		},
+	//		Fixed{"a"},
+	//	},
+	{
+		"nested intersect nodes",
+		false,
+		IntersectNodes{
+			IntersectNodes{
+				Fixed{"bob", "fred"},
+			},
+			IntersectNodes{
+				NotNodes{Fixed{"dani"}},
+				Fixed{"bob", "john"},
+			},
+		},
+		IntersectNodes{ // TODO: fixed-intersects-not optimization
+			NotNodes{Fixed{"dani"}},
+			Fixed{"bob"},
+		},
+	},
+	{
+		"out with no labels",
+		false,
+		Out{
+			From: AllNodes{},
+			Via:  Fixed{"follows"},
+		},
+		nil,
+	},
+	{
+		"out with all labels",
+		false,
+		Out{
+			From:   AllNodes{},
+			Via:    Fixed{"follows"},
+			Labels: AllNodes{},
+		},
+		Out{
+			From:   AllNodes{},
+			Via:    Fixed{"follows"},
+			Labels: AllNodes{},
+		},
+	},
+	{
+		"out with all labels (simplify)",
+		true,
+		Out{
+			From:   AllNodes{},
+			Via:    Fixed{"follows"},
+			Labels: AllNodes{},
+		},
+		HasA{
+			Links: LinksTo{
+				Nodes: Fixed{"follows"},
+				Dir:   quad.Predicate,
+			},
+			Dir: quad.Object,
+		},
+	},
+}
+
+func TestOptimize(t *testing.T) {
+	for _, test := range casesOptimize {
+		got := test.path
+		if test.simplify {
+			switch si := got.(type) {
+			case NodesSimplifier:
+				got = si.Simplify()
+			case LinksSimplifier:
+				got = si.Simplify()
+			default:
+				t.Errorf("Failed to optimize %s: not simplifiable", test.message)
+			}
+		}
+		got, _ = Optimize(got)
+		if !reflect.DeepEqual(got, test.expect) {
+			t.Errorf("Failed to optimize %s, got: %#v expected: %#v", test.message, got, test.expect)
+		}
+	}
+}

--- a/graph/path2/optimize_test.go
+++ b/graph/path2/optimize_test.go
@@ -1,7 +1,0 @@
-package path
-
-import "testing"
-
-func TestOptimize(t *testing.T) {
-
-}

--- a/graph/path2/optimize_test.go
+++ b/graph/path2/optimize_test.go
@@ -1,0 +1,7 @@
+package path
+
+import "testing"
+
+func TestOptimize(t *testing.T) {
+
+}

--- a/graph/path2/optimize_test.go
+++ b/graph/path2/optimize_test.go
@@ -80,6 +80,18 @@ var casesOptimize = []struct {
 		},
 	},
 	{
+		"intersect all and optional",
+		false,
+		IntersectNodes{
+			AllNodes{},
+			Optional{Fixed{"b", "a", "d"}},
+		},
+		IntersectNodes{
+			Optional{Fixed{"b", "a", "d"}},
+			AllNodes{},
+		},
+	},
+	{
 		"out with no labels",
 		false,
 		Out{

--- a/graph/path2/optimize_test.go
+++ b/graph/path2/optimize_test.go
@@ -75,8 +75,8 @@ var casesOptimize = []struct {
 			},
 		},
 		IntersectNodes{ // TODO: fixed-intersects-not optimization
-			NotNodes{Fixed{"dani"}},
 			Fixed{"bob"},
+			NotNodes{Fixed{"dani"}},
 		},
 	},
 	{

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -57,7 +57,7 @@ type LinksReplacer interface {
 }
 
 func replaceAny(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) PathObj {
-	// TODO: reflect-based replacer
+	// TODO: reflect-based replacer?
 	panic(fmt.Errorf("not implemented, type: %T", p))
 }
 func Replace(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) (out PathObj) {

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -181,12 +181,24 @@ func OptimizeOn(p PathObj, qs graph.QuadStore) PathObj {
 	}
 	// Step 3: replace all abstract paths
 	// TODO: remove, when all stores will support optimizations
-	p = Replace(p, func(sp Nodes) (Nodes, bool) {
+	p = bindTo(p, qs, true)
+	return p
+}
+
+func BindTo(p PathObj, qs graph.QuadStore) PathObj {
+	return bindTo(p, qs, false)
+}
+
+func bindTo(p PathObj, qs graph.QuadStore, optimize bool) PathObj {
+	return Replace(p, func(sp Nodes) (Nodes, bool) {
 		if a, ok := sp.(NodesAbstract); ok {
 			return a.BindTo(qs), false
 		}
 		if si, ok := sp.(NodesSimplifier); ok {
-			sp, _ = si.Simplify().Optimize()
+			sp = si.Simplify()
+			if optimize {
+				sp, _ = sp.Optimize()
+			}
 		}
 		if a, ok := sp.(NodesAbstract); ok {
 			return a.BindTo(qs), false
@@ -197,12 +209,14 @@ func OptimizeOn(p PathObj, qs graph.QuadStore) PathObj {
 			return a.BindTo(qs), false
 		}
 		if si, ok := sp.(LinksSimplifier); ok {
-			sp, _ = si.Simplify().Optimize()
+			sp = si.Simplify()
+			if optimize {
+				sp, _ = sp.Optimize()
+			}
 		}
 		if a, ok := sp.(LinksAbstract); ok {
 			return a.BindTo(qs), false
 		}
 		return sp, true
 	})
-	return p
 }

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -1,0 +1,10 @@
+package path
+
+type NodePath interface {
+	Simplify() (NodePath, bool)
+	Optimize() (NodePath, bool)
+}
+type LinkPath interface {
+	Simplify() (LinkPath, bool)
+	Optimize() (LinkPath, bool)
+}

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -5,68 +5,112 @@ import (
 	"github.com/google/cayley/graph"
 )
 
+// PathObj is an common interface for path (for both Links and Nodes).
 type PathObj interface {
-	//DescribePath()
+	// BuildIterator creates an iterator for the given path.
+	//
+	// Note, that some path parts may be abstract (All, for example),
+	// thus it must be bound to QuadStore with BindTo or OptimizeOn.
 	BuildIterator() graph.Iterator
 }
 
+// NodesWrapper is a function which can replace Nodes.
+type NodesWrapper func(Nodes) Nodes
+
+// LinksWrapper is a function which can replace Links.
+type LinksWrapper func(Links) Links
+
+// Nodes is an interface for path which describes a set of nodes (values).
+type Nodes interface {
+	PathObj
+	// Replace applies wrapper functions to all sub-paths and returns
+	// a modified copy of this path.
+	//
+	// One of the wrappers can be nil, what means that paths of this
+	// type should not be changed.
+	Replace(nf NodesWrapper, lf LinksWrapper) Nodes
+	// Optimize returns a copy of current path with all possible optimizations applied.
+	//
+	// The second return value is true if path was replaced.
+	//
+	// It is a path's responsibility to apply Optimize to all it's sub-paths.
+	Optimize() (Nodes, bool)
+}
+
+// Links is an interface for path which describes a set of links (quads).
+type Links interface {
+	PathObj
+	// Replace applies wrapper functions to all sub-paths and returns
+	// a modified copy of this path.
+	//
+	// One of the wrappers can be nil, what means that paths of this
+	// type should not be changed.
+	Replace(nf NodesWrapper, lf LinksWrapper) Links
+	// Optimize returns a copy of current path with all possible optimizations applied.
+	//
+	// The second return value is true if path was replaced.
+	//
+	// It is a path's responsibility to apply Optimize to all it's sub-paths.
+	Optimize() (Links, bool)
+}
+
+// PathOptimizer is an optional interface for QuadStore, which
+// advertise an ability to optimize Nodes or Links paths.
+//
+// TODO: make it a required interface and remove abstract path replacer.
 type PathOptimizer interface {
+	// OptimizeNodesPath is a QuadStore's variant of Nodes.Optimize.
 	OptimizeNodesPath(p Nodes) (Nodes, bool)
+	// OptimizeLinksPath is a QuadStore's variant of Links.Optimize.
 	OptimizeLinksPath(p Links) (Links, bool)
 }
 
+// NodesAbstract is an interface for Nodes paths that can not be used without
+// QuadStore implementation (All, for example).
 type NodesAbstract interface {
+	// BindTo returns a Nodes path bound to provided QuadStore.
 	BindTo(qs graph.QuadStore) Nodes
 }
 
+// LinksAbstract is an interface for Links paths that can not be used without
+// QuadStore implementation (All, for example).
 type LinksAbstract interface {
+	// BindTo returns a Links path bound to provided QuadStore.
 	BindTo(qs graph.QuadStore) Links
 }
 
+// NodesSimplifier is an optional interface for high-level path objects,
+// that can be decomposed into a tree of basic paths.
 type NodesSimplifier interface {
 	Simplify() Nodes
 }
 
+// LinksSimplifier is an optional interface for high-level path objects,
+// that can be decomposed into a tree of basic paths.
 type LinksSimplifier interface {
 	Simplify() Links
 }
 
-type Nodes interface {
-	PathObj
-	NodesReplacer
-	Optimize() (Nodes, bool)
-}
-type Links interface {
-	PathObj
-	LinksReplacer
-	Optimize() (Links, bool)
-}
-
+// NodesReverser is an optional interface for Node paths that
+// traversal direction can be reversed.
 type NodesReverser interface {
 	Reverse() Nodes
 }
 
-//
-
-type WrapNodesFunc func(Nodes) Nodes
-type WrapLinksFunc func(Links) Links
-
 type ReplaceNodesFunc func(p Nodes) (np Nodes, next bool)
 type ReplaceLinksFunc func(p Links) (np Links, next bool)
-type NodesReplacer interface {
-	Replace(nf WrapNodesFunc, lf WrapLinksFunc) Nodes
-}
-type LinksReplacer interface {
-	Replace(nf WrapNodesFunc, lf WrapLinksFunc) Links
-}
 
-func replaceAny(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) PathObj {
-	// TODO: reflect-based replacer?
-	panic(fmt.Errorf("not implemented, type: %T", p))
-}
+// Replace will call provided functions to replace Nodes and/or Links in the path
+// recursively.
+//
+// It stops tree descent if function returns false as a second return value.
+//
+// One of the functions can be nil.
 func Replace(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) (out PathObj) {
 	if p == nil {
 		return nil
+	} else if nf == nil && lf == nil {
+		return p
 	}
 	//	fmt.Printf("replace on %T\n", p)
 	//	defer func(){
@@ -74,47 +118,74 @@ func Replace(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) (out PathObj) 
 	//	}()
 	switch tp := p.(type) {
 	case Nodes:
-		if nf != nil && tp != nil {
-			np, next := nf(tp)
-			if !next {
-				return np
-			}
-			p = np
+		if tp != nil {
+			return replaceNodes(tp, nf, lf)
 		}
+		return nil
 	case Links:
-		if lf != nil && tp != nil {
-			np, next := lf(tp)
-			if !next {
-				return np
-			}
-			p = np
+		if tp != nil {
+			return replaceLinks(tp, nf, lf)
 		}
+		return nil
 	default:
-		panic("unknown type")
-	}
-	nfw := func(p Nodes) Nodes {
-		if np := Replace(p, nf, lf); np != nil {
-			return np.(Nodes)
-		}
-		return nil
-	}
-	lfw := func(p Links) Links {
-		if np := Replace(p, nf, lf); np != nil {
-			return np.(Links)
-		}
-		return nil
-	}
-	if nr, ok := p.(NodesReplacer); ok {
-		return nr.Replace(nfw, lfw)
-	} else if lr, ok := p.(LinksReplacer); ok {
-		return lr.Replace(nfw, lfw)
-	} else {
-		return replaceAny(p, nf, lf)
+		panic(fmt.Errorf("unknown path type: %T", p))
 	}
 }
 
-//
+func replaceNodes(p Nodes, nf ReplaceNodesFunc, lf ReplaceLinksFunc) Nodes {
+	if p == nil {
+		return nil
+	}
+	if nf != nil {
+		var next bool
+		p, next = nf(p)
+		if !next {
+			return p
+		} else if p == nil {
+			return nil
+		}
+	}
+	var (
+		nw NodesWrapper
+		lw LinksWrapper
+	)
+	if nf != nil {
+		nw = func(p Nodes) Nodes { return replaceNodes(p, nf, lf) }
+	}
+	if lf != nil {
+		lw = func(p Links) Links { return replaceLinks(p, nf, lf) }
+	}
+	return p.Replace(nw, lw)
+}
+func replaceLinks(p Links, nf ReplaceNodesFunc, lf ReplaceLinksFunc) Links {
+	if p == nil {
+		return nil
+	}
+	if lf != nil {
+		var next bool
+		p, next = lf(p)
+		if !next {
+			return p
+		} else if p == nil {
+			return nil
+		}
+	}
+	var (
+		nw NodesWrapper
+		lw LinksWrapper
+	)
+	if nf != nil {
+		nw = func(p Nodes) Nodes { return replaceNodes(p, nf, lf) }
+	}
+	if lf != nil {
+		lw = func(p Links) Links { return replaceLinks(p, nf, lf) }
+	}
+	return p.Replace(nw, lw)
+}
 
+// Optimize applies all possible optimizations, that are common for all QuadStores.
+//
+// Second return value is true, if path was replaced.
 func Optimize(p PathObj) (PathObj, bool) {
 	if p == nil {
 		return nil, false
@@ -134,15 +205,11 @@ func Optimize(p PathObj) (PathObj, bool) {
 	return p, false
 }
 
-// Steps:
-// 1) Optimize everything
-// 2) Replace all Abstract paths
-// 3) Give QS a chance to optimize
-//   a) Check for known types and replace them
-//   b) If type is unknown, try to simplify
-//   c) If it's simplifiable - try to optimize again
-//   d) If failed, leave it untouched
-
+// OptimizeOn binds provided path to a QuadStore, applying all
+// generic optimizations an all QuadStore-specific optimizations.
+//
+// Resulting path will always produce the fastest possible iterator
+// for a specified query shape for that particular QuadStore.
 func OptimizeOn(p PathObj, qs graph.QuadStore) PathObj {
 	// Step 1: optimize pure path
 	p, _ = Optimize(p)
@@ -153,38 +220,43 @@ func OptimizeOn(p PathObj, qs graph.QuadStore) PathObj {
 	if po, ok := qs.(PathOptimizer); ok {
 		p = Replace(p, func(sp Nodes) (Nodes, bool) {
 			np, opt := po.OptimizeNodesPath(sp)
-			if opt { // replaced, no need to indirect
+			if opt { // replaced, stop tree descent
 				return np, false
 			}
 			if sm, ok := sp.(NodesSimplifier); ok {
 				np, _ = sm.Simplify().Optimize()
-			} else { // can't simplify, indirect further
+			} else { // can't simplify, continue descent
 				return sp, true
 			}
-			// give a second chance - optimize a simplified variant
+			// give QS a second chance - optimize a simplified variant
 			np, opt = po.OptimizeNodesPath(np)
 			return np, !opt
 		}, func(sp Links) (Links, bool) {
 			np, opt := po.OptimizeLinksPath(sp)
-			if opt { // replaced, no need to indirect
+			if opt { // replaced, stop tree descent
 				return np, false
 			}
 			if sm, ok := sp.(LinksSimplifier); ok {
 				np, _ = sm.Simplify().Optimize()
-			} else { // can't simplify, indirect further
+			} else { // can't simplify, continue descent
 				return sp, true
 			}
-			// give a second chance - optimize a simplified variant
+			// give QS a second chance - optimize a simplified variant
 			np, opt = po.OptimizeLinksPath(np)
 			return np, !opt
 		})
 	}
 	// Step 3: replace all abstract paths
-	// TODO: remove, when all stores will support optimizations
+	// TODO: remove this when all stores will support direct abstract path optimizations
 	p = bindTo(p, qs, true)
 	return p
 }
 
+// BindTo binds all abstract sub-paths to QuadStore, making path buildable.
+//
+// BindTo is similar to OptimizeOn, but it omits all generic optimization.
+// This may be useful for rarely-reused queries, where optimization time
+// is comparable to iteration over non-optimized iterator.
 func BindTo(p PathObj, qs graph.QuadStore) PathObj {
 	return bindTo(p, qs, false)
 }

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -1,10 +1,201 @@
 package path
 
-type NodePath interface {
-	Simplify() (NodePath, bool)
-	Optimize() (NodePath, bool)
+import (
+	"fmt"
+	"github.com/google/cayley/graph"
+)
+
+type PathObj interface {
+	//DescribePath()
+	BuildIterator() graph.Iterator
 }
-type LinkPath interface {
-	Simplify() (LinkPath, bool)
-	Optimize() (LinkPath, bool)
+
+type PathOptimizer interface {
+	OptimizeNodesPath(p Nodes) (Nodes, bool)
+	OptimizeLinksPath(p Links) (Links, bool)
+}
+
+type NodesAbstract interface {
+	BindTo(qs graph.QuadStore) Nodes
+}
+
+type LinksAbstract interface {
+	BindTo(qs graph.QuadStore) Links
+}
+
+type NodesSimplifier interface {
+	Simplify() Nodes
+}
+
+type LinksSimplifier interface {
+	Simplify() Links
+}
+
+type Nodes interface {
+	PathObj
+	NodesReplacer
+	Optimize() (Nodes, bool)
+}
+type Links interface {
+	PathObj
+	LinksReplacer
+	Optimize() (Links, bool)
+}
+
+//
+
+type WrapNodesFunc func(Nodes) Nodes
+type WrapLinksFunc func(Links) Links
+
+type ReplaceNodesFunc func(p Nodes) (np Nodes, next bool)
+type ReplaceLinksFunc func(p Links) (np Links, next bool)
+type NodesReplacer interface {
+	Replace(nf WrapNodesFunc, lf WrapLinksFunc) Nodes
+}
+type LinksReplacer interface {
+	Replace(nf WrapNodesFunc, lf WrapLinksFunc) Links
+}
+
+func replaceAny(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) PathObj {
+	// TODO: reflect-based replacer
+	panic(fmt.Errorf("not implemented, type: %T", p))
+}
+func Replace(p PathObj, nf ReplaceNodesFunc, lf ReplaceLinksFunc) (out PathObj) {
+	if p == nil {
+		return nil
+	}
+	//	fmt.Printf("replace on %T\n", p)
+	//	defer func(){
+	//		fmt.Printf("replaced %T -> %T\n", p, out)
+	//	}()
+	switch tp := p.(type) {
+	case Nodes:
+		if nf != nil && tp != nil {
+			np, next := nf(tp)
+			if !next {
+				return np
+			}
+			p = np
+		}
+	case Links:
+		if lf != nil && tp != nil {
+			np, next := lf(tp)
+			if !next {
+				return np
+			}
+			p = np
+		}
+	default:
+		panic("unknown type")
+	}
+	nfw := func(p Nodes) Nodes {
+		return Replace(p, nf, lf).(Nodes)
+	}
+	lfw := func(p Links) Links {
+		return Replace(p, nf, lf).(Links)
+	}
+	if nr, ok := p.(NodesReplacer); ok {
+		return nr.Replace(nfw, lfw)
+	} else if lr, ok := p.(LinksReplacer); ok {
+		return lr.Replace(nfw, lfw)
+	} else {
+		return replaceAny(p, nf, lf)
+	}
+}
+
+//
+
+func Optimize(p PathObj) (PathObj, bool) {
+	if p == nil {
+		return nil, false
+	}
+	switch tp := p.(type) {
+	case Nodes:
+		if tp == nil {
+			return nil, true
+		}
+		return tp.Optimize()
+	case Links:
+		if tp == nil {
+			return nil, true
+		}
+		return tp.Optimize()
+	}
+	return p, false
+}
+
+// Steps:
+// 1) Optimize everything
+// 2) Replace all Abstract paths
+// 3) Give QS a chance to optimize
+//   a) Check for known types and replace them
+//   b) If type is unknown, try to simplify
+//   c) If it's simplifiable - try to optimize again
+//   d) If failed, leave it untouched
+
+func OptimizeOn(p PathObj, qs graph.QuadStore) PathObj {
+	// Step 1: optimize pure path
+	p, _ = Optimize(p)
+	if qs == nil {
+		return p
+	}
+	// Step 2: let quad store optimize things
+	if po, ok := qs.(PathOptimizer); ok {
+		p = Replace(p, func(sp Nodes) (Nodes, bool) {
+			np, opt := po.OptimizeNodesPath(sp)
+			if opt { // replaced, no need to indirect
+				return np, false
+			}
+			if sm, ok := sp.(NodesSimplifier); ok {
+				np = sm.Simplify()
+			} else { // can't simplify, indirect further
+				return sp, true
+			}
+			np, opt = po.OptimizeNodesPath(np)
+			if !opt { // can't optimize simplified variant
+				return sp, true
+			}
+			return np, false
+		}, func(sp Links) (Links, bool) {
+			np, ok := po.OptimizeLinksPath(sp)
+			if ok { // replaced, no need to indirect
+				return np, false
+			}
+			if sm, ok := sp.(LinksSimplifier); ok {
+				np = sm.Simplify()
+			} else { // can't simplify, indirect further
+				return sp, true
+			}
+			np, ok = po.OptimizeLinksPath(np)
+			if !ok { // can't optimize simplified variant
+				return sp, true
+			}
+			return np, false
+		})
+	}
+	// Step 3: replace all abstract paths
+	p = Replace(p, func(sp Nodes) (Nodes, bool) {
+		if a, ok := sp.(NodesAbstract); ok {
+			return a.BindTo(qs), false
+		}
+		if si, ok := sp.(NodesSimplifier); ok {
+			sp = si.Simplify()
+		}
+		if a, ok := sp.(NodesAbstract); ok {
+			return a.BindTo(qs), false
+		}
+		return sp, true
+	}, func(sp Links) (Links, bool) {
+		if a, ok := sp.(LinksAbstract); ok {
+			return a.BindTo(qs), false
+		}
+		if si, ok := sp.(LinksSimplifier); ok {
+			sp = si.Simplify()
+		}
+		if a, ok := sp.(LinksAbstract); ok {
+			return a.BindTo(qs), false
+		}
+		return sp, true
+	})
+	return p
 }

--- a/graph/path2/path.go
+++ b/graph/path2/path.go
@@ -42,6 +42,10 @@ type Links interface {
 	Optimize() (Links, bool)
 }
 
+type NodesReverser interface {
+	Reverse() Nodes
+}
+
 //
 
 type WrapNodesFunc func(Nodes) Nodes

--- a/graph/path2/pathtest/pathtest.go
+++ b/graph/path2/pathtest/pathtest.go
@@ -1,0 +1,331 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathtest
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/quad"
+	"github.com/google/cayley/quad/cquads"
+
+	. "github.com/google/cayley/graph/path2"
+	_ "github.com/google/cayley/writer"
+)
+
+// This is a simple test graph.
+//
+//  +-------+                        +------+
+//  | alice |-----                 ->| fred |<--
+//  +-------+     \---->+-------+-/  +------+   \-+-------+
+//                ----->| #bob# |       |         | emily |
+//  +---------+--/  --->+-------+       |         +-------+
+//  | charlie |    /                    v
+//  +---------+   /                  +--------+
+//    \---    +--------+             | #greg# |
+//        \-->| #dani# |------------>+--------+
+//            +--------+
+
+func loadGraph(path string, t testing.TB) []quad.Quad {
+	var r io.Reader
+	var simpleGraph []quad.Quad
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open %q: %v", path, err)
+	}
+	defer f.Close()
+	r = f
+
+	dec := cquads.NewDecoder(r)
+	q1, err := dec.Unmarshal()
+	if err != nil {
+		t.Fatalf("Failed to Unmarshal: %v", err)
+	}
+	for ; err == nil; q1, err = dec.Unmarshal() {
+		simpleGraph = append(simpleGraph, q1)
+	}
+	return simpleGraph
+}
+
+func makeTestStore(t testing.TB, fnc func() graph.QuadStore) graph.QuadStore {
+	simpleGraph := loadGraph("../../data/testdata.nq", t)
+	qs := fnc()
+	w, _ := graph.NewQuadWriter("single", qs, nil)
+	for _, t := range simpleGraph {
+		w.AddQuad(t)
+	}
+	return qs
+}
+
+func runTopLevel(qs graph.QuadStore, p PathObj) []string {
+	var out []string
+	p = OptimizeOn(p, qs)
+	it := p.BuildIterator()
+	it, _ = it.Optimize()
+	for graph.Next(it) {
+		v := qs.NameOf(it.Result())
+		out = append(out, v)
+	}
+	return out
+}
+
+func runTag(qs graph.QuadStore, p PathObj, tag string) []string {
+	var out []string
+	p = OptimizeOn(p, qs)
+	it := p.BuildIterator()
+	it, _ = it.Optimize()
+	for graph.Next(it) {
+		tags := make(map[string]graph.Value)
+		it.TagResults(tags)
+		out = append(out, qs.NameOf(tags[tag]))
+		for it.NextPath() {
+			tags := make(map[string]graph.Value)
+			it.TagResults(tags)
+			out = append(out, qs.NameOf(tags[tag]))
+		}
+	}
+	return out
+}
+
+type test struct {
+	message string
+	path    Nodes
+	expect  []string
+	tag     string
+}
+
+// Define morphisms without a QuadStore
+
+var (
+	//	grandfollows = StartMorphism().Out("follows").Out("follows")
+	grandfollowsPath = Out{
+		From: Out{
+			From: Start{},
+			Via:  Fixed{"follows"},
+		},
+		Via: Fixed{"follows"},
+	}
+)
+
+func testSet(qs graph.QuadStore) []test {
+	return []test{
+		{
+			message: "use out",
+			//			path: StartPath(qs, "alice").Out("follows"),
+			path:   Out{From: Fixed{"alice"}, Via: Fixed{"follows"}},
+			expect: []string{"bob"},
+		},
+		{
+			message: "use in",
+			path:    Out{From: Fixed{"bob"}, Via: Fixed{"follows"}, Rev: true},
+			//			path:    StartPath(qs, "bob").In("follows"),
+			expect: []string{"alice", "charlie", "dani"},
+		},
+		{
+			message: "use path Out",
+			path: Out{
+				From: Fixed{"bob"},
+				Via: Out{
+					From: Fixed{"predicates"},
+					Via:  Fixed{"are"},
+				},
+			},
+			//			path:    StartPath(qs, "bob").Out(StartPath(qs, "predicates").Out("are")),
+			expect: []string{"fred", "cool_person"},
+		},
+		{
+			message: "use And",
+			path: IntersectNodes{
+				Out{From: Fixed{"dani"}, Via: Fixed{"follows"}},
+				Out{From: Fixed{"charlie"}, Via: Fixed{"follows"}},
+			},
+			//			path: StartPath(qs, "dani").Out("follows").And(
+			//				StartPath(qs, "charlie").Out("follows")),
+			expect: []string{"bob"},
+		},
+		{
+			message: "use Or",
+			path: UnionNodes{
+				Out{From: Fixed{"fred"}, Via: Fixed{"follows"}},
+				Out{From: Fixed{"alice"}, Via: Fixed{"follows"}},
+			},
+			//			path: StartPath(qs, "fred").Out("follows").Or(
+			//				StartPath(qs, "alice").Out("follows")),
+			expect: []string{"bob", "greg"},
+		},
+		{
+			message: "implicit All",
+			path:    AllNodes{},
+			//			path:    StartPath(qs),
+			expect: []string{"alice", "bob", "charlie", "dani", "emily", "fred", "greg", "follows", "status", "cool_person", "predicates", "are", "smart_graph", "smart_person"},
+		},
+		{
+			message: "follow",
+			path: Follow(
+				Fixed{"charlie"},
+				Out{
+					From: Out{
+						From: Start{},
+						Via:  Fixed{"follows"},
+					},
+					Via: Fixed{"follows"},
+				},
+			),
+			//			path:    StartPath(qs, "charlie").Follow(StartMorphism().Out("follows").Out("follows")),
+			expect: []string{"bob", "fred", "greg"},
+		},
+		//		{ // TODO: reverse
+		//			message: "followR",
+		//			path:    StartPath(qs, "fred").FollowReverse(StartMorphism().Out("follows").Out("follows")),
+		//			expect:  []string{"alice", "charlie", "dani"},
+		//		},
+		{
+			message: "is, tag, instead of FollowR",
+			path: IntersectNodes{
+				Follow(
+					Tag{
+						Nodes: AllNodes{},
+						Tags:  []string{"first"},
+					},
+					Out{
+						From: Out{
+							From: Start{},
+							Via:  Fixed{"follows"},
+						},
+						Via: Fixed{"follows"},
+					},
+				),
+				Fixed{"fred"},
+			},
+			//			path:    StartPath(qs).Tag("first").Follow(StartMorphism().Out("follows").Out("follows")).Is("fred"),
+			expect: []string{"alice", "charlie", "dani"},
+			tag:    "first",
+		},
+		{
+			message: "use Except to filter out a single vertex",
+			path: Except{
+				From:  Fixed{"alice", "bob"},
+				Nodes: Fixed{"alice"},
+			},
+			//			path:    StartPath(qs, "alice", "bob").Except(StartPath(qs, "alice")),
+			expect: []string{"bob"},
+		},
+		{
+			message: "use chained Except",
+			path: Except{
+				From: Except{
+					From:  Fixed{"alice", "bob", "charlie"},
+					Nodes: Fixed{"bob"},
+				},
+				Nodes: Fixed{"alice"},
+			},
+			//			path:    StartPath(qs, "alice", "bob", "charlie").Except(StartPath(qs, "bob")).Except(StartPath(qs, "alice")),
+			expect: []string{"charlie"},
+		},
+		//		{
+		//			message: "show a simple save",
+		//			path:    StartPath(qs).Save("status", "somecool"),
+		//			tag:     "somecool",
+		//			expect:  []string{"cool_person", "cool_person", "cool_person", "smart_person", "smart_person"},
+		//		},
+		//		{
+		//			message: "show a simple saveR",
+		//			path:    StartPath(qs, "cool_person").SaveReverse("status", "who"),
+		//			tag:     "who",
+		//			expect:  []string{"greg", "dani", "bob"},
+		//		},
+		//		{
+		//			message: "show a simple Has",
+		//			path:    StartPath(qs).Has("status", "cool_person"),
+		//			expect:  []string{"greg", "dani", "bob"},
+		//		},
+		//		{
+		//			message: "show a double Has",
+		//			path:    StartPath(qs).Has("status", "cool_person").Has("follows", "fred"),
+		//			expect:  []string{"bob"},
+		//		},
+		//		{
+		//			message: "use .Tag()-.Is()-.Back()",
+		//			path:    StartPath(qs, "bob").In("follows").Tag("foo").Out("status").Is("cool_person").Back("foo"),
+		//			expect:  []string{"dani"},
+		//		},
+		//		{
+		//			message: "do multiple .Back()s",
+		//			path:    StartPath(qs, "emily").Out("follows").Tag("f").Out("follows").Out("status").Is("cool_person").Back("f").In("follows").In("follows").Tag("acd").Out("status").Is("cool_person").Back("f"),
+		//			tag:     "acd",
+		//			expect:  []string{"dani"},
+		//		},
+		//		{
+		//			message: "InPredicates()",
+		//			path:    StartPath(qs, "bob").InPredicates(),
+		//			expect:  []string{"follows"},
+		//		},
+		//		{
+		//			message: "OutPredicates()",
+		//			path:    StartPath(qs, "bob").OutPredicates(),
+		//			expect:  []string{"follows", "status"},
+		//		},
+		// Morphism tests
+		{
+			message: "show simple morphism",
+			path:    Follow(Fixed{"charlie"}, grandfollowsPath),
+			//			path:    StartPath(qs, "charlie").Follow(grandfollows),
+			expect: []string{"greg", "fred", "bob"},
+		},
+		//		{
+		//			message: "show reverse morphism",
+		//			path:    StartPath(qs, "fred").FollowReverse(grandfollows),
+		//			expect:  []string{"alice", "charlie", "dani"},
+		//		},
+		//		// Context tests
+		//		{
+		//			message: "query without label limitation",
+		//			path:    StartPath(qs, "greg").Out("status"),
+		//			expect:  []string{"smart_person", "cool_person"},
+		//		},
+		//		{
+		//			message: "query with label limitation",
+		//			path:    StartPath(qs, "greg").LabelContext("smart_graph").Out("status"),
+		//			expect:  []string{"smart_person"},
+		//		},
+		//		{
+		//			message: "reverse context",
+		//			path:    StartPath(qs, "greg").Tag("base").LabelContext("smart_graph").Out("status").Tag("status").Back("base"),
+		//			expect:  []string{"greg"},
+		//		},
+	}
+}
+
+func TestMorphisms(t testing.TB, fnc func() graph.QuadStore) {
+	qs := makeTestStore(t, fnc)
+	for _, test := range testSet(qs) {
+		t.Log(test.message)
+		var got []string
+		if test.tag == "" {
+			got = runTopLevel(qs, test.path)
+		} else {
+			got = runTag(qs, test.path, test.tag)
+		}
+		sort.Strings(got)
+		sort.Strings(test.expect)
+		if !reflect.DeepEqual(got, test.expect) {
+			t.Errorf("Failed to %s, got: %v expected: %v", test.message, got, test.expect)
+		}
+	}
+}

--- a/graph/path2/pathtest/pathtest.go
+++ b/graph/path2/pathtest/pathtest.go
@@ -238,18 +238,29 @@ func testSet(qs graph.QuadStore) []test {
 			//			path:    StartPath(qs, "alice", "bob", "charlie").Except(StartPath(qs, "bob")).Except(StartPath(qs, "alice")),
 			expect: []string{"charlie"},
 		},
-		//		{
-		//			message: "show a simple save",
-		//			path:    StartPath(qs).Save("status", "somecool"),
-		//			tag:     "somecool",
-		//			expect:  []string{"cool_person", "cool_person", "cool_person", "smart_person", "smart_person"},
-		//		},
-		//		{
-		//			message: "show a simple saveR",
-		//			path:    StartPath(qs, "cool_person").SaveReverse("status", "who"),
-		//			tag:     "who",
-		//			expect:  []string{"greg", "dani", "bob"},
-		//		},
+		{
+			message: "show a simple save",
+			path: Save{
+				From: AllNodes{},
+				Via:  Fixed{"status"},
+				Tags: []string{"somecool"},
+			},
+			//				path:    StartPath(qs).Save("status", "somecool"),
+			tag:    "somecool",
+			expect: []string{"cool_person", "cool_person", "cool_person", "smart_person", "smart_person"},
+		},
+		{
+			message: "show a simple saveR",
+			path: Save{
+				From: Fixed{"cool_person"},
+				Via:  Fixed{"status"},
+				Tags: []string{"who"},
+				Rev:  true,
+			},
+			//				path:    StartPath(qs, "cool_person").SaveReverse("status", "who"),
+			tag:    "who",
+			expect: []string{"greg", "dani", "bob"},
+		},
 		{
 			message: "show a simple Has",
 			path: Has{

--- a/graph/path2/pathtest/pathtest.go
+++ b/graph/path2/pathtest/pathtest.go
@@ -250,16 +250,30 @@ func testSet(qs graph.QuadStore) []test {
 		//			tag:     "who",
 		//			expect:  []string{"greg", "dani", "bob"},
 		//		},
-		//		{
-		//			message: "show a simple Has",
-		//			path:    StartPath(qs).Has("status", "cool_person"),
-		//			expect:  []string{"greg", "dani", "bob"},
-		//		},
-		//		{
-		//			message: "show a double Has",
-		//			path:    StartPath(qs).Has("status", "cool_person").Has("follows", "fred"),
-		//			expect:  []string{"bob"},
-		//		},
+		{
+			message: "show a simple Has",
+			path: Has{
+				From:  AllNodes{},
+				Via:   Fixed{"status"},
+				Nodes: Fixed{"cool_person"},
+			},
+			//				path:    StartPath(qs).Has("status", "cool_person"),
+			expect: []string{"greg", "dani", "bob"},
+		},
+		{
+			message: "show a double Has",
+			path: Has{
+				From: Has{
+					From:  AllNodes{},
+					Via:   Fixed{"status"},
+					Nodes: Fixed{"cool_person"},
+				},
+				Via:   Fixed{"follows"},
+				Nodes: Fixed{"fred"},
+			},
+			//				path:    StartPath(qs).Has("status", "cool_person").Has("follows", "fred"),
+			expect: []string{"bob"},
+		},
 		//		{
 		//			message: "use .Tag()-.Is()-.Back()",
 		//			path:    StartPath(qs, "bob").In("follows").Tag("foo").Out("status").Is("cool_person").Back("foo"),
@@ -271,16 +285,23 @@ func testSet(qs graph.QuadStore) []test {
 		//			tag:     "acd",
 		//			expect:  []string{"dani"},
 		//		},
-		//		{
-		//			message: "InPredicates()",
-		//			path:    StartPath(qs, "bob").InPredicates(),
-		//			expect:  []string{"follows"},
-		//		},
-		//		{
-		//			message: "OutPredicates()",
-		//			path:    StartPath(qs, "bob").OutPredicates(),
-		//			expect:  []string{"follows", "status"},
-		//		},
+		{
+			message: "InPredicates()",
+			path: Predicates{
+				From: Fixed{"bob"},
+				Rev:  true,
+			},
+			//				path:    StartPath(qs, "bob").InPredicates(),
+			expect: []string{"follows"},
+		},
+		{
+			message: "OutPredicates()",
+			path: Predicates{
+				From: Fixed{"bob"},
+			},
+			//				path:    StartPath(qs, "bob").OutPredicates(),
+			expect: []string{"follows", "status"},
+		},
 		// Morphism tests
 		{
 			message: "show simple morphism",
@@ -294,11 +315,15 @@ func testSet(qs graph.QuadStore) []test {
 		//			expect:  []string{"alice", "charlie", "dani"},
 		//		},
 		//		// Context tests
-		//		{
-		//			message: "query without label limitation",
-		//			path:    StartPath(qs, "greg").Out("status"),
-		//			expect:  []string{"smart_person", "cool_person"},
-		//		},
+		{
+			message: "query without label limitation",
+			path: Out{
+				From: Fixed{"greg"},
+				Via:  Fixed{"status"},
+			},
+			//				path:    StartPath(qs, "greg").Out("status"),
+			expect: []string{"smart_person", "cool_person"},
+		},
 		//		{
 		//			message: "query with label limitation",
 		//			path:    StartPath(qs, "greg").LabelContext("smart_graph").Out("status"),

--- a/graph/path2/pathtest/pathtest.go
+++ b/graph/path2/pathtest/pathtest.go
@@ -375,7 +375,7 @@ func testSet(qs graph.QuadStore) []test {
 				Via:    Fixed{"status"},
 				Labels: Fixed{"smart_graph"},
 			},
-			//		pathc:    StartPath(qs, "greg").LabelContext("smart_graph").Out("status"),
+			pathc:  StartPath(qs, "greg").LabelContext("smart_graph").Out("status"),
 			expect: []string{"smart_person"},
 		},
 		//		{

--- a/graph/path2/pathtest/pathtest.go
+++ b/graph/path2/pathtest/pathtest.go
@@ -281,6 +281,18 @@ func testSet(qs graph.QuadStore) []test {
 			expect: []string{"cool_person", "cool_person", "cool_person", "smart_person", "smart_person"},
 		},
 		{
+			message: "show a simple saveOpt",
+			path: Save{
+				From: AllNodes{},
+				Via:  Fixed{"status"},
+				Tags: []string{"somecool"},
+				Opt:  true,
+			},
+			pathc:  StartPath(qs).SaveOptional("status", "somecool"),
+			tag:    "somecool",
+			expect: []string{"", "", "", "", "", "", "", "", "", "", "cool_person", "cool_person", "cool_person", "smart_person", "smart_person"},
+		},
+		{
 			message: "show a simple saveR",
 			path: Save{
 				From: Fixed{"cool_person"},
@@ -406,10 +418,10 @@ func TestMorphisms(t testing.TB, fnc func() graph.QuadStore) {
 		sort.Strings(gotc)
 		sort.Strings(test.expect)
 		if !reflect.DeepEqual(got, test.expect) {
-			t.Errorf("Failed to %s, got: %v expected: %v", test.message, got, test.expect)
+			t.Errorf("Failed to %s, got: %v (%d) expected: %v (%d)", test.message, got, len(got), test.expect, len(test.expect))
 		}
 		if test.pathc != nil && !reflect.DeepEqual(gotc, test.expect) {
-			t.Errorf("Failed to %s (compat), got: %v expected: %v", test.message, gotc, test.expect)
+			t.Errorf("Failed to %s (compat), got: %v (%d) expected: %v (%d)", test.message, gotc, len(gotc), test.expect, len(test.expect))
 		}
 	}
 }

--- a/graph/sql/all_iterator.go
+++ b/graph/sql/all_iterator.go
@@ -58,7 +58,7 @@ func (it *AllIterator) makeCursor() {
 				UNION
 				SELECT object FROM quads
 				UNION
-				SELECT label FROM quads
+				SELECT label FROM quads WHERE label <> ''
 			) AS DistinctNodes (node) WHERE node IS NOT NULL;`)
 		if err != nil {
 			glog.Errorln("Couldn't get cursor from SQL database: %v", err)

--- a/graph/sql/sql_test.go
+++ b/graph/sql/sql_test.go
@@ -1,0 +1,77 @@
+package sql
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/graph/path2/pathtest"
+	"github.com/lib/pq"
+	"testing"
+	"time"
+)
+
+func runPostgres(t testing.TB) (string, func()) {
+	cl, err := docker.NewClient("unix:///var/run/docker.sock")
+	if err != nil {
+		t.Skip(err)
+	}
+	cont, err := cl.CreateContainer(docker.CreateContainerOptions{
+		Config: &docker.Config{
+			OpenStdin: true, Tty: true,
+			Image: `postgres:9`,
+			Env: []string{
+				`POSTGRES_PASSWORD=postgres`,
+			},
+		},
+		HostConfig: &docker.HostConfig{},
+	})
+	if err != nil {
+		t.Skip(err)
+	}
+
+	closer := func() {
+		cl.RemoveContainer(docker.RemoveContainerOptions{ID: cont.ID, Force: true})
+	}
+
+	if err := cl.StartContainer(cont.ID, &docker.HostConfig{}); err != nil {
+		closer()
+		t.Skip(err)
+	}
+	info, err := cl.InspectContainer(cont.ID)
+	if err != nil {
+		closer()
+		t.Skip(err)
+	}
+
+	ip := info.NetworkSettings.IPAddress
+	ok := false
+	for i := 0; i < 5; i++ {
+		conn, err := pq.Open(`postgres://postgres:postgres@` + ip + `/postgres?sslmode=disable`)
+		if err == nil {
+			conn.Close()
+			ok = true
+		} else {
+			time.Sleep(time.Second * 2)
+		}
+	}
+	if !ok {
+		t.Fatal("Container port is still closed.")
+	}
+	return ip, closer
+}
+
+func makeStore(t testing.TB) (graph.QuadStore, func()) {
+	ip, closer := runPostgres(t)
+	addr := `postgres://postgres:postgres@` + ip + `/postgres?sslmode=disable`
+	if err := createSQLTables(addr, nil); err != nil {
+		t.Fatal("Failed to create Postgres database:", err)
+	}
+	qs, err := newQuadStore(addr, nil)
+	if err != nil {
+		t.Fatal("Failed to create Postgres database:", err)
+	}
+	return qs, closer
+}
+
+func TestMorphisms(t *testing.T) {
+	pathtest.TestMorphisms(t, makeStore)
+}


### PR DESCRIPTION
## Preface

_(I may update header from time to time to reflect changes in the code)_

For now path lib is only used as a wrapper around iterators, but I think it deserves a separate handling mechanism. This PR proposes a concrete types for path elements (morphisms). Some pros of the change:
- Most of the time we don't need to optimize iterators shape - we can optimize paths shape instead and then spawn already-optimized iterators from them.
- Paths can be reused. Thus, user can optimize most-used query once and use it faster.
- Paths are state-less. We can define a serialization mechanism (protobuf?) which will allow to construct queries separately (client-side), and then pass resulting path to the server. This can lead to more extensible query layer.
- As an additional optimization, we can "bind" path to a specific quad store. For example, SQL implementation may replace some path elements with a plain-text SQL queries (or at least fast iterator generators). Each iterator, produced from such path will be already optimized for a given quad store.
- Keeping in mind two previous statements, we can define a function to convert iterators back to paths, so they can be serialized again. Then we can pass serialized queries back to client as pagination tokens (each iterator implementation will insert "Skip" path element if it was already iterated to some extent).
- Concrete types can be processed with reflection allowing operations like "find all Placeholder paths in this tree and replace them with ...".
- Optimization code is easier and allows to use high-level constructs.
## Implementation

For now, code is located in a separate folder `graph/path2` for evaluation purposes. It preserve compatibility with current path lib implementation, but misses a "Back" feature (will be implemented soon). It may also miss some optimizations.
### Path interfaces

Path interface is pretty generic:

``` Go
type PathObj interface{
    BuildIterator() graph.Iterator
}
```

For type-safety reasons it was split into two sub-interfaces:

``` Go
type Nodes interface {
    PathObj
    Optimize() (Nodes, bool)
    // ...
}
type Links interface {
    PathObj
    Optimize() (Links, bool)
    // ...
}
```

With this approach, path types cannot be mixed, making it a compilation error. One may complain about code duplication, but most of existing iterators falls into Nodes category, so the cost of such decision is minimal.
### Abstract paths

Some path elements are "abstract" - they cannot generate iterators without a concrete quad store (AllNodes, AllLinks for example). There is a optional interface for such types:

``` Go
type NodesAbstract interface {
    BindTo(qs graph.QuadStore) Nodes
}
type LinksAbstract interface {
    BindTo(qs graph.QuadStore) Links
}
```

Those path elements should be replaced with a concrete variant by quad store or by replacing function. Without it, they may panic on iterator generation.

**Current list of abstract paths:**
- AllNodes
- AllLinks
- NotNodes (for optimization purposes)
- Fixed (should be converted into graph.Value by QS)
- HasA (not abstract, but constructor requires QS to call Contains)
- LinksTo (same reason)
### Basic paths

These are converted from original Cayley iterators, thus they have implementation independent from a particular quad store. Most of them are one-liners: call iterator constructor. Some examples:

``` Go
type Tag struct{
    Nodes Nodes
    Tags []string
}

type IntersectNodes []Nodes

type Unique struct {
    Nodes Nodes
}
```
### High-level paths

These are converted from current path lib. The idea here is to preserve a high-level view on path to allow easier optimization code, but still having a low-level fallback variant. Such paths can implement an optional interface:

``` Go
type NodesSimplifier interface {
    Simplify() Nodes
}
// Same duplicated for Links
```

"Simplify" function tells path element to build an analog of itself in terms of basic path elements. This mechanism is also used as a second pass of optimization: firstly let high-level iterator to apply some optimization and if it fails, simplify path to a tree of basic paths and try to optimize it again. Full optimization pass is described below.

**High-level path example:**

``` Go
type Predicates struct {
    From Nodes
    Rev   bool
}
func (p Predicates) Simplify() Nodes {
    dir := quad.Subject
    if p.Rev {
        dir = quad.Object
    }
    return Unique{
        Nodes: HasA{
            Links: LinksTo{
                Nodes: p.From,
                Dir:   dir,
            },
            Dir: quad.Predicate,
        },
    }
}
```
### Replacers

An ability to replace some path elements in tree is important for easy manipulation, thus a Replace method is required for paths:

``` Go
type NodesWrapper func(Nodes) Nodes
type Nodes interface {
    // ...
    Replace(NodesWrapper, LinksWrapper) Nodes
}
// The same is duplicated for Links
```

Method tells a path to generate a clone of itself, applying wrapper functions for sub-paths with appropriate types.
**TBD:** We can make a generic reflect-based replacer instead of forcing implementation of Replace function for every path type.

This replacement mechanism allows to replace Abstract paths with a concrete implementations, allows to use pure morphisms (paths without a start, that can be followed from any other path point), simplifies high-level path elements that was not optimized by QS and much more.
### Optimization steps

**1) Pure path optimization**
This step calls Optimize method for each path element. Paths can be moved around, merged or disappear, but abstract and high-level paths will preserve their own type. Example: optimize ordering and merge "Fixed" nodes in "Intersect" ("And") path element.

**2) QS optimization**
Step lets quad store to optimize path. It will try to optimize high-level paths first and if it fails, path will be simplified, optimized according to step 1 and QS will retry optimization. Example: QS may optimize "Out" path at once, or simplify it and optimize all "LinksTo" in there.

**3) Bind path to QS**
The last step, which involves replacing abstract path elements with iterator constructor for a given QS, allowing to call BuildIterator for the whole tree.
### End notes

Any feedback is welcomed. I will greatly appreciate any help on concrete path types for SQL implementation and path optimizations in general.

More tests and benchmarks will appear soon.
As a raw result: my benchmark showed 20% speedup on memstore in "the helpless checker" integration test. But it may be related to some other cause, which I might be not aware of.

PR also includes few unrelated things, which were included to fix a specific bug or for convenience:
- Fix for Unique iterator for LevelDB/Bolt (https://github.com/google/cayley/commit/0158b23da11f688c85a8ed796ea67c5b61847019, the same as https://github.com/google/cayley/pull/320)
- Fix Postgres enumerating empty quad label in AllNodes iterator (https://github.com/google/cayley/commit/c1ff6ac7a866c27103c021ef3e61e42a62871532)
- Some code to bring up a fresh Mongo/Postgres in Docker for tests (will be skipped if it's not installed) (https://github.com/google/cayley/commit/b2523d17fa28b194a420365687f5e4f5db77ccd1 and https://github.com/google/cayley/commit/a2a3e136384a5039481e767239dcd680d38572fe)
#### TODOs:
- [ ] Concrete path types for SQL backend.
- [ ] Docs on path types.
- [ ] More tests.
- [ ] Benchmarks.
- [ ] Define a cost mechanism for paths (if possible).
- [ ] Port other optimizations.
- [ ] Implement Back mechanism for compatibility layer.
- [ ] Resolve reflect-vs-interface question for Replacer.
