### PR TITLE
query: Refactor interfaces

### DIFF
--- a/appengine/appengine.go
+++ b/appengine/appengine.go
@@ -29,6 +29,10 @@ import (
 
 	_ "github.com/cayleygraph/cayley/graph/gaedatastore"
 	_ "github.com/cayleygraph/cayley/writer"
+
+	// Register supported query languages
+	_ "github.com/cayleygraph/cayley/query/gremlin"
+	_ "github.com/cayleygraph/cayley/query/mql"
 )
 
 var (

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -44,6 +44,11 @@ import (
 
 	// Load writer registry
 	_ "github.com/cayleygraph/cayley/writer"
+
+	// Load supported query languages
+	_ "github.com/cayleygraph/cayley/query/gremlin"
+	_ "github.com/cayleygraph/cayley/query/mql"
+	_ "github.com/cayleygraph/cayley/query/sexp"
 )
 
 var (

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -24,6 +24,8 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cayleygraph/cayley/clog"
 	_ "github.com/cayleygraph/cayley/clog/glog"
 
@@ -260,7 +262,7 @@ func main() {
 			}
 		}
 
-		err = db.Repl(handle, *queryLanguage, cfg)
+		err = db.Repl(context.TODO(), handle, *queryLanguage, cfg.Timeout)
 
 		handle.Close()
 

--- a/internal/db/repl.go
+++ b/internal/db/repl.go
@@ -85,10 +85,11 @@ func Repl(ctx context.Context, h *graph.Handle, queryLanguage string, timeout ti
 	if queryLanguage == "" {
 		queryLanguage = defaultLanguage
 	}
-	ses := query.NewREPLSession(h.QuadStore, queryLanguage)
-	if ses == nil {
+	l := query.GetLanguage(queryLanguage)
+	if l == nil || l.REPL == nil {
 		return fmt.Errorf("unsupported query language: %q", queryLanguage)
 	}
+	ses := l.REPL(h.QuadStore)
 
 	term, err := terminal(history)
 	if os.IsNotExist(err) {

--- a/internal/db/repl.go
+++ b/internal/db/repl.go
@@ -32,9 +32,6 @@ import (
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/quad/cquads"
 	"github.com/cayleygraph/cayley/query"
-	"github.com/cayleygraph/cayley/query/gremlin"
-	"github.com/cayleygraph/cayley/query/mql"
-	"github.com/cayleygraph/cayley/query/sexp"
 )
 
 func trace(s string) (string, time.Time) {
@@ -76,6 +73,8 @@ func Run(ctx context.Context, qu string, ses query.REPLSession) error {
 }
 
 const (
+	defaultLanguage = "gremlin"
+
 	ps1 = "cayley> "
 	ps2 = "...     "
 
@@ -83,16 +82,12 @@ const (
 )
 
 func Repl(ctx context.Context, h *graph.Handle, queryLanguage string, timeout time.Duration) error {
-	var ses query.REPLSession
-	switch queryLanguage {
-	case "sexp":
-		ses = sexp.NewSession(h.QuadStore)
-	case "mql":
-		ses = mql.NewSession(h.QuadStore)
-	case "gremlin":
-		fallthrough
-	default:
-		ses = gremlin.NewSession(h.QuadStore, true)
+	if queryLanguage == "" {
+		queryLanguage = defaultLanguage
+	}
+	ses := query.NewREPLSession(h.QuadStore, queryLanguage)
+	if ses == nil {
+		return fmt.Errorf("unsupported query language: %q", queryLanguage)
 	}
 
 	term, err := terminal(history)

--- a/internal/db/repl.go
+++ b/internal/db/repl.go
@@ -26,9 +26,10 @@ import (
 	"time"
 
 	"github.com/peterh/liner"
+	"golang.org/x/net/context"
 
+	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
-	"github.com/cayleygraph/cayley/internal/config"
 	"github.com/cayleygraph/cayley/quad/cquads"
 	"github.com/cayleygraph/cayley/query"
 	"github.com/cayleygraph/cayley/query/gremlin"
@@ -46,7 +47,7 @@ func un(s string, startTime time.Time) {
 	fmt.Printf(s, float64(endTime.UnixNano()-startTime.UnixNano())/float64(1E6))
 }
 
-func Run(query string, ses query.Session) {
+func Run(ctx context.Context, qu string, ses query.REPLSession) error {
 	nResults := 0
 	startTrace, startTime := trace("Elapsed time: %g ms\n\n")
 	defer func() {
@@ -55,10 +56,13 @@ func Run(query string, ses query.Session) {
 		}
 	}()
 	fmt.Printf("\n")
-	c := make(chan interface{}, 5)
-	go ses.Execute(query, c, 100)
+	c := make(chan query.Result, 5)
+	go ses.Execute(ctx, qu, c, 100)
 	for res := range c {
-		fmt.Print(ses.Format(res))
+		if err := res.Err(); err != nil {
+			return err
+		}
+		fmt.Print(ses.FormatREPL(res))
 		nResults++
 	}
 	if nResults > 0 {
@@ -68,6 +72,7 @@ func Run(query string, ses query.Session) {
 		}
 		fmt.Printf("-----------\n%d %s\n", nResults, results)
 	}
+	return nil
 }
 
 const (
@@ -77,8 +82,8 @@ const (
 	history = ".cayley_history"
 )
 
-func Repl(h *graph.Handle, queryLanguage string, cfg *config.Config) error {
-	var ses query.Session
+func Repl(ctx context.Context, h *graph.Handle, queryLanguage string, timeout time.Duration) error {
+	var ses query.REPLSession
 	switch queryLanguage {
 	case "sexp":
 		ses = sexp.NewSession(h.QuadStore)
@@ -87,7 +92,7 @@ func Repl(h *graph.Handle, queryLanguage string, cfg *config.Config) error {
 	case "gremlin":
 		fallthrough
 	default:
-		ses = gremlin.NewSession(h.QuadStore, cfg.Timeout, true)
+		ses = gremlin.NewSession(h.QuadStore, true)
 	}
 
 	term, err := terminal(history)
@@ -102,7 +107,17 @@ func Repl(h *graph.Handle, queryLanguage string, cfg *config.Config) error {
 		code string
 	)
 
+	newCtx := func() (context.Context, func()) { return ctx, func() {} }
+	if timeout > 0 {
+		newCtx = func() (context.Context, func()) { return context.WithTimeout(ctx, timeout) }
+	}
+
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		if len(code) == 0 {
 			prompt = ps1
 		} else {
@@ -143,7 +158,11 @@ func Repl(h *graph.Handle, queryLanguage string, cfg *config.Config) error {
 						continue
 					}
 				}
-				ses.Debug(debug)
+				if debug {
+					clog.SetV(2)
+				} else {
+					clog.SetV(0)
+				}
 				fmt.Printf("Debug set to %t\n", debug)
 				continue
 
@@ -183,15 +202,16 @@ func Repl(h *graph.Handle, queryLanguage string, cfg *config.Config) error {
 
 		code += line
 
-		result, err := ses.Parse(code)
-		switch result {
-		case query.Parsed:
-			Run(code, ses)
-			code = ""
-		case query.ParseFail:
+		nctx, cancel := newCtx()
+		err = Run(nctx, code, ses)
+		cancel()
+		if err == query.ErrParseMore {
+			// collect more input
+		} else if err != nil {
 			fmt.Println("Error: ", err)
 			code = ""
-		case query.ParseMore:
+		} else {
+			code = ""
 		}
 	}
 }

--- a/internal/http/query.go
+++ b/internal/http/query.go
@@ -23,8 +23,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cayleygraph/cayley/query"
-	"github.com/cayleygraph/cayley/query/gremlin"
-	"github.com/cayleygraph/cayley/query/mql"
 )
 
 type SuccessQueryWrapper struct {
@@ -74,14 +72,9 @@ func (api *API) ServeV1Query(w http.ResponseWriter, r *http.Request, params http
 	default:
 	}
 	h, err := api.GetHandleForRequest(r)
-	var ses query.HTTP
-	switch params.ByName("query_lang") {
-	case "gremlin":
-		ses = gremlin.NewSession(h.QuadStore, false)
-	case "mql":
-		ses = mql.NewSession(h.QuadStore)
-	default:
-		return jsonResponse(w, 400, "Need a query language.")
+	ses := query.NewHTTPSession(h.QuadStore, params.ByName("query_lang"))
+	if ses == nil {
+		return jsonResponse(w, 400, "Unknown query language.")
 	}
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -128,14 +121,9 @@ func (api *API) ServeV1Shape(w http.ResponseWriter, r *http.Request, params http
 	default:
 	}
 	h, err := api.GetHandleForRequest(r)
-	var ses query.HTTP
-	switch params.ByName("query_lang") {
-	case "gremlin":
-		ses = gremlin.NewSession(h.QuadStore, false)
-	case "mql":
-		ses = mql.NewSession(h.QuadStore)
-	default:
-		return jsonResponse(w, 400, "Need a query language.")
+	ses := query.NewHTTPSession(h.QuadStore, params.ByName("query_lang"))
+	if ses == nil {
+		return jsonResponse(w, 400, "Unknown query language.")
 	}
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/query/gremlin/environ.go
+++ b/query/gremlin/environ.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/graph/path"
 	"github.com/cayleygraph/cayley/quad"
+	"github.com/cayleygraph/cayley/query"
 )
 
 type worker struct {
@@ -34,7 +35,7 @@ type worker struct {
 	env *otto.Otto
 	sync.Mutex
 
-	results chan interface{}
+	results chan query.Result
 	shape   map[string]interface{}
 
 	count int

--- a/query/gremlin/session.go
+++ b/query/gremlin/session.go
@@ -15,12 +15,11 @@
 package gremlin
 
 import (
-	"errors"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/robertkrimen/otto"
+	"golang.org/x/net/context"
 	// Provide underscore JS library.
 	_ "github.com/robertkrimen/otto/underscore"
 
@@ -29,7 +28,17 @@ import (
 	"github.com/cayleygraph/cayley/query"
 )
 
-var ErrKillTimeout = errors.New("query timed out")
+var (
+	_ query.Session     = (*Session)(nil)
+	_ query.HTTP        = (*Session)(nil)
+	_ query.REPLSession = (*Session)(nil)
+)
+
+type errKilled struct {
+	Err error
+}
+
+func (e errKilled) Error() string { return e.Err.Error() }
 
 type Session struct {
 	qs graph.QuadStore
@@ -38,20 +47,17 @@ type Session struct {
 	script  *otto.Script
 	persist *otto.Otto
 
-	timeout time.Duration
-	kill    chan struct{}
+	kill chan struct{}
 
-	debug      bool
 	dataOutput []interface{}
 
 	err error
 }
 
-func NewSession(qs graph.QuadStore, timeout time.Duration, persist bool) *Session {
+func NewSession(qs graph.QuadStore, persist bool) *Session {
 	g := Session{
-		qs:      qs,
-		wk:      newWorker(qs),
-		timeout: timeout,
+		qs: qs,
+		wk: newWorker(qs),
 	}
 	if persist {
 		g.persist = g.wk.env
@@ -66,8 +72,18 @@ type Result struct {
 	actualResults map[string]graph.Value
 }
 
-func (s *Session) Debug(ok bool) {
-	s.debug = ok
+func (r *Result) Err() error { return r.err }
+func (r *Result) Result() interface{} {
+	if r.metaresult {
+		return nil
+	} else if r.val == nil {
+		if r.actualResults == nil {
+			return nil
+		}
+		return r.actualResults
+	} else {
+		return r.val
+	}
 }
 
 func (s *Session) ShapeOf(query string) (interface{}, error) {
@@ -80,22 +96,16 @@ func (s *Session) ShapeOf(query string) (interface{}, error) {
 	return out, nil
 }
 
-func (s *Session) Parse(input string) (query.ParseResult, error) {
-	script, err := s.wk.env.Compile("", input)
-	if err != nil {
-		return query.ParseFail, err
-	}
-	s.script = script
-	return query.Parsed, nil
-}
-
-func (s *Session) runUnsafe(input interface{}) (_ otto.Value, gerr error) {
+func (s *Session) runUnsafe(ctx context.Context, input interface{}) (_ otto.Value, gerr error) {
 	wk := s.wk
 	defer func() {
 		if r := recover(); r != nil {
-			if r == ErrKillTimeout {
-				s.err = ErrKillTimeout
+			if e, ok := r.(errKilled); ok {
+				s.err = e.Err
 				wk.env = s.persist
+				if gerr == nil {
+					gerr = e.Err
+				}
 				return
 			} else if err, ok := r.(error); ok {
 				gerr = err
@@ -112,22 +122,20 @@ func (s *Session) runUnsafe(input interface{}) (_ otto.Value, gerr error) {
 
 	done := make(chan struct{})
 	defer close(done)
-	if s.timeout >= 0 {
-		go func() {
-			select {
-			case <-done:
-			case <-time.After(s.timeout):
-				close(s.kill)
-				wk.Lock()
-				if wk.env != nil {
-					wk.env.Interrupt <- func() {
-						panic(ErrKillTimeout)
-					}
+	go func() {
+		select {
+		case <-done:
+		case <-ctx.Done(): // timeout or cancelled
+			close(s.kill)
+			wk.Lock()
+			if wk.env != nil {
+				wk.env.Interrupt <- func() {
+					panic(errKilled{ctx.Err()})
 				}
-				wk.Unlock()
 			}
-		}()
-	}
+			wk.Unlock()
+		}
+	}()
 
 	wk.Lock()
 	env := wk.env
@@ -135,16 +143,19 @@ func (s *Session) runUnsafe(input interface{}) (_ otto.Value, gerr error) {
 	return env.Run(input)
 }
 
-func (s *Session) Execute(input string, out chan interface{}, _ int) {
+func (s *Session) Execute(ctx context.Context, input string, out chan query.Result, _ int) {
+	// FIXME: use limit
 	defer close(out)
 	s.err = nil
 	s.wk.results = out
-	var err error
-	var value otto.Value
+	var (
+		err   error
+		value otto.Value
+	)
 	if s.script == nil {
-		value, err = s.runUnsafe(input)
+		value, err = s.runUnsafe(ctx, input)
 	} else {
-		value, err = s.runUnsafe(s.script)
+		value, err = s.runUnsafe(ctx, s.script)
 	}
 	out <- &Result{
 		metaresult: true,
@@ -158,7 +169,7 @@ func (s *Session) Execute(input string, out chan interface{}, _ int) {
 	s.wk.Unlock()
 }
 
-func (s *Session) Format(result interface{}) string {
+func (s *Session) FormatREPL(result query.Result) string {
 	data, ok := result.(*Result)
 	if !ok {
 		return fmt.Sprintf("Error: unexpected result type: %T\n", result)
@@ -212,34 +223,34 @@ func (s *Session) Format(result interface{}) string {
 }
 
 // Web stuff
-func (s *Session) Collate(result interface{}) {
+func (s *Session) Collate(result query.Result) {
 	data, ok := result.(*Result)
 	if !ok {
 		clog.Errorf("unexpected result type: %T", result)
 		return
+	} else if data.metaresult {
+		return
 	}
-	if !data.metaresult {
-		if data.val == nil {
-			obj := make(map[string]interface{})
-			tags := data.actualResults
-			var tagKeys []string
-			for k := range tags {
-				tagKeys = append(tagKeys, k)
-			}
-			sort.Strings(tagKeys)
-			for _, k := range tagKeys {
-				if name := s.qs.NameOf(tags[k]); name != nil {
-					obj[k] = quadValueToNative(name)
-				} else {
-					delete(obj, k)
-				}
-			}
-			if len(obj) != 0 {
-				s.dataOutput = append(s.dataOutput, obj)
-			}
+	if data.val != nil {
+		s.dataOutput = append(s.dataOutput, data.val)
+		return
+	}
+	obj := make(map[string]interface{})
+	tags := data.actualResults
+	var tagKeys []string
+	for k := range tags {
+		tagKeys = append(tagKeys, k)
+	}
+	sort.Strings(tagKeys)
+	for _, k := range tagKeys {
+		if name := s.qs.NameOf(tags[k]); name != nil {
+			obj[k] = quadValueToNative(name)
 		} else {
-			s.dataOutput = append(s.dataOutput, data.val)
+			delete(obj, k)
 		}
+	}
+	if len(obj) != 0 {
+		s.dataOutput = append(s.dataOutput, obj)
 	}
 }
 
@@ -248,12 +259,7 @@ func (s *Session) Results() (interface{}, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
-	select {
-	case <-s.kill:
-		return nil, ErrKillTimeout
-	default:
-		return s.dataOutput, nil
-	}
+	return s.dataOutput, nil
 }
 
 func (s *Session) Clear() {

--- a/query/gremlin/session.go
+++ b/query/gremlin/session.go
@@ -28,11 +28,22 @@ import (
 	"github.com/cayleygraph/cayley/query"
 )
 
-var (
-	_ query.Session     = (*Session)(nil)
-	_ query.HTTP        = (*Session)(nil)
-	_ query.REPLSession = (*Session)(nil)
-)
+const Name = "gremlin"
+
+func init() {
+	query.RegisterLanguage(query.Language{
+		Name: Name,
+		Session: func(qs graph.QuadStore) query.Session {
+			return NewSession(qs, false)
+		},
+		HTTP: func(qs graph.QuadStore) query.HTTP {
+			return NewSession(qs, false)
+		},
+		REPL: func(qs graph.QuadStore) query.REPLSession {
+			return NewSession(qs, true)
+		},
+	})
+}
 
 type errKilled struct {
 	Err error

--- a/query/mql/mql_test.go
+++ b/query/mql/mql_test.go
@@ -19,9 +19,12 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/cayleygraph/cayley/graph"
 	_ "github.com/cayleygraph/cayley/graph/memstore"
 	"github.com/cayleygraph/cayley/quad"
+	"github.com/cayleygraph/cayley/query"
 	_ "github.com/cayleygraph/cayley/writer"
 )
 
@@ -167,10 +170,10 @@ var testQueries = []struct {
 	},
 }
 
-func runQuery(g []quad.Quad, query string) interface{} {
+func runQuery(g []quad.Quad, qu string) interface{} {
 	s := makeTestSession(g)
-	c := make(chan interface{}, 5)
-	go s.Execute(query, c, -1)
+	c := make(chan query.Result, 5)
+	go s.Execute(context.TODO(), qu, c, -1)
 	for result := range c {
 		s.Collate(result)
 	}

--- a/query/mql/session.go
+++ b/query/mql/session.go
@@ -21,26 +21,24 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/query"
 )
 
+var (
+	_ query.Session     = (*Session)(nil)
+	_ query.HTTP        = (*Session)(nil)
+	_ query.REPLSession = (*Session)(nil)
+)
+
 type Session struct {
-	qs           graph.QuadStore
-	currentQuery *Query
-	debug        bool
+	qs    graph.QuadStore
+	query *Query
 }
 
 func NewSession(qs graph.QuadStore) *Session {
-	var m Session
-	m.qs = qs
-	return &m
-}
-
-func (s *Session) Debug(ok bool) {
-	s.debug = ok
+	return &Session{qs: qs}
 }
 
 func (s *Session) ShapeOf(query string) (interface{}, error) {
@@ -49,10 +47,10 @@ func (s *Session) ShapeOf(query string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.currentQuery = NewQuery(s)
-	s.currentQuery.BuildIteratorTree(mqlQuery)
+	s.query = NewQuery(s)
+	s.query.BuildIteratorTree(mqlQuery)
 	output := make(map[string]interface{})
-	iterator.OutputQueryShapeForIterator(s.currentQuery.it, s.qs, output)
+	iterator.OutputQueryShapeForIterator(s.query.it, s.qs, output)
 	nodes := make([]iterator.Node, 0)
 	for _, n := range output["nodes"].([]iterator.Node) {
 		n.Tags = nil
@@ -62,47 +60,51 @@ func (s *Session) ShapeOf(query string) (interface{}, error) {
 	return output, nil
 }
 
-func (s *Session) Parse(input string) (query.ParseResult, error) {
-	var x interface{}
-	err := json.Unmarshal([]byte(input), &x)
-	if err != nil {
-		return query.ParseFail, err
-	}
-	return query.Parsed, nil
-}
-
-func (s *Session) Execute(input string, c chan interface{}, limit int) {
+func (s *Session) Execute(ctx context.Context, input string, c chan query.Result, limit int) {
 	defer close(c)
 	var mqlQuery interface{}
-	err := json.Unmarshal([]byte(input), &mqlQuery)
-	if err != nil {
+	if err := json.Unmarshal([]byte(input), &mqlQuery); err != nil {
+		select {
+		case c <- query.ErrorResult(err):
+		case <-ctx.Done():
+		}
 		return
 	}
-	s.currentQuery = NewQuery(s)
-	s.currentQuery.BuildIteratorTree(mqlQuery)
-	if s.currentQuery.isError() {
+	s.query = NewQuery(s)
+	s.query.BuildIteratorTree(mqlQuery)
+	if s.query.isError() {
+		select {
+		case c <- query.ErrorResult(s.query.err):
+		case <-ctx.Done():
+		}
 		return
 	}
 
-	it := s.currentQuery.it
-	err = graph.Iterate(context.TODO(), it).Limit(limit).TagEach(func(tags map[string]graph.Value) {
-		c <- tags
+	it := s.query.it
+	err := graph.Iterate(ctx, it).Limit(limit).TagEach(func(tags map[string]graph.Value) {
+		select {
+		case c <- query.TagMapResult(tags):
+		case <-ctx.Done():
+		}
 	})
 	if err != nil {
-		clog.Errorf("mql: %v", err)
+		select {
+		case c <- query.ErrorResult(err):
+		case <-ctx.Done():
+		}
 	}
 }
 
-func (s *Session) Format(result interface{}) string {
-	tags, ok := result.(map[string]graph.Value)
+func (s *Session) FormatREPL(result query.Result) string {
+	tags, ok := result.Result().(map[string]graph.Value)
 	if !ok {
 		return ""
 	}
 	out := fmt.Sprintln("****")
 	tagKeys := make([]string, len(tags))
-	s.currentQuery.treeifyResult(tags)
-	s.currentQuery.buildResults()
-	r, _ := json.MarshalIndent(s.currentQuery.results, "", " ")
+	s.query.treeifyResult(tags)
+	s.query.buildResults()
+	r, _ := json.MarshalIndent(s.query.results, "", " ")
 	fmt.Println(string(r))
 	i := 0
 	for k := range tags {
@@ -119,20 +121,20 @@ func (s *Session) Format(result interface{}) string {
 	return out
 }
 
-func (s *Session) Collate(result interface{}) {
-	res, ok := result.(map[string]graph.Value)
+func (s *Session) Collate(result query.Result) {
+	res, ok := result.Result().(map[string]graph.Value)
 	if !ok {
 		return
 	}
-	s.currentQuery.treeifyResult(res)
+	s.query.treeifyResult(res)
 }
 
 func (s *Session) Results() (interface{}, error) {
-	s.currentQuery.buildResults()
-	if s.currentQuery.isError() {
-		return nil, s.currentQuery.err
+	s.query.buildResults()
+	if s.query.isError() {
+		return nil, s.query.err
 	}
-	return s.currentQuery.results, nil
+	return s.query.results, nil
 }
 
 func (s *Session) Clear() {

--- a/query/mql/session.go
+++ b/query/mql/session.go
@@ -26,11 +26,22 @@ import (
 	"github.com/cayleygraph/cayley/query"
 )
 
-var (
-	_ query.Session     = (*Session)(nil)
-	_ query.HTTP        = (*Session)(nil)
-	_ query.REPLSession = (*Session)(nil)
-)
+const Name = "mql"
+
+func init() {
+	query.RegisterLanguage(query.Language{
+		Name: Name,
+		Session: func(qs graph.QuadStore) query.Session {
+			return NewSession(qs)
+		},
+		HTTP: func(qs graph.QuadStore) query.HTTP {
+			return NewSession(qs)
+		},
+		REPL: func(qs graph.QuadStore) query.REPLSession {
+			return NewSession(qs)
+		},
+	})
+}
 
 type Session struct {
 	qs    graph.QuadStore

--- a/query/session.go
+++ b/query/session.go
@@ -70,3 +70,54 @@ type REPLSession interface {
 	Session
 	FormatREPL(Result) string
 }
+
+// Language is a description of query language.
+type Language struct {
+	Name    string
+	Session func(graph.QuadStore) Session
+	REPL    func(graph.QuadStore) REPLSession
+	HTTP    func(graph.QuadStore) HTTP
+}
+
+var languages = make(map[string]Language)
+
+// RegisterLanguage register a new query language.
+func RegisterLanguage(lang Language) {
+	languages[lang.Name] = lang
+}
+
+// NewSession creates a new session for specified query language.
+// It returns nil if language was not registered.
+func NewSession(qs graph.QuadStore, lang string) Session {
+	if l := languages[lang]; l.Session != nil {
+		return l.Session(qs)
+	}
+	return nil
+}
+
+// NewHTTPSession creates a new session for specified query language to serve via HTTP.
+// It returns nil if language was not registered.
+func NewHTTPSession(qs graph.QuadStore, lang string) HTTP {
+	if l := languages[lang]; l.HTTP != nil {
+		return l.HTTP(qs)
+	}
+	return nil
+}
+
+// NewREPLSession creates a new session for specified query language to serve via HTTP.
+// It returns nil if language was not registered.
+func NewREPLSession(qs graph.QuadStore, lang string) REPLSession {
+	if l := languages[lang]; l.REPL != nil {
+		return l.REPL(qs)
+	}
+	return nil
+}
+
+// Languages returns names of registered query languages.
+func Languages() []string {
+	out := make([]string, 0, len(languages))
+	for name := range languages {
+		out = append(out, name)
+	}
+	return out
+}

--- a/query/sexp/session.go
+++ b/query/sexp/session.go
@@ -27,10 +27,19 @@ import (
 	"github.com/cayleygraph/cayley/query"
 )
 
-var (
-	_ query.Session     = (*Session)(nil)
-	_ query.REPLSession = (*Session)(nil)
-)
+const Name = "sexp"
+
+func init() {
+	query.RegisterLanguage(query.Language{
+		Name: Name,
+		Session: func(qs graph.QuadStore) query.Session {
+			return NewSession(qs)
+		},
+		REPL: func(qs graph.QuadStore) query.REPLSession {
+			return NewSession(qs)
+		},
+	})
+}
 
 type Session struct {
 	qs graph.QuadStore

--- a/query/sexp/session.go
+++ b/query/sexp/session.go
@@ -23,27 +23,24 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/query"
 )
 
+var (
+	_ query.Session     = (*Session)(nil)
+	_ query.REPLSession = (*Session)(nil)
+)
+
 type Session struct {
-	qs    graph.QuadStore
-	debug bool
+	qs graph.QuadStore
 }
 
 func NewSession(qs graph.QuadStore) *Session {
-	var s Session
-	s.qs = qs
-	return &s
+	return &Session{qs: qs}
 }
 
-func (s *Session) Debug(ok bool) {
-	s.debug = ok
-}
-
-func (s *Session) Parse(input string) (query.ParseResult, error) {
+func (s *Session) Parse(input string) error {
 	var parenDepth int
 	for i, x := range input {
 		if x == '(' {
@@ -56,33 +53,39 @@ func (s *Session) Parse(input string) (query.ParseResult, error) {
 				if (i - 10) > min {
 					min = i - 10
 				}
-				return query.ParseFail, fmt.Errorf("too many close parentheses at char %d: %s", i, input[min:i])
+				return fmt.Errorf("too many close parentheses at char %d: %s", i, input[min:i])
 			}
 		}
 	}
 	if parenDepth > 0 {
-		return query.ParseMore, nil
+		return query.ErrParseMore
 	}
 	if len(ParseString(input)) > 0 {
-		return query.Parsed, nil
+		return nil
 	}
-	return query.ParseFail, errors.New("invalid syntax")
+	return errors.New("invalid syntax")
 }
 
-func (s *Session) Execute(input string, out chan interface{}, limit int) {
+func (s *Session) Execute(ctx context.Context, input string, out chan query.Result, limit int) {
 	defer close(out)
 	it := BuildIteratorTreeForQuery(s.qs, input)
-	err := graph.Iterate(context.TODO(), it).Paths(true).Limit(limit).TagEach(func(tags map[string]graph.Value) {
-		out <- &tags
+	err := graph.Iterate(ctx, it).Paths(true).Limit(limit).TagEach(func(tags map[string]graph.Value) {
+		select {
+		case out <- query.TagMapResult(tags):
+		case <-ctx.Done():
+		}
 	})
 	if err != nil {
-		clog.Errorf("sexp: %v", err)
+		select {
+		case out <- query.ErrorResult(err):
+		case <-ctx.Done():
+		}
 	}
 }
 
-func (s *Session) Format(result interface{}) string {
+func (s *Session) FormatREPL(result query.Result) string {
 	out := fmt.Sprintln("****")
-	tags, ok := result.(map[string]graph.Value)
+	tags, ok := result.Result().(map[string]graph.Value)
 	if !ok {
 		return ""
 	}


### PR DESCRIPTION
Change interfaces for query languages.

* use context for cancellation and timeouts
* specify exact type of results
* separate interface for REPL