### PR TITLE
Add Clone() to Path for easier reuse of Path segments

### DIFF
--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -98,6 +98,16 @@ func NewPath(qs graph.QuadStore) *Path {
 	}
 }
 
+// Clone returns a clone of the current path.
+func (p *Path) Clone() *Path {
+	stack := p.stack
+	return &Path{
+		stack:       stack[:len(stack):len(stack)],
+		qs:          p.qs,
+		baseContext: p.baseContext,
+	}
+}
+
 // Reverse returns a new Path that is the reverse of the current one.
 func (p *Path) Reverse() *Path {
 	newPath := NewPath(p.qs)


### PR DESCRIPTION
This allows for construction of sub-Paths, and then cloning to use them under multiple `And`s or `Or`s.