### PR TITLE
Use standard golang/glog instead of a fork

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -10,8 +10,8 @@
 			"Rev": "9e5f7f4d07ca576562618c23e8abadda278b684f"
 		},
 		{
-			"ImportPath": "github.com/barakmich/glog",
-			"Rev": "fafcb6128a8a2e6360ff034091434d547397d54a"
+			"ImportPath": "github.com/golang/glog",
+			"Rev": "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 		},
 		{
 			"ImportPath": "github.com/boltdb/bolt",

--- a/appengine/appengine.go
+++ b/appengine/appengine.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/internal/config"
 	"github.com/google/cayley/internal/db"

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -24,7 +24,7 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/internal"

--- a/cmd/cayleyupgrade/cayleyupgrade.go
+++ b/cmd/cayleyupgrade/cayleyupgrade.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/internal/config"
 

--- a/graph/bolt/all_iterator.go
+++ b/graph/bolt/all_iterator.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/boltdb/bolt"
 
 	"github.com/google/cayley/graph"

--- a/graph/bolt/iterator.go
+++ b/graph/bolt/iterator.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/boltdb/bolt"
 
 	"github.com/google/cayley/graph"

--- a/graph/bolt/migrate.go
+++ b/graph/bolt/migrate.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/boltdb/bolt"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/proto"

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -23,7 +23,7 @@ import (
 	"hash"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/boltdb/bolt"
 
 	"github.com/google/cayley/graph"

--- a/graph/gaedatastore/iterator.go
+++ b/graph/gaedatastore/iterator.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/cayley/quad"
 
 	"appengine/datastore"
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 )
 
 type Iterator struct {

--- a/graph/gaedatastore/quadstore.go
+++ b/graph/gaedatastore/quadstore.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"appengine"
 	"appengine/datastore"

--- a/graph/gaedatastore/quadstore_test.go
+++ b/graph/gaedatastore/quadstore_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"errors"
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/quad"
 )
 

--- a/graph/iterator/and_iterator_optimize.go
+++ b/graph/iterator/and_iterator_optimize.go
@@ -17,7 +17,7 @@ package iterator
 import (
 	"sort"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 )

--- a/graph/iterator/hasa_iterator.go
+++ b/graph/iterator/hasa_iterator.go
@@ -34,7 +34,7 @@ package iterator
 // Alternatively, can be seen as the dual of the LinksTo iterator.
 
 import (
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/quad"

--- a/graph/iterator/materialize_iterator.go
+++ b/graph/iterator/materialize_iterator.go
@@ -17,7 +17,7 @@ package iterator
 // A simple iterator that, when first called Contains() or Next() upon, materializes the whole subiterator, stores it locally, and responds. Essentially a cache.
 
 import (
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 )

--- a/graph/leveldb/iterator.go
+++ b/graph/leveldb/iterator.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	ldbit "github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -24,7 +24,7 @@ import (
 	"hash"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -17,7 +17,7 @@ package mongo
 import (
 	"fmt"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"

--- a/graph/mongo/quadstore_iterator_optimize.go
+++ b/graph/mongo/quadstore_iterator_optimize.go
@@ -15,7 +15,7 @@
 package mongo
 
 import (
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"

--- a/graph/primarykey.go
+++ b/graph/primarykey.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/pborman/uuid"
 )
 

--- a/graph/sql/all_iterator.go
+++ b/graph/sql/all_iterator.go
@@ -17,7 +17,7 @@ package sql
 import (
 	"database/sql"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"

--- a/graph/sql/optimizers.go
+++ b/graph/sql/optimizers.go
@@ -17,7 +17,7 @@ package sql
 import (
 	"errors"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"

--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"

--- a/graph/sql/sql_iterator.go
+++ b/graph/sql/sql_iterator.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"
 	"github.com/google/cayley/quad"

--- a/graph/sql/sql_link_iterator.go
+++ b/graph/sql/sql_link_iterator.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/quad"
 )

--- a/graph/sql/sql_node_intersection.go
+++ b/graph/sql/sql_node_intersection.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/quad"
 )

--- a/graph/sql/sql_node_iterator.go
+++ b/graph/sql/sql_node_iterator.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/quad"
 )

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/internal/config"

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/google/cayley/graph"

--- a/internal/http/write.go
+++ b/internal/http/write.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/google/cayley/internal"

--- a/query/gremlin/build_iterator.go
+++ b/query/gremlin/build_iterator.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/robertkrimen/otto"
 
 	"github.com/google/cayley/graph"

--- a/query/gremlin/environ.go
+++ b/query/gremlin/environ.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/robertkrimen/otto"
 
 	"github.com/google/cayley/graph"

--- a/query/gremlin/finals.go
+++ b/query/gremlin/finals.go
@@ -17,7 +17,7 @@ package gremlin
 import (
 	"encoding/json"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/robertkrimen/otto"
 
 	"github.com/google/cayley/graph"

--- a/query/gremlin/traversals.go
+++ b/query/gremlin/traversals.go
@@ -17,7 +17,7 @@ package gremlin
 // Adds special traversal functions to JS Gremlin objects. Most of these just build the chain of objects, and won't often need the session.
 
 import (
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 	"github.com/robertkrimen/otto"
 )
 

--- a/query/mql/session.go
+++ b/query/mql/session.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/barakmich/glog"
+	"github.com/golang/glog"
 
 	"github.com/google/cayley/graph"
 	"github.com/google/cayley/graph/iterator"


### PR DESCRIPTION
Using a fork causes issues when embedding cayley due to duplicate global
flags between glog and the fork.  This causes applications which have
dependencies on glog natively, or through another dependency to be
unable to use cayley without manually modifing its imports.