### PR TITLE
Implement regex filter as iterator

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -240,6 +240,7 @@ const (
 	Unique
 	Limit
 	Skip
+	Regex
 )
 
 var (
@@ -264,6 +265,7 @@ var (
 		"unique",
 		"limit",
 		"skip",
+		"regex",
 	}
 )
 

--- a/graph/iterator/regex_iterator.go
+++ b/graph/iterator/regex_iterator.go
@@ -14,11 +14,6 @@
 
 package iterator
 
-// "Regex" is a unary operator -- a filter across the values in the relevant
-// subiterator. It works similarly to gremlin's filter{it.matches('exp')},
-// reducing the iterator set to values whose string representation passes a
-// regular expression test.
-
 import (
 	"regexp"
 
@@ -26,6 +21,10 @@ import (
 	"github.com/cayleygraph/cayley/quad"
 )
 
+// Regex is a unary operator -- a filter across the values in the relevant
+// subiterator. It works similarly to gremlin's filter{it.matches('exp')},
+// reducing the iterator set to values whose string representation passes a
+// regular expression test.
 type Regex struct {
 	uid    uint64
 	tags   graph.Tagger
@@ -70,6 +69,8 @@ func (it *Regex) Close() error {
 
 func (it *Regex) Reset() {
 	it.subIt.Reset()
+	it.err = nil
+	it.result = nil
 }
 
 func (it *Regex) Tagger() *graph.Tagger {
@@ -177,7 +178,7 @@ func (it *Regex) TagResults(dst map[string]graph.Value) {
 }
 
 func (it *Regex) Size() (int64, bool) {
-	return 0, true
+	return 0, false
 }
 
 var _ graph.Iterator = &Regex{}

--- a/graph/iterator/regex_iterator.go
+++ b/graph/iterator/regex_iterator.go
@@ -1,0 +1,183 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iterator
+
+// "Regex" is a unary operator -- a filter across the values in the relevant
+// subiterator. It works similarly to gremlin's filter{it.matches('exp')},
+// reducing the iterator set to values whose string representation passes a
+// regular expression test.
+
+import (
+	"regexp"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/quad"
+)
+
+type Regex struct {
+	uid    uint64
+	tags   graph.Tagger
+	subIt  graph.Iterator
+	re     *regexp.Regexp
+	qs     graph.QuadStore
+	result graph.Value
+	err    error
+}
+
+func NewRegex(sub graph.Iterator, re *regexp.Regexp, qs graph.QuadStore) *Regex {
+	return &Regex{
+		uid:   NextUID(),
+		subIt: sub,
+		re:    re,
+		qs:    qs,
+	}
+}
+
+func (it *Regex) testRegex(val graph.Value) bool {
+	// Type switch to avoid coercing and testing numeric types
+	switch tVal := it.qs.NameOf(val).(type) {
+	case quad.Raw:
+		return it.re.MatchString(string(tVal))
+	case quad.String:
+		return it.re.MatchString(string(tVal))
+	case quad.BNode:
+		return it.re.MatchString(string(tVal))
+	case quad.IRI:
+		return it.re.MatchString(string(tVal))
+	}
+	return false
+}
+
+func (it *Regex) UID() uint64 {
+	return it.uid
+}
+
+func (it *Regex) Close() error {
+	return it.subIt.Close()
+}
+
+func (it *Regex) Reset() {
+	it.subIt.Reset()
+}
+
+func (it *Regex) Tagger() *graph.Tagger {
+	return &it.tags
+}
+
+func (it *Regex) Clone() graph.Iterator {
+	out := NewRegex(it.subIt.Clone(), it.re, it.qs)
+	out.tags.CopyFrom(it)
+	return out
+}
+
+func (it *Regex) Next() bool {
+	for it.subIt.Next() {
+		val := it.subIt.Result()
+		if it.testRegex(val) {
+			it.result = val
+			return true
+		}
+	}
+	it.err = it.subIt.Err()
+	return false
+}
+
+func (it *Regex) Err() error {
+	return it.err
+}
+
+func (it *Regex) Result() graph.Value {
+	return it.result
+}
+
+func (it *Regex) NextPath() bool {
+	for {
+		hasNext := it.subIt.NextPath()
+		if !hasNext {
+			it.err = it.subIt.Err()
+			return false
+		}
+		if it.testRegex(it.subIt.Result()) {
+			break
+		}
+	}
+	it.result = it.subIt.Result()
+	return true
+}
+
+func (it *Regex) SubIterators() []graph.Iterator {
+	return []graph.Iterator{it.subIt}
+}
+
+func (it *Regex) Contains(val graph.Value) bool {
+	if !it.testRegex(val) {
+		return false
+	}
+	ok := it.subIt.Contains(val)
+	if !ok {
+		it.err = it.subIt.Err()
+	}
+	return ok
+}
+
+// Registers the Regex iterator.
+func (it *Regex) Type() graph.Type {
+	return graph.Regex
+}
+
+func (it *Regex) Describe() graph.Description {
+	primary := it.subIt.Describe()
+	return graph.Description{
+		UID:      it.UID(),
+		Type:     it.Type(),
+		Iterator: &primary,
+	}
+}
+
+// There's nothing to optimize, locally, for a Regex iterator.
+// Replace the underlying iterator if need be.
+func (it *Regex) Optimize() (graph.Iterator, bool) {
+	newSub, changed := it.subIt.Optimize()
+	if changed {
+		it.subIt.Close()
+		it.subIt = newSub
+	}
+	return it, false
+}
+
+// We're only as expensive as our subiterator.
+func (it *Regex) Stats() graph.IteratorStats {
+	return it.subIt.Stats()
+}
+
+// If we failed the check, then the subiterator should not contribute to the result
+// set. Otherwise, go ahead and tag it.
+func (it *Regex) TagResults(dst map[string]graph.Value) {
+	for _, tag := range it.tags.Tags() {
+		dst[tag] = it.Result()
+	}
+
+	for tag, value := range it.tags.Fixed() {
+		dst[tag] = value
+	}
+
+	it.subIt.TagResults(dst)
+}
+
+func (it *Regex) Size() (int64, bool) {
+	return 0, true
+}
+
+var _ graph.Iterator = &Regex{}

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -16,6 +16,7 @@ package path
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
@@ -58,6 +59,16 @@ func isMorphism(nodes ...quad.Value) morphism {
 			// Anything with fixedIterators will usually have a much
 			// smaller result set, so join isNodes first here.
 			return join(qs, isNodes, in), ctx
+		},
+	}
+}
+
+func regexMorphism(pattern *regexp.Regexp) morphism {
+	return morphism{
+		Name:     "regex",
+		Reversal: func(ctx *pathContext) (morphism, *pathContext) { return regexMorphism(pattern), ctx },
+		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *pathContext) (graph.Iterator, *pathContext) {
+			return iterator.NewRegex(in, pattern, qs), ctx
 		},
 	}
 }

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -15,6 +15,8 @@
 package path
 
 import (
+	"regexp"
+
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/quad"
@@ -144,6 +146,12 @@ func (p *Path) Reverse() *Path {
 func (p *Path) Is(nodes ...quad.Value) *Path {
 	np := p.clone()
 	np.stack = append(np.stack, isMorphism(nodes...))
+	return np
+}
+
+func (p *Path) Regex(pattern *regexp.Regexp) *Path {
+	np := p.clone()
+	np.stack = append(np.stack, regexMorphism(pattern))
 	return np
 }
 

--- a/graph/path/path_test.go
+++ b/graph/path/path_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -142,6 +143,11 @@ func testSet(qs graph.QuadStore) []test {
 			message: "use in with filter",
 			path:    StartPath(qs, vBob).In(vFollows).Filter(iterator.CompareGT, quad.IRI("c")),
 			expect:  []quad.Value{vCharlie, vDani},
+		},
+		{
+			message: "use in with regex",
+			path:    StartPath(qs, vBob).In(vFollows).Regex(regexp.MustCompile("ar?li.*e")),
+			expect:  []quad.Value{vAlice, vCharlie},
 		},
 		{
 			message: "use path Out",


### PR DESCRIPTION
Provides a new filtering path `.Regex`. The implementation largely mirrors that of `.Filter`