### PR TITLE
Implement Recursive Iterator

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -265,6 +265,7 @@ var (
 		"unique",
 		"limit",
 		"skip",
+		"recursive",
 	}
 )
 

--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -240,6 +240,7 @@ const (
 	Unique
 	Limit
 	Skip
+	Recursive
 )
 
 var (

--- a/graph/iterator/and_iterator_optimize_test.go
+++ b/graph/iterator/and_iterator_optimize_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestIteratorPromotion(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -55,7 +55,7 @@ func TestIteratorPromotion(t *testing.T) {
 }
 
 func TestNullIteratorAnd(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -74,7 +74,7 @@ func TestNullIteratorAnd(t *testing.T) {
 }
 
 func TestAllPromotion(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -106,7 +106,7 @@ func TestAllPromotion(t *testing.T) {
 }
 
 func TestReorderWithTag(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -145,7 +145,7 @@ func TestReorderWithTag(t *testing.T) {
 }
 
 func TestAndStatistics(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}

--- a/graph/iterator/and_iterator_test.go
+++ b/graph/iterator/and_iterator_test.go
@@ -23,7 +23,7 @@ import (
 
 // Make sure that tags work on the And.
 func TestTag(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -60,7 +60,7 @@ func TestTag(t *testing.T) {
 
 // Do a simple itersection of fixed values.
 func TestAndAndFixedIterators(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -102,7 +102,7 @@ func TestAndAndFixedIterators(t *testing.T) {
 // If there's no intersection, the size should still report the same,
 // but there should be nothing to Next()
 func TestNonOverlappingFixedIterators(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -134,7 +134,7 @@ func TestNonOverlappingFixedIterators(t *testing.T) {
 }
 
 func TestAllIterators(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}
@@ -158,7 +158,7 @@ func TestAllIterators(t *testing.T) {
 }
 
 func TestAndIteratorErr(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{},
 		iter: NewFixed(Identity),
 	}

--- a/graph/iterator/linksto_iterator_test.go
+++ b/graph/iterator/linksto_iterator_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestLinksTo(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{1: "cool"},
 		iter: NewFixed(Identity),
 	}

--- a/graph/iterator/mock_ts_test.go
+++ b/graph/iterator/mock_ts_test.go
@@ -15,19 +15,20 @@
 package iterator
 
 import (
+	"strconv"
+
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/quad"
-	"strconv"
 )
 
-// store is a mocked version of the QuadStore interface, for use in tests.
-type store struct {
+// oldstore is a mocked version of the QuadStore interface, for use in tests.
+type oldstore struct {
 	parse bool
 	data  []string
 	iter  graph.Iterator
 }
 
-func (qs *store) valueAt(i int) quad.Value {
+func (qs *oldstore) valueAt(i int) quad.Value {
 	if !qs.parse {
 		return quad.Raw(qs.data[i])
 	}
@@ -38,7 +39,7 @@ func (qs *store) valueAt(i int) quad.Value {
 	return quad.String(qs.data[i])
 }
 
-func (qs *store) ValueOf(s quad.Value) graph.Value {
+func (qs *oldstore) ValueOf(s quad.Value) graph.Value {
 	if s == nil {
 		return nil
 	}
@@ -50,19 +51,19 @@ func (qs *store) ValueOf(s quad.Value) graph.Value {
 	return nil
 }
 
-func (qs *store) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
+func (qs *oldstore) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
 
-func (qs *store) Quad(graph.Value) quad.Quad { return quad.Quad{} }
+func (qs *oldstore) Quad(graph.Value) quad.Quad { return quad.Quad{} }
 
-func (qs *store) QuadIterator(d quad.Direction, i graph.Value) graph.Iterator {
+func (qs *oldstore) QuadIterator(d quad.Direction, i graph.Value) graph.Iterator {
 	return qs.iter
 }
 
-func (qs *store) NodesAllIterator() graph.Iterator { return &Null{} }
+func (qs *oldstore) NodesAllIterator() graph.Iterator { return &Null{} }
 
-func (qs *store) QuadsAllIterator() graph.Iterator { return &Null{} }
+func (qs *oldstore) QuadsAllIterator() graph.Iterator { return &Null{} }
 
-func (qs *store) NameOf(v graph.Value) quad.Value {
+func (qs *oldstore) NameOf(v graph.Value) quad.Value {
 	switch v.(type) {
 	case Int64Node:
 		i := int(v.(Int64Node))
@@ -80,11 +81,53 @@ func (qs *store) NameOf(v graph.Value) quad.Value {
 	}
 }
 
-func (qs *store) Size() int64 { return 0 }
+func (qs *oldstore) Size() int64 { return 0 }
 
-func (qs *store) Horizon() graph.PrimaryKey { return graph.NewSequentialKey(0) }
+func (qs *oldstore) Horizon() graph.PrimaryKey { return graph.NewSequentialKey(0) }
 
-func (qs *store) DebugPrint() {}
+func (qs *oldstore) DebugPrint() {}
+
+func (qs *oldstore) OptimizeIterator(it graph.Iterator) (graph.Iterator, bool) {
+	return &Null{}, false
+}
+
+func (qs *oldstore) FixedIterator() graph.FixedIterator {
+	return NewFixed(Identity)
+}
+
+func (qs *oldstore) Close() {}
+
+func (qs *oldstore) QuadDirection(graph.Value, quad.Direction) graph.Value { return Int64Node(0) }
+
+func (qs *oldstore) RemoveQuad(t quad.Quad) {}
+
+func (qs *oldstore) Type() string { return "oldmockstore" }
+
+type store struct {
+	data []quad.Quad
+}
+
+var _ graph.QuadStore = &store{}
+
+func (qs *store) ValueOf(s quad.Value) graph.Value {
+	return s
+}
+
+func (qs *store) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
+
+func (qs *store) Quad(v graph.Value) quad.Quad { return v.(quad.Quad) }
+
+func (qs *store) NameOf(v graph.Value) quad.Value {
+	return v.(quad.String)
+}
+
+func (qs *store) RemoveQuad(t quad.Quad) {}
+
+func (qs *store) Type() string { return "mockstore" }
+
+func (qs *store) QuadDirection(v graph.Value, d quad.Direction) graph.Value {
+	return qs.Quad(v).Get(d)
+}
 
 func (qs *store) OptimizeIterator(it graph.Iterator) (graph.Iterator, bool) {
 	return &Null{}, false
@@ -96,8 +139,40 @@ func (qs *store) FixedIterator() graph.FixedIterator {
 
 func (qs *store) Close() {}
 
-func (qs *store) QuadDirection(graph.Value, quad.Direction) graph.Value { return Int64Quad(0) }
+func (qs *store) Horizon() graph.PrimaryKey { return graph.NewSequentialKey(0) }
 
-func (qs *store) RemoveQuad(t quad.Quad) {}
+func (qs *store) DebugPrint() {}
 
-func (qs *store) Type() string { return "mockstore" }
+func (qs *store) QuadIterator(d quad.Direction, i graph.Value) graph.Iterator {
+	fixed := qs.FixedIterator()
+	for _, q := range qs.data {
+		if q.Get(d) == i {
+			fixed.Add(q)
+		}
+	}
+	return fixed
+}
+
+func (qs *store) NodesAllIterator() graph.Iterator {
+	set := make(map[string]bool)
+	for _, q := range qs.data {
+		for _, d := range quad.Directions {
+			set[qs.NameOf(q.Get(d)).String()] = true
+		}
+	}
+	fixed := qs.FixedIterator()
+	for k, _ := range set {
+		fixed.Add(quad.String(k))
+	}
+	return fixed
+}
+
+func (qs *store) QuadsAllIterator() graph.Iterator {
+	fixed := qs.FixedIterator()
+	for _, q := range qs.data {
+		fixed.Add(q)
+	}
+	return fixed
+}
+
+func (qs *store) Size() int64 { return int64(len(qs.data)) }

--- a/graph/iterator/mock_ts_test.go
+++ b/graph/iterator/mock_ts_test.go
@@ -118,7 +118,10 @@ func (qs *store) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil
 func (qs *store) Quad(v graph.Value) quad.Quad { return v.(quad.Quad) }
 
 func (qs *store) NameOf(v graph.Value) quad.Value {
-	return v.(quad.String)
+	if v == nil {
+		return nil
+	}
+	return v.(quad.Value)
 }
 
 func (qs *store) RemoveQuad(t quad.Quad) {}
@@ -157,12 +160,15 @@ func (qs *store) NodesAllIterator() graph.Iterator {
 	set := make(map[string]bool)
 	for _, q := range qs.data {
 		for _, d := range quad.Directions {
-			set[qs.NameOf(q.Get(d)).String()] = true
+			n := qs.NameOf(q.Get(d))
+			if n != nil {
+				set[n.String()] = true
+			}
 		}
 	}
 	fixed := qs.FixedIterator()
 	for k, _ := range set {
-		fixed.Add(quad.String(k))
+		fixed.Add(quad.Raw(k))
 	}
 	return fixed
 }

--- a/graph/iterator/query_shape_test.go
+++ b/graph/iterator/query_shape_test.go
@@ -38,7 +38,7 @@ func hasaWithTag(qs graph.QuadStore, tag string, target string) *HasA {
 }
 
 func TestQueryShape(t *testing.T) {
-	qs := &store{
+	qs := &oldstore{
 		data: []string{
 			1: "cool",
 			2: "status",

--- a/graph/iterator/recursive_iterator.go
+++ b/graph/iterator/recursive_iterator.go
@@ -76,6 +76,10 @@ func (it *Recursive) Tagger() *graph.Tagger {
 	return &it.tags
 }
 
+func (it *Recursive) AddDepthTag(s string) {
+	it.depthTags.Add(s)
+}
+
 func (it *Recursive) TagResults(dst map[string]graph.Value) {
 	for _, tag := range it.tags.Tags() {
 		dst[tag] = it.Result()

--- a/graph/iterator/recursive_iterator.go
+++ b/graph/iterator/recursive_iterator.go
@@ -1,0 +1,238 @@
+package iterator
+
+import (
+	"math"
+
+	"github.com/google/cayley/graph"
+)
+
+// Recursive iterator takes a base iterator and a morphism to be applied recursively, for each result.
+type Recursive struct {
+	uid      uint64
+	tags     graph.Tagger
+	subIt    graph.Iterator
+	result   seenAt
+	runstats graph.IteratorStats
+	err      error
+
+	qs          graph.QuadStore
+	morphism    graph.ApplyMorphism
+	seen        map[graph.Value]seenAt
+	nextIt      graph.Iterator
+	depth       int
+	containsSub graph.Iterator
+	depthTags   graph.Tagger
+	depthCache  []graph.Value
+	baseIt      graph.FixedIterator
+}
+
+type seenAt struct {
+	depth int
+	val   graph.Value
+}
+
+var _ graph.Iterator = &Recursive{}
+var _ graph.Nexter = &Recursive{}
+
+var MaxRecursiveSteps = 50
+
+func NewRecursive(qs graph.QuadStore, it graph.Iterator, morphism graph.ApplyMorphism) *Recursive {
+	return &Recursive{
+		uid:   NextUID(),
+		subIt: it,
+
+		qs:       qs,
+		morphism: morphism,
+		seen:     make(map[graph.Value]seenAt),
+		nextIt:   &Null{},
+		baseIt:   qs.FixedIterator(),
+	}
+}
+
+func (it *Recursive) UID() uint64 {
+	return it.uid
+}
+
+func (it *Recursive) Reset() {
+	it.result.val = nil
+	it.result.depth = 0
+	it.err = nil
+	it.subIt.Reset()
+	it.seen = make(map[graph.Value]seenAt)
+	it.nextIt = &Null{}
+	it.baseIt = it.qs.FixedIterator()
+	it.depth = 0
+}
+
+func (it *Recursive) Tagger() *graph.Tagger {
+	return &it.tags
+}
+
+func (it *Recursive) TagResults(dst map[string]graph.Value) {
+	for _, tag := range it.tags.Tags() {
+		dst[tag] = it.Result()
+	}
+
+	for _, tag := range it.depthTags.Tags() {
+		dst[tag] = it.qs.ValueOf(string(it.result.depth))
+	}
+
+	for tag, value := range it.tags.Fixed() {
+		dst[tag] = value
+	}
+
+	for tag, value := range it.depthTags.Fixed() {
+		dst[tag] = value
+	}
+
+	if it.subIt != nil {
+		it.subIt.TagResults(dst)
+	}
+}
+
+func (it *Recursive) Clone() graph.Iterator {
+	n := NewRecursive(it.qs, it.subIt.Clone(), it.morphism)
+	n.tags.CopyFrom(it)
+	n.depthTags.CopyFromTagger(&it.depthTags)
+	return n
+}
+
+func (it *Recursive) SubIterators() []graph.Iterator {
+	return []graph.Iterator{it.subIt}
+}
+
+func (it *Recursive) Next() bool {
+	if it.depth == 0 {
+		for graph.Next(it.subIt) {
+			it.depthCache = append(it.depthCache, it.subIt.Result())
+		}
+	}
+	for {
+		ok := graph.Next(it.nextIt)
+		if !ok {
+			if len(it.depthCache) == 0 {
+				return graph.NextLogOut(it, it.Result(), false)
+			}
+			it.depth++
+			it.baseIt = it.qs.FixedIterator()
+			for _, x := range it.depthCache {
+				it.baseIt.Add(x)
+			}
+			it.nextIt = it.morphism(it.qs, it.baseIt)
+		}
+		val := it.nextIt.Result()
+		if _, ok := it.seen[val]; ok {
+			continue
+		}
+		it.seen[val] = seenAt{
+			val:   it.baseIt.Result(),
+			depth: it.depth,
+		}
+		it.result.depth = it.depth
+		it.result.val = val
+		it.depthCache = append(it.depthCache, val)
+		break
+	}
+	return graph.NextLogOut(it, it.Result(), true)
+}
+
+func (it *Recursive) Err() error {
+	return it.err
+}
+
+func (it *Recursive) Result() graph.Value {
+	return it.result.val
+}
+
+func (it *Recursive) Contains(val graph.Value) bool {
+	if it.containsSub == nil {
+		it.containsSub = it.subIt.Clone()
+	}
+	graph.ContainsLogIn(it, val)
+	if at, ok := it.seen[val]; ok {
+		subat := at
+		for subat.depth != 1 {
+			subat = it.seen[subat.val]
+		}
+		it.containsSub.Contains(subat.val)
+		it.result = at
+		return graph.ContainsLogOut(it, val, true)
+	}
+	for graph.Next(it) {
+		if it.Result() == val {
+			it.containsSub.Contains(val)
+			return graph.ContainsLogOut(it, val, true)
+		}
+	}
+	return graph.ContainsLogOut(it, val, false)
+}
+
+func (it *Recursive) NextPath() bool {
+	return it.containsSub.NextPath()
+}
+
+func (it *Recursive) Close() error {
+	err := it.subIt.Close()
+	if err != nil {
+		return err
+	}
+	err = it.containsSub.Close()
+	if err != nil {
+		return err
+	}
+	err = it.nextIt.Close()
+	if err != nil {
+		return err
+	}
+	it.seen = nil
+	return it.err
+}
+
+func (it *Recursive) Type() graph.Type { return graph.Recursive }
+
+func (it *Recursive) Optimize() (graph.Iterator, bool) {
+	newIt, optimized := it.subIt.Optimize()
+	if optimized {
+		it.subIt = newIt
+	}
+	return it, false
+}
+
+func (it *Recursive) Size() (int64, bool) {
+	return it.Stats().Size, false
+}
+
+func (it *Recursive) Stats() graph.IteratorStats {
+	base := it.qs.FixedIterator()
+	base.Add(it.qs.ValueOf("foo"))
+	fanoutit := it.morphism(it.qs, base)
+	fanoutStats := fanoutit.Stats()
+	subitStats := it.subIt.Stats()
+
+	size := int64(math.Pow(float64(subitStats.Size*fanoutStats.Size), 5))
+	return graph.IteratorStats{
+		NextCost:     subitStats.NextCost + fanoutStats.NextCost,
+		ContainsCost: (subitStats.NextCost+fanoutStats.NextCost)*(size/10) + subitStats.ContainsCost,
+		Size:         size,
+		Next:         it.runstats.Next,
+		Contains:     it.runstats.Contains,
+		ContainsNext: it.runstats.ContainsNext,
+	}
+}
+
+func (it *Recursive) Describe() graph.Description {
+	base := it.qs.FixedIterator()
+	base.Add(it.qs.ValueOf("foo"))
+	fanoutdesc := it.morphism(it.qs, base).Describe()
+	subIts := []graph.Description{
+		it.subIt.Describe(),
+		fanoutdesc,
+	}
+
+	return graph.Description{
+		UID:       it.UID(),
+		Type:      it.Type(),
+		Tags:      it.tags.Tags(),
+		Iterators: subIts,
+	}
+}

--- a/graph/iterator/recursive_iterator.go
+++ b/graph/iterator/recursive_iterator.go
@@ -1,7 +1,6 @@
 package iterator
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/cayleygraph/cayley/graph"
@@ -130,7 +129,6 @@ func (it *Recursive) Next() bool {
 				it.subIt.TagResults(tags)
 				it.pathMap[res] = append(it.pathMap[res], tags)
 			}
-			fmt.Printf("A: %#v %#v\n", res, it.pathMap[res])
 		}
 	}
 	for {

--- a/graph/iterator/recursive_iterator_test.go
+++ b/graph/iterator/recursive_iterator_test.go
@@ -100,6 +100,11 @@ func TestRecursiveNextPath(t *testing.T) {
 		res := make(map[string]graph.Value)
 		r.TagResults(res)
 		got = append(got, qs.NameOf(res["person"]))
+		for r.NextPath() {
+			res := make(map[string]graph.Value)
+			r.TagResults(res)
+			got = append(got, qs.NameOf(res["person"]))
+		}
 	}
 	sort.Strings(expected)
 	sort.Strings(got)

--- a/graph/iterator/recursive_iterator_test.go
+++ b/graph/iterator/recursive_iterator_test.go
@@ -1,0 +1,109 @@
+// Copyright 2015 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/google/cayley/graph"
+	"github.com/google/cayley/quad"
+)
+
+func singleHop(pred string) graph.ApplyMorphism {
+	return func(qs graph.QuadStore, it graph.Iterator) graph.Iterator {
+		fixed := qs.FixedIterator()
+		fixed.Add(pred)
+		predlto := NewLinksTo(qs, fixed, quad.Predicate)
+		lto := NewLinksTo(qs, it.Clone(), quad.Subject)
+		and := NewAnd(qs)
+		and.AddSubIterator(lto)
+		and.AddSubIterator(predlto)
+		return NewHasA(qs, and, quad.Object)
+	}
+}
+
+var rec_test_qs = &store{
+	data: []quad.Quad{
+		{"alice", "parent", "bob", ""},
+		{"bob", "parent", "charlie", ""},
+		{"charlie", "parent", "dani", ""},
+		{"charlie", "parent", "bob", ""},
+		{"dani", "parent", "emily", ""},
+		{"fred", "follows", "alice", ""},
+		{"greg", "follows", "alice", ""},
+	},
+}
+
+func TestRecursiveNext(t *testing.T) {
+	qs := rec_test_qs
+	start := qs.FixedIterator()
+	start.Add("alice")
+	r := NewRecursive(qs, start, singleHop("parent"))
+	expected := []string{"bob", "charlie", "dani", "emily"}
+
+	var got []string
+	for graph.Next(r) {
+		got = append(got, qs.NameOf(r.Result()))
+	}
+	sort.Strings(expected)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Failed to %s, got: %v, expected: %v", "check basic recursive iterator", got, expected)
+	}
+}
+
+func TestRecursiveContains(t *testing.T) {
+	qs := rec_test_qs
+	start := qs.FixedIterator()
+	start.Add("alice")
+	r := NewRecursive(qs, start, singleHop("parent"))
+	values := []string{"charlie", "bob", "not"}
+	expected := []bool{true, true, false}
+
+	for i, v := range values {
+		ok := r.Contains(qs.ValueOf(v))
+		if expected[i] != ok {
+			t.Errorf("Failed to %s, value: %s, got: %v, expected: %v", "check basic recursive contains", v, ok, expected[i])
+		}
+	}
+}
+
+func TestRecursiveNextPath(t *testing.T) {
+	qs := rec_test_qs
+	start := qs.NodesAllIterator()
+	start.Tagger().Add("person")
+	it := singleHop("follows")(qs, start)
+	and := NewAnd(qs)
+	and.AddSubIterator(it)
+	fixed := qs.FixedIterator()
+	fixed.Add("alice")
+	and.AddSubIterator(fixed)
+	r := NewRecursive(qs, and, singleHop("parent"))
+
+	expected := []string{"fred", "fred", "fred", "fred", "greg", "greg", "greg", "greg"}
+	var got []string
+	for graph.Next(r) {
+		res := make(map[string]graph.Value)
+		r.TagResults(res)
+		got = append(got, qs.NameOf(res["person"]))
+	}
+	sort.Strings(expected)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("Failed to check NextPath, got: %v, expected: %v", got, expected)
+	}
+}

--- a/graph/iterator/value_comparison_iterator_test.go
+++ b/graph/iterator/value_comparison_iterator_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	simpleStore = &store{data: []string{"0", "1", "2", "3", "4", "5"}, parse: true}
-	stringStore = &store{data: []string{"foo", "bar", "baz", "echo"}, parse: true}
-	mixedStore  = &store{data: []string{"0", "1", "2", "3", "4", "5", "foo", "bar", "baz", "echo"}, parse: true}
+	simpleStore = &oldstore{data: []string{"0", "1", "2", "3", "4", "5"}, parse: true}
+	stringStore = &oldstore{data: []string{"foo", "bar", "baz", "echo"}, parse: true}
+	mixedStore  = &oldstore{data: []string{"0", "1", "2", "3", "4", "5", "foo", "bar", "baz", "echo"}, parse: true}
 )
 
 func simpleFixedIterator() *Fixed {

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -250,6 +250,20 @@ func followMorphism(p *Path) morphism {
 	}
 }
 
+func followRecursiveMorphism(p *Path, depthTags []string) morphism {
+	return morphism{
+		Name:     "follow_recursive",
+		Reversal: func(ctx *context) (morphism, *context) { return followRecursiveMorphism(p.Reverse(), depthTags), ctx },
+		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *context) (graph.Iterator, *context) {
+			it := iterator.NewRecursive(qs, in, p.Morphism())
+			for _, s := range depthTags {
+				it.AddDepthTag(s)
+			}
+			return it, ctx
+		},
+	}
+}
+
 // exceptMorphism removes all results on p.(*Path) from the current iterators.
 func exceptMorphism(p *Path) morphism {
 	return morphism{

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -252,9 +252,11 @@ func followMorphism(p *Path) morphism {
 
 func followRecursiveMorphism(p *Path, depthTags []string) morphism {
 	return morphism{
-		Name:     "follow_recursive",
-		Reversal: func(ctx *context) (morphism, *context) { return followRecursiveMorphism(p.Reverse(), depthTags), ctx },
-		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *context) (graph.Iterator, *context) {
+		Name: "follow_recursive",
+		Reversal: func(ctx *pathContext) (morphism, *pathContext) {
+			return followRecursiveMorphism(p.Reverse(), depthTags), ctx
+		},
+		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *pathContext) (graph.Iterator, *pathContext) {
 			it := iterator.NewRecursive(qs, in, p.Morphism())
 			for _, s := range depthTags {
 				it.AddDepthTag(s)

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -295,6 +295,32 @@ func (p *Path) FollowReverse(path *Path) *Path {
 	return np
 }
 
+// FollowRecursive will repeatedly follow the given string predicate or Path
+// object starting from the given node(s), through the morphism or pattern
+// provided, ignoring loops. For example, this turns "parent" into "all
+// ancestors", by repeatedly following the "parent" connection on the result of
+// the parent nodes.
+//
+// The second argument, "depthTags" is a set of tags that will return strings of
+// numeric values relating to how many applications of the path were applied the
+// first time the result node was seen.
+//
+// This is a very expensive operation in practice. Be sure to use it wisely.
+
+func (p *Path) FollowRecursive(via interface{}, depthTags []string) *Path {
+	var path *Path
+	switch v := via.(type) {
+	case string:
+		path = StartMorphism().Out(v)
+	case *Path:
+		path = v
+	default:
+		panic("did not pass a string predicate or a Path to FollowRecursive")
+	}
+	p.stack = append(p.stack, followRecursiveMorphism(path, depthTags))
+	return p
+}
+
 // Save will, from the current nodes in the path, retrieve the node
 // one linkage away (given by either a path or a predicate), add the given
 // tag, and propagate that to the result set.

--- a/quad/quad.go
+++ b/quad/quad.go
@@ -207,6 +207,8 @@ func (q Quad) String() string {
 	return fmt.Sprintf("%v -- %v -> %v", q.Subject, q.Predicate, q.Object)
 }
 
+func (q Quad) IsNode() bool { return false }
+
 func (q Quad) IsValid() bool {
 	return q.Subject != nil && q.Predicate != nil && q.Object != nil &&
 		q.Subject.String() != "" && q.Predicate.String() != "" && q.Object.String() != ""

--- a/quad/value.go
+++ b/quad/value.go
@@ -12,6 +12,7 @@ import (
 // Value is a type used by all quad directions.
 type Value interface {
 	String() string
+	IsNode() bool
 	// Native converts Value to a closest native Go type.
 	//
 	// If type has no analogs in Go, Native return an object itself.
@@ -122,6 +123,7 @@ type Raw string
 
 func (s Raw) String() string      { return string(s) }
 func (s Raw) Native() interface{} { return s }
+func (s Raw) IsNode() bool        { return true }
 
 // String is an RDF string value (ex: "name").
 type String string
@@ -139,6 +141,7 @@ func (s String) String() string {
 	return `"` + escaper.Replace(string(s)) + `"`
 }
 func (s String) Native() interface{} { return string(s) }
+func (s String) IsNode() bool        { return true }
 
 // TypedString is an RDF value with type (ex: "name"^^<type>).
 type TypedString struct {
@@ -158,6 +161,8 @@ func (s TypedString) Native() interface{} {
 	}
 	return s
 }
+
+func (s TypedString) IsNode() bool { return true }
 
 // ParseValue will try to parse underlying string value using registered functions.
 //
@@ -182,18 +187,21 @@ func (s LangString) String() string {
 	return s.Value.String() + `@` + s.Lang
 }
 func (s LangString) Native() interface{} { return s.Value.Native() }
+func (s LangString) IsNode() bool        { return true }
 
 // IRI is an RDF Internationalized Resource Identifier (ex: <name>).
 type IRI string
 
 func (s IRI) String() string      { return `<` + string(s) + `>` }
 func (s IRI) Native() interface{} { return s }
+func (s IRI) IsNode() bool        { return true }
 
 // BNode is an RDF Blank Node (ex: _:name).
 type BNode string
 
 func (s BNode) String() string      { return `_:` + string(s) }
 func (s BNode) Native() interface{} { return s }
+func (s BNode) IsNode() bool        { return true }
 
 // Native support for basic types
 
@@ -283,6 +291,7 @@ func (s Int) String() string {
 	return `"` + strconv.Itoa(int(s)) + `"^^<` + string(defaultIntType) + `>`
 }
 func (s Int) Native() interface{} { return int(s) }
+func (s Int) IsNode() bool        { return true }
 
 // Float is a native wrapper for float64 type.
 //
@@ -293,6 +302,7 @@ func (s Float) String() string {
 	return `"` + strconv.FormatFloat(float64(s), 'E', -1, 64) + `"^^<` + string(defaultFloatType) + `>`
 }
 func (s Float) Native() interface{} { return float64(s) }
+func (s Float) IsNode() bool        { return true }
 
 // Bool is a native wrapper for bool type.
 //
@@ -306,6 +316,7 @@ func (s Bool) String() string {
 	return `"False"^^<` + string(defaultBoolType) + `>`
 }
 func (s Bool) Native() interface{} { return bool(s) }
+func (s Bool) IsNode() bool        { return true }
 
 var _ Equaler = Time{}
 
@@ -319,6 +330,7 @@ func (s Time) String() string {
 	return `"` + time.Time(s).Format(time.RFC3339) + `"^^<` + string(defaultTimeType) + `>`
 }
 func (s Time) Native() interface{} { return time.Time(s) }
+func (s Time) IsNode() bool        { return true }
 func (s Time) Equal(v Value) bool {
 	t, ok := v.(Time)
 	if !ok {


### PR DESCRIPTION
Rebased and updated (now with types) my old `transitive_closure` branch. The notion here is that, in the path library:

```
g.V(start).FollowRecursive(g.M().Out("parent"))
```

Will follow the `parent` predicate (or general morphism) out to the set of reachable (within a maximum) nodes generated by repeating that query. There's the option for adding a special tag which will tell you, numerically, at what depth (eg, parent: 1, grandparent: 2, great-grandparent: 3) the node was first visited. Loops are _not_ followed; their depth is their minimum distance.

Effectively, it goes from an input set of nodes (left-hand side of the operation) to a set of nodes recursively reachable by the morphism (on the right hand side). 

Adding it to Gizmo is a followup.
