### PR TITLE
Added sync.RWMutex to mongo cache to prevent: fatal error 

### DIFF
--- a/graph/mongo/lru.go
+++ b/graph/mongo/lru.go
@@ -46,14 +46,14 @@ func (lru *cache) Put(key string, value interface{}) {
 	if _, ok := lru.Get(key); ok {
 		return
 	}
+
+	lru.Lock()
+	defer lru.Unlock()
 	if len(lru.cache) == lru.maxSize {
 		lru.removeOldest()
 	}
-
 	lru.priority.PushFront(kv{key: key, value: value})
-	lru.Lock()
 	lru.cache[key] = lru.priority.Front()
-	lru.Unlock()
 }
 
 func (lru *cache) Get(key string) (interface{}, bool) {
@@ -68,8 +68,6 @@ func (lru *cache) Get(key string) (interface{}, bool) {
 }
 
 func (lru *cache) removeOldest() {
-	lru.Lock()
-	defer lru.Unlock()
 	last := lru.priority.Remove(lru.priority.Back())
 	delete(lru.cache, last.(kv).key)
 

--- a/graph/mongo/lru_test.go
+++ b/graph/mongo/lru_test.go
@@ -1,0 +1,41 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongo
+
+import (
+	"fmt"
+	"testing"
+)
+
+// checks fatal error: concurrent map read and map write
+
+func TestPanicLRUCache(t *testing.T) {
+	xch := make(chan int)
+	c := newCache(1024)
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			key := fmt.Sprintf("Key%d", i)
+			c.Put(key, i)
+			c.Get(key)
+			xch <- i
+
+		}(i)
+
+	}
+	for i := 0; i < 100; i++ {
+		<-xch
+	}
+
+}


### PR DESCRIPTION
Added RWMutex on mongo cache to prevent Fatal Error: concurrent map read and map write on Go >= 1.6.

And a test that throws a panic with current code and go >= 1.6

```
fatal error: concurrent map read and map write

goroutine 11 [running]:
runtime.throw(0x374e80, 0x21)
        /usr/local/go/src/runtime/panic.go:530 +0x90 fp=0xc8200d6d88 sp=0xc8200d6d70
runtime.mapaccess2_faststr(0x254800, 0xc820016780, 0xc8200cc010, 0x4, 0x49e728, 0x4)
	/usr/local/go/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc8200d6de8 sp=0xc8200d6d88
github.com/drzippie/cayley/graph/mongo.(*cache).Get(0xc820012320, 0xc8200cc010, 0x4, 0x0, 0x0, 0xf4909)
	/Users/drzippie/go/src/github.com/drzippie/cayley/graph/mongo/lru.go:55 +0x67 fp=0xc8200d6e58 sp=0xc8200d6de8

github.com/drzippie/cayley/graph/mongo.(*cache).Put(0xc820012320, 0xc8200cc010, 0x4, 0x253e00, 0xc8200cc018)
	/Users/drzippie/go/src/github.com/drzippie/cayley/graph/mongo/lru.go:44 +0x4a fp=0xc8200d6f08 sp=0xc8200d6e58
[...]
```

(CLA Signed)