### PR TITLE
Ability to pass the Mongo Backend an externally managed session.

### DIFF
--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -175,6 +175,16 @@ func newQuadStore(addr string, options graph.Options) (graph.QuadStore, error) {
 	return &qs, nil
 }
 
+func (qs *QuadStore) Copy() *QuadStore {
+	nqs := *qs
+	nqs.session = qs.session.Copy()
+	return &nqs
+}
+
+func (qs *QuadStore) Release() {
+	qs.session.Close()
+}
+
 func (qs *QuadStore) getIDForQuad(t quad.Quad) string {
 	id := hashOf(t.Subject)
 	id += hashOf(t.Predicate)


### PR DESCRIPTION
This PR allows users to pass Cayley an optional mgo session to use for connecting to Cayley.  When the session is passed, a new connection is not dialed.  This provides an advantage for users managing many concurrent requests, who have already implemented logic to manage a pool of mgo sessions outside of Cayley.  