### PR TITLE
graph/sql: add support for cockroachdb

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -124,6 +124,16 @@ Optionally disable syncing to disk per transaction. Nosync being true means much
 
 The name of the database within MongoDB to connect to. Manages its own collections and indices therein.
 
+### SQL
+
+#### **`db_sql_flavor`**
+
+  * Type: String
+  * Default: "postgres"
+
+The SQL flavor to use with the sql driver. Can be "postgres" or "cockroach".
+
+
 ## Per-Replication Options
 
 The `replication_options` object in the main configuration file contains any of these following options that change the behavior of the replication manager.

--- a/graph/sql/quadstore_test.go
+++ b/graph/sql/quadstore_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/google/cayley/graph"
+)
+
+func TestGetSQLFlavor(t *testing.T) {
+	testData := []struct {
+		flavor      string
+		expected    sqlFlavor
+		expectError bool
+	}{
+		{"postgres", postgres, false},
+		{"cockroach", cockroach, false},
+		{"nosql", "", true},
+		{"", postgres, false},
+	}
+
+	for _, td := range testData {
+		opts := make(graph.Options)
+		if len(td.flavor) > 0 {
+			opts["db_sql_flavor"] = td.flavor
+		}
+		f, err := getSQLFlavor(opts)
+		if err != nil && !td.expectError {
+			t.Error(err)
+		} else if err == nil && td.expectError {
+			t.Errorf("getSQLFlavor(%v) expected error", td.flavor)
+		} else if td.expected != f {
+			t.Errorf("getSQLFlavor(%v) = %v; not %v", td.flavor, f, td.expected)
+		}
+	}
+}


### PR DESCRIPTION
This fleshes out the multiple SQL flavor support in the graph/sql package. It
adds an `db_sql_flavor` option that can either be `postgres` (default) or
`cockroach`.

This also implements opts.IgnoreDup for postgres and cockroach.

The cockroach SQL dialect specific changes:
- Not using `WITH (FILLFACTOR = %d)` for indexes as it's not supported.
- Not using `pq.CopyIn` as `COPY <table> (<columns, ...) FROM STDIN` isn't
  supported yet.
- Retrying inserts when the "restart transaction" error is returned.
  https://www.cockroachlabs.com/docs/transactions.html#transaction-retries
#### Example config file using cockroach

``` json
{
  "database": "sql",
  "db_path": "postgres://root@localhost:26257/quads?sslmode=disable",
  "db_options": {
    "db_sql_flavor": "cockroach"
  },
  "read_only": false
}
```
#### Other Notes

It seems like that using a high load size when bulk inserting has a tendency to cause connection timeouts when inserting with cockroachdb. That may just because I'm running a multinode cluster on my resource limited laptop. Lowering it to 1000 seems to fix it.

``` bash
cayley load --config="cayley.json" --quads=data/30kmoviedata.nq.gz --load_size=1000
```
