### PR TITLE
appengine: updating dependency paths and adding documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ install:
 
   # Google App Engine dependencies
   - cd ..
-  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.23.zip
-  - unzip -q go_appengine_sdk_linux_amd64-1.9.23.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.40.zip
+  - unzip -q go_appengine_sdk_linux_amd64-1.9.40.zip
   - export PATH=$PATH:$PWD/go_appengine/
-  - $PWD/go_appengine/goapp get github.com/stretchr/testify/require github.com/pborman/uuid golang.org/x/net/context # FIXME
   - cd cayley
 
 script:

--- a/appengine/.gitignore
+++ b/appengine/.gitignore
@@ -1,0 +1,4 @@
+/appengine
+/docs
+/static
+/templates

--- a/appengine/README.md
+++ b/appengine/README.md
@@ -1,0 +1,59 @@
+# About appengine
+
+This directory contains a appengine deployable cayley graph instance.
+
+# Running/testing traditional appengine locally
+
+Install the latest appengine sdk, and ensure that your local version of go
+matches the same version obtained from `goapp`.
+
+Note: if you use a more recent version of Go locally, `goapp` get might
+accidentally copy the wrong files from the local `$GOPATH`.
+
+```sh
+$ cd $GOPATH/src/github.com/cayleygraph/cayley/appengine
+
+# check go version
+$ go version
+
+# check goapp version
+$ goapp version
+
+# install dependencies
+$ goapp get
+
+# ensure that goapp can build
+$ goapp build
+
+# test locally
+$ goapp serve
+```
+
+# Running/testing flexible appengine locally
+
+The latest appengine flexible environment can be tested instead of the
+traditional environment by doing the following:
+
+```sh
+# calls ./sync-assets.sh
+$ go generate
+
+$ goapp serve app.flexible.yaml
+```
+
+# Deploying to traditional appengine environment
+```sh
+$ goapp deploy -version 1 -application <MY_PROJECT_ID>
+```
+
+# Deploying to flexible appengine environment
+```sh
+# install aedeploy if not installed
+$ go get -u google.golang.org/appengine/cmd/aedeploy
+
+# calls ./sync-assets.sh
+$ go generate
+
+# deploy
+$ aedeploy gcloud app deploy app.flexible.yaml
+```

--- a/appengine/app.flexible.yaml
+++ b/appengine/app.flexible.yaml
@@ -1,0 +1,2 @@
+runtime: go
+vm: true

--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,7 +1,5 @@
-application: cayley-test
-version: 1
 runtime: go
-api_version: go1.6.3
+api_version: go1
 
 handlers:
 - url: /.*

--- a/appengine/appengine.go
+++ b/appengine/appengine.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build appengine
+// +build appengine appenginevm
 
 package main
 

--- a/appengine/main.go
+++ b/appengine/main.go
@@ -1,0 +1,10 @@
+// +build appenginevm
+package main
+
+//go:generate ./sync-assets.sh
+
+import "google.golang.org/appengine"
+
+func main() {
+	appengine.Main()
+}

--- a/appengine/sync-assets.sh
+++ b/appengine/sync-assets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+SRC="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+rsync -avP --delete $GOPATH/src/github.com/cayleygraph/cayley/{static,docs,templates} $SRC/

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b9452c276b5ad9ebb6fa81400b572fdaaee285039f34aefdb458bd754029031b
-updated: 2016-08-18T23:26:11.061439122+03:00
+hash: 80622f54e5ee6819770a6d90324f90b5fc75790d8311d1e39d12be1bb00cd95b
+updated: 2016-08-26T17:11:12.108578825+07:00
 imports:
 - name: github.com/badgerodon/peg
   version: 9e5f7f4d07ca576562618c23e8abadda278b684f
@@ -18,19 +18,19 @@ imports:
   - pkg/archive
   - pkg/fileutils
   - pkg/homedir
-  - pkg/stdcopy
   - pkg/idtools
   - pkg/ioutils
+  - pkg/longpath
   - pkg/pools
   - pkg/promise
+  - pkg/stdcopy
   - pkg/system
-  - pkg/longpath
 - name: github.com/docker/engine-api
   version: c9fd33c91008b9c558a6ed1cb11a68dbe4db0493
   subpackages:
-  - types/swarm
   - types/filters
   - types/mount
+  - types/swarm
   - types/versions
 - name: github.com/docker/go-units
   version: eb879ae3e2b84e2a142af415b679ddeda47ec71c
@@ -39,11 +39,15 @@ imports:
 - name: github.com/gogo/protobuf
   version: ff05bbbb0ff143cc11fc3f8b700fc3a2864b884d
   subpackages:
-  - proto
   - gogoproto
+  - proto
   - protoc-gen-gogo/descriptor
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+- name: github.com/golang/protobuf
+  version: 888eb0692c857ec880338addf316bd662d5e630e
+  subpackages:
+  - proto
 - name: github.com/hashicorp/go-cleanhttp
   version: ad28ea4487f05916463e2423a55166280e8254b5
 - name: github.com/julienschmidt/httprouter
@@ -68,13 +72,13 @@ imports:
 - name: github.com/robertkrimen/otto
   version: d1b4d8ef0e0e4b088c8328c95ca63ab9ebd8fc9d
   subpackages:
-  - underscore
   - ast
   - dbg
   - file
   - parser
   - registry
   - token
+  - underscore
 - name: github.com/russross/blackfriday
   version: 17bb7999de6cfb791d4f8986cc00b3309b370cdb
 - name: github.com/shurcooL/sanitized_anchor_name
@@ -90,17 +94,17 @@ imports:
   version: 4875955338b0a434238a31165cb87255ab6e9e4a
   subpackages:
   - leveldb
-  - leveldb/iterator
-  - leveldb/opt
-  - leveldb/util
   - leveldb/cache
   - leveldb/comparer
   - leveldb/errors
   - leveldb/filter
+  - leveldb/iterator
   - leveldb/journal
   - leveldb/memdb
+  - leveldb/opt
   - leveldb/storage
   - leveldb/table
+  - leveldb/util
 - name: github.com/syndtr/gosnappy
   version: 156a073208e131d7d2e212cb749feae7c339e846
   subpackages:
@@ -114,6 +118,20 @@ imports:
   version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
   subpackages:
   - unix
+- name: google.golang.org/appengine
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
+  subpackages:
+  - aetest
+  - datastore
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/user
+  - user
 - name: gopkg.in/mgo.v2
   version: c6a7dce14133ccac2dcac3793f1d6e2ef048503a
   subpackages:

--- a/graph/gaedatastore/iterator.go
+++ b/graph/gaedatastore/iterator.go
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build appengine
-
 package gaedatastore
 
 import (
 	"fmt"
+
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/quad"
 
-	"appengine/datastore"
 	"github.com/cayleygraph/cayley/clog"
+	"google.golang.org/appengine/datastore"
 )
 
 type Iterator struct {

--- a/graph/gaedatastore/quadstore.go
+++ b/graph/gaedatastore/quadstore.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build appengine
-
 package gaedatastore
 
 import (
@@ -24,8 +22,9 @@ import (
 
 	"github.com/cayleygraph/cayley/clog"
 
-	"appengine"
-	"appengine/datastore"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
@@ -44,7 +43,7 @@ var (
 )
 
 type QuadStore struct {
-	context appengine.Context
+	context context.Context
 }
 
 type MetadataEntry struct {
@@ -156,7 +155,7 @@ func (qs *QuadStore) checkValid(k *datastore.Key) (bool, error) {
 	return true, nil
 }
 
-func getContext(opts graph.Options) (appengine.Context, error) {
+func getContext(opts graph.Options) (context.Context, error) {
 	req := opts["HTTPRequest"].(*http.Request)
 	if req == nil {
 		err := errors.New("HTTP Request needed")
@@ -270,7 +269,7 @@ func (qs *QuadStore) updateNodes(in []graph.Delta) (int64, error) {
 	for i := 0; i < len(nodeDeltas); i += 5 {
 		j := int(math.Min(float64(len(nodeDeltas)-i), 5))
 		foundNodes := make([]NodeEntry, j)
-		err := datastore.RunInTransaction(qs.context, func(c appengine.Context) error {
+		err := datastore.RunInTransaction(qs.context, func(c context.Context) error {
 			err := datastore.GetMulti(c, keys[i:i+j], foundNodes)
 			// Sift through for errors
 			if me, ok := err.(appengine.MultiError); ok {
@@ -308,7 +307,7 @@ func (qs *QuadStore) updateQuads(in []graph.Delta) (int64, error) {
 	for i := 0; i < len(in); i += 5 {
 		// Find the closest batch of 5
 		j := int(math.Min(float64(len(in)-i), 5))
-		err := datastore.RunInTransaction(qs.context, func(c appengine.Context) error {
+		err := datastore.RunInTransaction(qs.context, func(c context.Context) error {
 			foundQuads := make([]QuadEntry, j)
 			// We don't process errors from GetMulti as they don't mean anything,
 			// we've handled existing quad conflicts above and we overwrite everything again anyways
@@ -343,7 +342,7 @@ func (qs *QuadStore) updateQuads(in []graph.Delta) (int64, error) {
 func (qs *QuadStore) updateMetadata(quadsAdded int64, nodesAdded int64) error {
 	key := qs.createKeyForMetadata()
 	foundMetadata := new(MetadataEntry)
-	err := datastore.RunInTransaction(qs.context, func(c appengine.Context) error {
+	err := datastore.RunInTransaction(qs.context, func(c context.Context) error {
 		err := datastore.Get(c, key, foundMetadata)
 		if err != nil && err != datastore.ErrNoSuchEntity {
 			clog.Errorf("Error: %v", err)

--- a/graph/gaedatastore/quadstore_test.go
+++ b/graph/gaedatastore/quadstore_test.go
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build appengine
 
 package gaedatastore
 
@@ -24,7 +23,7 @@ import (
 	"github.com/cayleygraph/cayley/writer"
 	"github.com/stretchr/testify/require"
 
-	"appengine/aetest"
+	"google.golang.org/appengine/aetest"
 )
 
 // This is a simple test graph.


### PR DESCRIPTION
Ran aefix against the gaedatastore and added some documentation to the
appengine folder along with an example for deploying to the traditional
and flexible environments.