### PR TITLE
Clone receiver paths

### DIFF
--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -130,21 +130,24 @@ func (p *Path) Reverse() *Path {
 // Is declares that the current nodes in this path are only the nodes
 // passed as arguments.
 func (p *Path) Is(nodes ...quad.Value) *Path {
-	p.stack = append(p.stack, isMorphism(nodes...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, isMorphism(nodes...))
+	return np
 }
 
 // Filter represents the nodes that are passing comparison with provided value.
 func (p *Path) Filter(op iterator.Operator, node quad.Value) *Path {
-	p.stack = append(p.stack, cmpMorphism(op, node))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, cmpMorphism(op, node))
+	return np
 }
 
 // Tag adds tag strings to the nodes at this point in the path for each result
 // path in the set.
 func (p *Path) Tag(tags ...string) *Path {
-	p.stack = append(p.stack, tagMorphism(tags...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, tagMorphism(tags...))
+	return np
 }
 
 // Out updates this Path to represent the nodes that are adjacent to the
@@ -157,8 +160,9 @@ func (p *Path) Tag(tags ...string) *Path {
 //  // to "F" labelled "follows".
 //  StartPath(qs, "A").Out("follows")
 func (p *Path) Out(via ...interface{}) *Path {
-	p.stack = append(p.stack, outMorphism(nil, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, outMorphism(nil, via...))
+	return np
 }
 
 // In updates this Path to represent the nodes that are adjacent to the
@@ -171,22 +175,25 @@ func (p *Path) Out(via ...interface{}) *Path {
 //  // edges from those nodes to "B" labelled "follows".
 //  StartPath(qs, "B").In("follows")
 func (p *Path) In(via ...interface{}) *Path {
-	p.stack = append(p.stack, inMorphism(nil, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, inMorphism(nil, via...))
+	return np
 }
 
 // InWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
-	p.stack = append(p.stack, inMorphism(tags, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, inMorphism(tags, via...))
+	return np
 }
 
 // OutWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
-	p.stack = append(p.stack, outMorphism(tags, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, outMorphism(tags, via...))
+	return np
 }
 
 // Both updates this path following both inbound and outbound predicates.
@@ -198,8 +205,9 @@ func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
 //  // edges from those nodes to "B" labelled "follows", in either direction.
 //  StartPath(qs, "B").Both("follows")
 func (p *Path) Both(via ...interface{}) *Path {
-	p.stack = append(p.stack, bothMorphism(nil, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, bothMorphism(nil, via...))
+	return np
 }
 
 // InPredicates updates this path to represent the nodes of the valid inbound
@@ -211,8 +219,9 @@ func (p *Path) Both(via ...interface{}) *Path {
 //  // Will return []string{"follows"} if there are any things that "follow" Bob
 //  StartPath(qs, "bob").InPredicates()
 func (p *Path) InPredicates() *Path {
-	p.stack = append(p.stack, predicatesMorphism(true))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, predicatesMorphism(true))
+	return np
 }
 
 // OutPredicates updates this path to represent the nodes of the valid inbound
@@ -225,22 +234,25 @@ func (p *Path) InPredicates() *Path {
 //  // labelled "follows", and edges from "bob" that describe his "status".
 //  StartPath(qs, "bob").OutPredicates()
 func (p *Path) OutPredicates() *Path {
-	p.stack = append(p.stack, predicatesMorphism(false))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, predicatesMorphism(false))
+	return np
 }
 
 // And updates the current Path to represent the nodes that match both the
 // current Path so far, and the given Path.
 func (p *Path) And(path *Path) *Path {
-	p.stack = append(p.stack, andMorphism(path))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, andMorphism(path))
+	return np
 }
 
 // Or updates the current Path to represent the nodes that match either the
 // current Path so far, or the given Path.
 func (p *Path) Or(path *Path) *Path {
-	p.stack = append(p.stack, orMorphism(path))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, orMorphism(path))
+	return np
 }
 
 // Except updates the current Path to represent the all of the current nodes
@@ -250,22 +262,25 @@ func (p *Path) Or(path *Path) *Path {
 //  // Will return []string{"B"}
 //  StartPath(qs, "A", "B").Except(StartPath(qs, "A"))
 func (p *Path) Except(path *Path) *Path {
-	p.stack = append(p.stack, exceptMorphism(path))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, exceptMorphism(path))
+	return np
 }
 
 // Follow allows you to stitch two paths together. The resulting path will start
 // from where the first path left off and continue iterating down the path given.
 func (p *Path) Follow(path *Path) *Path {
-	p.stack = append(p.stack, followMorphism(path))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, followMorphism(path))
+	return np
 }
 
 // FollowReverse is the same as follow, except it will iterate backwards up the
 // path given as argument.
 func (p *Path) FollowReverse(path *Path) *Path {
-	p.stack = append(p.stack, followMorphism(path.Reverse()))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, followMorphism(path.Reverse()))
+	return np
 }
 
 // Save will, from the current nodes in the path, retrieve the node
@@ -276,55 +291,63 @@ func (p *Path) FollowReverse(path *Path) *Path {
 //  // Will return []map[string]string{{"social_status: "cool"}}
 //  StartPath(qs, "B").Save("status", "social_status"
 func (p *Path) Save(via interface{}, tag string) *Path {
-	p.stack = append(p.stack, saveMorphism(via, tag))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, saveMorphism(via, tag))
+	return np
 }
 
 // SaveReverse is the same as Save, only in the reverse direction
 // (the subject of the linkage should be tagged, instead of the object).
 func (p *Path) SaveReverse(via interface{}, tag string) *Path {
-	p.stack = append(p.stack, saveReverseMorphism(via, tag))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, saveReverseMorphism(via, tag))
+	return np
 }
 
 // SaveOptional is the same as Save, but does not require linkage to exist.
 func (p *Path) SaveOptional(via interface{}, tag string) *Path {
-	p.stack = append(p.stack, saveOptionalMorphism(via, tag))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, saveOptionalMorphism(via, tag))
+	return np
 }
 
 // SaveOptionalReverse is the same as SaveReverse, but does not require linkage to exist.
 func (p *Path) SaveOptionalReverse(via interface{}, tag string) *Path {
-	p.stack = append(p.stack, saveOptionalReverseMorphism(via, tag))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, saveOptionalReverseMorphism(via, tag))
+	return np
 }
 
 // Has limits the paths to be ones where the current nodes have some linkage
 // to some known node.
 func (p *Path) Has(via interface{}, nodes ...quad.Value) *Path {
-	p.stack = append(p.stack, hasMorphism(via, nodes...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, hasMorphism(via, nodes...))
+	return np
 }
 
 // HasReverse limits the paths to be ones where some known node have some linkage
 // to the current nodes.
 func (p *Path) HasReverse(via interface{}, nodes ...quad.Value) *Path {
-	p.stack = append(p.stack, hasReverseMorphism(via, nodes...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, hasReverseMorphism(via, nodes...))
+	return np
 }
 
 // LabelContext restricts the following operations (such as In, Out) to only
 // traverse edges that match the given set of labels.
 func (p *Path) LabelContext(via ...interface{}) *Path {
-	p.stack = append(p.stack, labelContextMorphism(nil, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, labelContextMorphism(nil, via...))
+	return np
 }
 
 // LabelContextWithTags is exactly like LabelContext, except it tags the value
 // of the label used in the traversal with the tags provided.
 func (p *Path) LabelContextWithTags(tags []string, via ...interface{}) *Path {
-	p.stack = append(p.stack, labelContextMorphism(tags, via...))
-	return p
+	np := p.Clone()
+	np.stack = append(np.stack, labelContextMorphism(tags, via...))
+	return np
 }
 
 // Back returns to a previously tagged place in the path. Any constraints applied after the Tag will remain in effect, but traversal continues from the tagged point instead, not from the end of the chain.

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -115,6 +115,19 @@ func (p *Path) Clone() *Path {
 	}
 }
 
+// Unexported clone method returns a *Path with a copy of the original stack.
+// On the assumption that the new stack will be appended to, the new
+// capacity is one greater than the current stack's length.
+func (p *Path) clone() *Path {
+	stack_c := make([]morphism, len(p.stack), len(p.stack)+1)
+	copy(stack_c, p.stack)
+	return &Path{
+		stack:       stack_c,
+		qs:          p.qs,
+		baseContext: p.baseContext,
+	}
+}
+
 // Reverse returns a new Path that is the reverse of the current one.
 func (p *Path) Reverse() *Path {
 	newPath := NewPath(p.qs)
@@ -130,14 +143,14 @@ func (p *Path) Reverse() *Path {
 // Is declares that the current nodes in this path are only the nodes
 // passed as arguments.
 func (p *Path) Is(nodes ...quad.Value) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, isMorphism(nodes...))
 	return np
 }
 
 // Filter represents the nodes that are passing comparison with provided value.
 func (p *Path) Filter(op iterator.Operator, node quad.Value) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, cmpMorphism(op, node))
 	return np
 }
@@ -145,7 +158,7 @@ func (p *Path) Filter(op iterator.Operator, node quad.Value) *Path {
 // Tag adds tag strings to the nodes at this point in the path for each result
 // path in the set.
 func (p *Path) Tag(tags ...string) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, tagMorphism(tags...))
 	return np
 }
@@ -160,7 +173,7 @@ func (p *Path) Tag(tags ...string) *Path {
 //  // to "F" labelled "follows".
 //  StartPath(qs, "A").Out("follows")
 func (p *Path) Out(via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, outMorphism(nil, via...))
 	return np
 }
@@ -175,7 +188,7 @@ func (p *Path) Out(via ...interface{}) *Path {
 //  // edges from those nodes to "B" labelled "follows".
 //  StartPath(qs, "B").In("follows")
 func (p *Path) In(via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, inMorphism(nil, via...))
 	return np
 }
@@ -183,7 +196,7 @@ func (p *Path) In(via ...interface{}) *Path {
 // InWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, inMorphism(tags, via...))
 	return np
 }
@@ -191,7 +204,7 @@ func (p *Path) InWithTags(tags []string, via ...interface{}) *Path {
 // OutWithTags is exactly like In, except it tags the value of the predicate
 // traversed with the tags provided.
 func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, outMorphism(tags, via...))
 	return np
 }
@@ -205,7 +218,7 @@ func (p *Path) OutWithTags(tags []string, via ...interface{}) *Path {
 //  // edges from those nodes to "B" labelled "follows", in either direction.
 //  StartPath(qs, "B").Both("follows")
 func (p *Path) Both(via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, bothMorphism(nil, via...))
 	return np
 }
@@ -219,7 +232,7 @@ func (p *Path) Both(via ...interface{}) *Path {
 //  // Will return []string{"follows"} if there are any things that "follow" Bob
 //  StartPath(qs, "bob").InPredicates()
 func (p *Path) InPredicates() *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, predicatesMorphism(true))
 	return np
 }
@@ -234,7 +247,7 @@ func (p *Path) InPredicates() *Path {
 //  // labelled "follows", and edges from "bob" that describe his "status".
 //  StartPath(qs, "bob").OutPredicates()
 func (p *Path) OutPredicates() *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, predicatesMorphism(false))
 	return np
 }
@@ -242,7 +255,7 @@ func (p *Path) OutPredicates() *Path {
 // And updates the current Path to represent the nodes that match both the
 // current Path so far, and the given Path.
 func (p *Path) And(path *Path) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, andMorphism(path))
 	return np
 }
@@ -250,7 +263,7 @@ func (p *Path) And(path *Path) *Path {
 // Or updates the current Path to represent the nodes that match either the
 // current Path so far, or the given Path.
 func (p *Path) Or(path *Path) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, orMorphism(path))
 	return np
 }
@@ -262,7 +275,7 @@ func (p *Path) Or(path *Path) *Path {
 //  // Will return []string{"B"}
 //  StartPath(qs, "A", "B").Except(StartPath(qs, "A"))
 func (p *Path) Except(path *Path) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, exceptMorphism(path))
 	return np
 }
@@ -270,7 +283,7 @@ func (p *Path) Except(path *Path) *Path {
 // Follow allows you to stitch two paths together. The resulting path will start
 // from where the first path left off and continue iterating down the path given.
 func (p *Path) Follow(path *Path) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, followMorphism(path))
 	return np
 }
@@ -278,7 +291,7 @@ func (p *Path) Follow(path *Path) *Path {
 // FollowReverse is the same as follow, except it will iterate backwards up the
 // path given as argument.
 func (p *Path) FollowReverse(path *Path) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, followMorphism(path.Reverse()))
 	return np
 }
@@ -291,7 +304,7 @@ func (p *Path) FollowReverse(path *Path) *Path {
 //  // Will return []map[string]string{{"social_status: "cool"}}
 //  StartPath(qs, "B").Save("status", "social_status"
 func (p *Path) Save(via interface{}, tag string) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, saveMorphism(via, tag))
 	return np
 }
@@ -299,21 +312,21 @@ func (p *Path) Save(via interface{}, tag string) *Path {
 // SaveReverse is the same as Save, only in the reverse direction
 // (the subject of the linkage should be tagged, instead of the object).
 func (p *Path) SaveReverse(via interface{}, tag string) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, saveReverseMorphism(via, tag))
 	return np
 }
 
 // SaveOptional is the same as Save, but does not require linkage to exist.
 func (p *Path) SaveOptional(via interface{}, tag string) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, saveOptionalMorphism(via, tag))
 	return np
 }
 
 // SaveOptionalReverse is the same as SaveReverse, but does not require linkage to exist.
 func (p *Path) SaveOptionalReverse(via interface{}, tag string) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, saveOptionalReverseMorphism(via, tag))
 	return np
 }
@@ -321,7 +334,7 @@ func (p *Path) SaveOptionalReverse(via interface{}, tag string) *Path {
 // Has limits the paths to be ones where the current nodes have some linkage
 // to some known node.
 func (p *Path) Has(via interface{}, nodes ...quad.Value) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, hasMorphism(via, nodes...))
 	return np
 }
@@ -329,7 +342,7 @@ func (p *Path) Has(via interface{}, nodes ...quad.Value) *Path {
 // HasReverse limits the paths to be ones where some known node have some linkage
 // to the current nodes.
 func (p *Path) HasReverse(via interface{}, nodes ...quad.Value) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, hasReverseMorphism(via, nodes...))
 	return np
 }
@@ -337,7 +350,7 @@ func (p *Path) HasReverse(via interface{}, nodes ...quad.Value) *Path {
 // LabelContext restricts the following operations (such as In, Out) to only
 // traverse edges that match the given set of labels.
 func (p *Path) LabelContext(via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, labelContextMorphism(nil, via...))
 	return np
 }
@@ -345,7 +358,7 @@ func (p *Path) LabelContext(via ...interface{}) *Path {
 // LabelContextWithTags is exactly like LabelContext, except it tags the value
 // of the label used in the traversal with the tags provided.
 func (p *Path) LabelContextWithTags(tags []string, via ...interface{}) *Path {
-	np := p.Clone()
+	np := p.clone()
 	np.stack = append(np.stack, labelContextMorphism(tags, via...))
 	return np
 }

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -115,14 +115,13 @@ func (p *Path) Clone() *Path {
 	}
 }
 
-// Unexported clone method returns a *Path with a copy of the original stack.
-// On the assumption that the new stack will be appended to, the new
-// capacity is one greater than the current stack's length.
+// Unexported clone method returns a *Path with a copy of the original stack,
+// with assumption that the new stack will be appended to.
 func (p *Path) clone() *Path {
-	stack_c := make([]morphism, len(p.stack), len(p.stack)+1)
-	copy(stack_c, p.stack)
+	stack := p.stack
+	p.stack = stack[:len(stack):len(stack)]
 	return &Path{
-		stack:       stack_c,
+		stack:       stack,
 		qs:          p.qs,
 		baseContext: p.baseContext,
 	}

--- a/graph/path/path_test.go
+++ b/graph/path/path_test.go
@@ -303,6 +303,16 @@ func testSet(qs graph.QuadStore) []test {
 			tag:     "statustag",
 			expect:  []quad.Value{vCool, vCool},
 		},
+		{
+			message: "composite paths (clone paths)",
+			path: func() *Path {
+				alice_path := StartPath(qs, vAlice)
+				_ = alice_path.Out(vFollows)
+
+				return alice_path
+			}(),
+			expect: []quad.Value{vAlice},
+		},
 	}
 }
 


### PR DESCRIPTION
This is a follow-up to a [previous issue](https://discourse.cayley.io/t/should-traversal-methods-change-their-receiver-path/308).

Said issue reported on path variables in Gremlin/javascript changing as new
paths were created as extensions from them.  This issue was resolved with
a subsequent [PR](https://github.com/cayleygraph/cayley/commit/cf824fe4bb9b5f64296c320f06febc3c33dbc9e0).

The problem, though, lies deeper.  Using cayley as a library and executing
a similar query pattern, the same results appear:

```
func main() {
     store, _ := cayley.NewGraph("leveldb", "/path/to/leveldb.db", nil)

     alice_path := path.StartPath(store, quad.IRI("alice"))
     alice_pre, _ := alice_path.Iterate(nil).AllValues(nil)
     fmt.Println("alice:", alice_pre)    // alice is <alice>

     alice_follows_path := alice_path.Out(quad.IRI("follows"))
     alice_follows, _ := alice_follows_path.Iterate(nil).AllValues(nil)
     fmt.Println("alice_follows:", alice_follows)    // alice follows <bob>

     alice_post, _ := alice_path.Iterate(nil).AllValues(nil)
     fmt.Println("alice:", alice_post)    // alice has turned into <bob>
}
```

Furthermore, for reasons I couldn't track down, I think this behavior contributed
to a pretty serious bug with the Except method on *Path.  Try the following and
watch what happens to your machine's memory usage:

```
func main() {
     fmt.Println("test_query2.go, building store")
     store, _ := cayley.NewGraph("leveldb", "/path/to/leveldb.db", nil)
     p := path.NewPath(store)
     coolpeople := p.Has(quad.IRI("status"), quad.String("cool_person"))
     bobfollowers := p.Has(quad.IRI("follows"), quad.IRI("bob"))
     reduced := bobfollowers.Except(coolpeople)
     vals, _ := reduced.Iterate(nil).AllValues(nil)
     fmt.Println("bob's followers who are not cool:", vals)
}
```

This commit includes a test in graph/path/path_test.go.  It does not undo the
changes to query/gremlin/traversals.go from the above-mentioned commit.
This probably means that there is some extra cloning that does not need to
happen and which should be removed.  The gremlin tests pass with this commit,
however.