### PR TITLE
appengine: add build constraint

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,7 +1,7 @@
 application: cayley-test
 version: 1
 runtime: go
-api_version: go1.4.1
+api_version: go1.6.3
 
 handlers:
 - url: /.*

--- a/internal/db/repl.go
+++ b/internal/db/repl.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !appengine
+
 package db
 
 import (


### PR DESCRIPTION
internal/db/repl.go is not used by the appengine deployment, however the
file is included in the general build. This commit adds the necessary
exclusionary build tag for appengine, and updates app.yaml to the latest
go API (1.6.3) available on appengine.