### PR TITLE
graph: fix Is*(err error) checkers to properly compare against *DeltaError

### DIFF
--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -91,7 +91,7 @@ func IsQuadExist(err error) bool {
 		return true
 	}
 	de, ok := err.(*DeltaError)
-	return ok && de == ErrQuadExists
+	return ok && de.Err == ErrQuadExists
 }
 
 // IsQuadNotExist returns whether an error is a DeltaError
@@ -101,7 +101,7 @@ func IsQuadNotExist(err error) bool {
 		return true
 	}
 	de, ok := err.(*DeltaError)
-	return ok && de == ErrQuadNotExist
+	return ok && de.Err == ErrQuadNotExist
 }
 
 // IsInvalidAction returns whether an error is a DeltaError
@@ -111,7 +111,7 @@ func IsInvalidAction(err error) bool {
 		return true
 	}
 	de, ok := err.(*DeltaError)
-	return ok && de == ErrInvalidAction
+	return ok && de.Err == ErrInvalidAction
 }
 
 var (

--- a/graph/quadwriter_test.go
+++ b/graph/quadwriter_test.go
@@ -1,0 +1,63 @@
+package graph
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsQuadExist(t *testing.T) {
+	tests := []struct {
+		Err     error
+		Matches bool
+	}{
+		{Err: nil, Matches: false},
+		{Err: errors.New("foo"), Matches: false},
+		{Err: ErrQuadExists, Matches: true},
+		{Err: &DeltaError{Err: errors.New("foo")}, Matches: false},
+		{Err: &DeltaError{Err: ErrQuadExists}, Matches: true},
+	}
+
+	for i, test := range tests {
+		if match := IsQuadExist(test.Err); test.Matches != match {
+			t.Errorf("%d> unexpected match: %t", i, match)
+		}
+	}
+}
+
+func TestIsQuadNotExist(t *testing.T) {
+	tests := []struct {
+		Err     error
+		Matches bool
+	}{
+		{Err: nil, Matches: false},
+		{Err: errors.New("foo"), Matches: false},
+		{Err: ErrQuadNotExist, Matches: true},
+		{Err: &DeltaError{Err: errors.New("foo")}, Matches: false},
+		{Err: &DeltaError{Err: ErrQuadNotExist}, Matches: true},
+	}
+
+	for i, test := range tests {
+		if match := IsQuadNotExist(test.Err); test.Matches != match {
+			t.Errorf("%d> unexpected match: %t", i, match)
+		}
+	}
+}
+
+func TestIsInvalidAction(t *testing.T) {
+	tests := []struct {
+		Err     error
+		Matches bool
+	}{
+		{Err: nil, Matches: false},
+		{Err: errors.New("foo"), Matches: false},
+		{Err: ErrInvalidAction, Matches: true},
+		{Err: &DeltaError{Err: errors.New("foo")}, Matches: false},
+		{Err: &DeltaError{Err: ErrInvalidAction}, Matches: true},
+	}
+
+	for i, test := range tests {
+		if match := IsInvalidAction(test.Err); test.Matches != match {
+			t.Errorf("%d> unexpected match: %t", i, match)
+		}
+	}
+}


### PR DESCRIPTION
The three error checkers in **graph** were missing the `.Err` for their final comparisons.