### PR TITLE
Fix Docker building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR /go/src/github.com/cayleygraph/cayley
 
 # Restore vendored dependencies
 RUN go get github.com/tools/godep
-ADD Godeps /go/src/github.com/cayleygraph/cayley/Godeps
+ADD Godeps ./Godeps
 RUN godep restore
 
 # Add and install cayley
 ADD . .
-RUN go install -v github.com/cayleygraph/cayley/cmd/cayley
+RUN go install -v ./cmd/cayley
 
 # Expose the port and volume for configuration and data persistence. If you're
 # using a backend like bolt, make sure the file is saved to this directory.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -68,6 +68,10 @@
 			"ImportPath": "gopkg.in/mgo.v2",
 			"Comment": "r2015.01.24",
 			"Rev": "c6a7dce14133ccac2dcac3793f1d6e2ef048503a"
+		},
+		{
+			"ImportPath": "golang.org/x/net/context",
+			"Rev": "6a513affb38dc9788b449d59ffed099b8de18fa0"
 		}
 	]
 }


### PR DESCRIPTION
We can see in https://quay.io/repository/cayleygraph/cayley that recent builds are failing.

I found out that there is a missing dependency, so this fix amounts to adding it to [Godeps/Godeps.json](https://github.com/cayleygraph/cayley/blob/master/Godeps/Godeps.json).

I also updated the Dockerfile to use relative imports, as this improves readability.