### PR TITLE
Support SQL flavors: Mysql, CockroachDB

### DIFF
--- a/graph/graphtest/graphtest.go
+++ b/graph/graphtest/graphtest.go
@@ -2,6 +2,7 @@ package graphtest
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 	"time"
@@ -66,9 +67,20 @@ func MakeWriter(t testing.TB, qs graph.QuadStore, opts graph.Options, data ...qu
 }
 
 func LoadGraph(t testing.TB, path string) []quad.Quad {
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("Failed to open %q: %v", path, err)
+	var (
+		f   *os.File
+		err error
+	)
+	const levels = 3
+	for i := 0; i < levels; i++ {
+		f, err = os.Open(path)
+		if i+1 < levels && os.IsNotExist(err) {
+			path = filepath.Join("../", path)
+		} else if err != nil {
+			t.Fatalf("Failed to open %q: %v", path, err)
+		} else {
+			break
+		}
 	}
 	defer f.Close()
 	dec := nquads.NewReader(f, false)

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -46,7 +46,7 @@ import (
 //            +--------+
 
 func makeTestStore(t testing.TB, fnc graphtest.DatabaseFunc) (graph.QuadStore, func()) {
-	simpleGraph := graphtest.LoadGraph(t, "../../data/testdata.nq")
+	simpleGraph := graphtest.LoadGraph(t, "data/testdata.nq")
 	var (
 		qs     graph.QuadStore
 		opts   graph.Options

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -61,27 +61,26 @@ func makeTestStore(t testing.TB, fnc graphtest.DatabaseFunc) (graph.QuadStore, f
 	return qs, closer
 }
 
-func runTopLevel(qs graph.QuadStore, path *Path, opt bool) []quad.Value {
+func runTopLevel(qs graph.QuadStore, path *Path, opt bool) ([]quad.Value, error) {
 	pb := path.Iterate(context.TODO())
 	if !opt {
 		pb = pb.UnOptimized()
 	}
-	out, _ := pb.Paths(false).AllValues(qs)
-	return out
+	return pb.Paths(false).AllValues(qs)
 }
 
-func runTag(qs graph.QuadStore, path *Path, tag string, opt bool) []quad.Value {
+func runTag(qs graph.QuadStore, path *Path, tag string, opt bool) ([]quad.Value, error) {
 	var out []quad.Value
 	pb := path.Iterate(context.TODO())
 	if !opt {
 		pb = pb.UnOptimized()
 	}
-	_ = pb.Paths(true).TagEach(func(tags map[string]graph.Value) {
+	err := pb.Paths(true).TagEach(func(tags map[string]graph.Value) {
 		if t, ok := tags[tag]; ok {
 			out = append(out, qs.NameOf(t))
 		}
 	})
-	return out
+	return out, err
 }
 
 type test struct {
@@ -350,19 +349,26 @@ func RunTestMorphisms(t testing.TB, fnc graphtest.DatabaseFunc) {
 	defer closer()
 
 	for _, test := range testSet(qs) {
-		var got []quad.Value
+		var (
+			got []quad.Value
+			err error
+		)
 		for _, opt := range []bool{true, false} {
 			if test.tag == "" {
-				got = runTopLevel(qs, test.path, opt)
+				got, err = runTopLevel(qs, test.path, opt)
 			} else {
-				got = runTag(qs, test.path, test.tag, opt)
+				got, err = runTag(qs, test.path, test.tag, opt)
 			}
-			sort.Sort(quad.ByValueString(got))
-			sort.Sort(quad.ByValueString(test.expect))
 			unopt := ""
 			if !opt {
 				unopt = " (unoptimized)"
 			}
+			if err != nil {
+				t.Errorf("Failed to %s%s: %v", test.message, unopt, err)
+				continue
+			}
+			sort.Sort(quad.ByValueString(got))
+			sort.Sort(quad.ByValueString(test.expect))
 			eq := reflect.DeepEqual(got, test.expect)
 			if !eq && test.expectAlt != nil {
 				eq = reflect.DeepEqual(got, test.expectAlt)

--- a/graph/sql/cockroach.go
+++ b/graph/sql/cockroach.go
@@ -1,0 +1,207 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/lib/pq"
+	"strconv"
+	"strings"
+)
+
+const flavorCockroach = "cockroach"
+
+func init() {
+	RegisterFlavor(Flavor{
+		Name:   flavorCockroach,
+		Driver: flavorPostgres,
+		NodesTable: `CREATE TABLE nodes (
+	hash BYTEA PRIMARY KEY,
+	value BYTEA,
+	value_string TEXT,
+	datatype TEXT,
+	language TEXT,
+	iri BOOLEAN,
+	bnode BOOLEAN,
+	value_int BIGINT,
+	value_bool BOOLEAN,
+	value_float double precision,
+	value_time timestamp with time zone,
+	FAMILY fhash (hash),
+	FAMILY fvalue (value, value_string, datatype, language, iri, bnode,
+		value_int, value_bool, value_float, value_time)
+);`,
+		QuadsTable: `CREATE TABLE quads (
+	horizon BIGSERIAL PRIMARY KEY,
+	subject_hash BYTEA NOT NULL,
+	predicate_hash BYTEA NOT NULL,
+	object_hash BYTEA NOT NULL,
+	label_hash BYTEA,
+	id BIGINT,
+	ts timestamp
+);`,
+		FieldQuote:  '"',
+		Placeholder: func(n int) string { return fmt.Sprintf("$%d", n) },
+		Indexes: func(options graph.Options) []string {
+			return []string{
+				`CREATE UNIQUE INDEX spol_unique ON quads (subject_hash, predicate_hash, object_hash, label_hash);`,
+				`CREATE UNIQUE INDEX spo_unique ON quads (subject_hash, predicate_hash, object_hash);`,
+				`CREATE INDEX spo_index ON quads (subject_hash);`,
+				`CREATE INDEX pos_index ON quads (predicate_hash);`,
+				`CREATE INDEX osp_index ON quads (object_hash);`,
+				//`ALTER TABLE quads ADD CONSTRAINT subject_hash_fk FOREIGN KEY (subject_hash) REFERENCES nodes (hash);`,
+				//`ALTER TABLE quads ADD CONSTRAINT predicate_hash_fk FOREIGN KEY (predicate_hash) REFERENCES nodes (hash);`,
+				//`ALTER TABLE quads ADD CONSTRAINT object_hash_fk FOREIGN KEY (object_hash) REFERENCES nodes (hash);`,
+				//`ALTER TABLE quads ADD CONSTRAINT label_hash_fk FOREIGN KEY (label_hash) REFERENCES nodes (hash);`,
+			}
+		},
+		Error: func(err error) error {
+			e, ok := err.(*pq.Error)
+			if !ok {
+				return err
+			}
+			switch e.Code {
+			case "42P07":
+				return graph.ErrDatabaseExists
+			}
+			return err
+		},
+		//Estimated: func(table string) string{
+		//	return "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='"+table+"';"
+		//},
+		RunTx: runTxCockroach,
+	})
+}
+
+func runTxCockroach(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
+	//allAdds := true
+	//for _, d := range in {
+	//	if d.Action != graph.Add {
+	//		allAdds = false
+	//	}
+	//}
+	//if allAdds && !opts.IgnoreDup {
+	//	return qs.copyFrom(tx, in, opts)
+	//}
+
+	end := ";"
+	if true || opts.IgnoreDup {
+		end = " ON CONFLICT (subject_hash, predicate_hash, object_hash) DO NOTHING;"
+	}
+
+	var (
+		insertQuad  *sql.Stmt
+		insertValue map[int]*sql.Stmt     // prepared statements for each value type
+		inserted    map[NodeHash]struct{} // tracks already inserted values
+
+		deleteQuad   *sql.Stmt
+		deleteTriple *sql.Stmt
+	)
+
+	var err error
+	for _, d := range in {
+		switch d.Action {
+		case graph.Add:
+			if insertQuad == nil {
+				insertQuad, err = tx.Prepare(`INSERT INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES ($1, $2, $3, $4, $5, $6)` + end)
+				if err != nil {
+					return err
+				}
+				insertValue = make(map[int]*sql.Stmt)
+				inserted = make(map[NodeHash]struct{}, len(in))
+			}
+			var hs, hp, ho, hl NodeHash
+			for _, dir := range quad.Directions {
+				v := d.Quad.Get(dir)
+				if v == nil {
+					continue
+				}
+				h := hashOf(v)
+				switch dir {
+				case quad.Subject:
+					hs = h
+				case quad.Predicate:
+					hp = h
+				case quad.Object:
+					ho = h
+				case quad.Label:
+					hl = h
+				}
+				if !h.Valid() {
+					continue
+				} else if _, ok := inserted[h]; ok {
+					continue
+				}
+				nodeKey, values, err := nodeValues(h, v)
+				if err != nil {
+					return err
+				}
+				stmt, ok := insertValue[nodeKey]
+				if !ok {
+					var ph = make([]string, len(values)-1)
+					for i := range ph {
+						ph[i] = "$" + strconv.FormatInt(int64(i)+2, 10)
+					}
+					stmt, err = tx.Prepare(`INSERT INTO nodes(hash, ` +
+						strings.Join(nodeInsertColumns[nodeKey], ", ") +
+						`) VALUES ($1, ` +
+						strings.Join(ph, ", ") +
+						`) ON CONFLICT (hash) DO NOTHING;`)
+					if err != nil {
+						return err
+					}
+					insertValue[nodeKey] = stmt
+				}
+				_, err = stmt.Exec(values...)
+				if err != nil {
+					clog.Errorf("couldn't exec INSERT statement: %v", err)
+					return err
+				}
+				inserted[h] = struct{}{}
+			}
+			_, err := insertQuad.Exec(
+				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
+				d.ID.Int(),
+				d.Timestamp,
+			)
+			if err != nil {
+				clog.Errorf("couldn't exec INSERT statement: %v", err)
+				return err
+			}
+		case graph.Delete:
+			if deleteQuad == nil {
+				deleteQuad, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash=$4;`)
+				if err != nil {
+					return err
+				}
+				deleteTriple, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash is null;`)
+				if err != nil {
+					return err
+				}
+			}
+			var result sql.Result
+			if d.Quad.Label == nil {
+				result, err = deleteTriple.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL())
+			} else {
+				result, err = deleteQuad.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL(), hashOf(d.Quad.Label).toSQL())
+			}
+			if err != nil {
+				clog.Errorf("couldn't exec DELETE statement: %v", err)
+				return err
+			}
+			affected, err := result.RowsAffected()
+			if err != nil {
+				clog.Errorf("couldn't get DELETE RowsAffected: %v", err)
+				return err
+			}
+			if affected != 1 && !opts.IgnoreMissing {
+				return graph.ErrQuadNotExist
+			}
+		default:
+			panic("unknown action")
+		}
+	}
+	return nil
+}

--- a/graph/sql/cockroach_test.go
+++ b/graph/sql/cockroach_test.go
@@ -1,3 +1,5 @@
+// +build docker
+
 package sql
 
 import (
@@ -15,7 +17,7 @@ import (
 func makeCockroach(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 	var conf dock.Config // TODO
 
-	conf.Image = "cockroachdb/cockroach:beta-20161103"
+	conf.Image = "cockroachdb/cockroach:beta-20170112"
 	conf.Cmd = []string{"start", "--insecure"}
 
 	opts := graph.Options{"flavor": flavorCockroach}

--- a/graph/sql/cockroach_test.go
+++ b/graph/sql/cockroach_test.go
@@ -1,0 +1,87 @@
+package sql
+
+import (
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/graphtest"
+	"github.com/cayleygraph/cayley/graph/path/pathtest"
+	"github.com/cayleygraph/cayley/internal/dock"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"unicode/utf8"
+)
+
+func makeCockroach(t testing.TB) (graph.QuadStore, graph.Options, func()) {
+	var conf dock.Config // TODO
+
+	conf.Image = "cockroachdb/cockroach:beta-20161103"
+	conf.Cmd = []string{"start", "--insecure"}
+
+	opts := graph.Options{"flavor": flavorCockroach}
+
+	addr, closer := dock.RunAndWait(t, conf, func(addr string) bool {
+		conn, err := pq.Open(`postgresql://root@` + addr + `:26257?sslmode=disable`)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	})
+	db, err := connect(`postgresql://root@`+addr+`:26257?sslmode=disable`, flavorPostgres, nil)
+	if err != nil {
+		closer()
+		t.Fatal(err)
+	} else if _, err = db.Exec("CREATE DATABASE cayley"); err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	db.Close()
+	addr = `postgresql://root@` + addr + `:26257/cayley?sslmode=disable`
+	if err := createSQLTables(addr, opts); err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	qs, err := newQuadStore(addr, opts)
+	if err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	return qs, nil, func() {
+		qs.Close()
+		closer()
+	}
+}
+
+func TestCockroachAll(t *testing.T) {
+	graphtest.TestAll(t, makeCockroach, &graphtest.Config{
+		TimeInMcs:               true,
+		TimeRound:               true,
+		SkipIntHorizon:          true,
+		SkipNodeDelAfterQuadDel: true,
+	})
+}
+
+func TestCockroachZeroRune(t *testing.T) {
+	qs, opts, closer := makeCockroach(t)
+	defer closer()
+
+	w := graphtest.MakeWriter(t, qs, opts)
+
+	obj := quad.String("AB\u0000CD")
+	if !utf8.ValidString(string(obj)) {
+		t.Fatal("invalid utf8")
+	}
+
+	err := w.AddQuad(quad.Quad{
+		Subject:   quad.IRI("bob"),
+		Predicate: quad.IRI("pred"),
+		Object:    obj,
+	})
+	require.Nil(t, err)
+	require.Equal(t, obj, qs.NameOf(qs.ValueOf(quad.Raw(obj.String()))))
+}
+
+func TestCockroachPaths(t *testing.T) {
+	pathtest.RunTestMorphisms(t, makeCockroach)
+}

--- a/graph/sql/mysql.go
+++ b/graph/sql/mysql.go
@@ -1,0 +1,189 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/quad"
+	_ "github.com/go-sql-driver/mysql"
+	"strings"
+)
+
+const flavorMysql = "mysql"
+
+func init() {
+	hs := fmt.Sprint(quad.HashSize)
+	RegisterFlavor(Flavor{
+		Name: flavorMysql,
+		NodesTable: `CREATE TABLE nodes (
+	hash BINARY(` + hs + `) PRIMARY KEY,
+	value BLOB,
+	value_string TEXT,
+	datatype TEXT,
+	language TEXT,
+	iri BOOLEAN,
+	bnode BOOLEAN,
+	value_int BIGINT,
+	value_bool BOOLEAN,
+	value_float double precision,
+	value_time DATETIME(6)
+);`,
+		QuadsTable: `CREATE TABLE quads (
+	horizon SERIAL PRIMARY KEY,
+	subject_hash BINARY(` + hs + `) NOT NULL,
+	predicate_hash BINARY(` + hs + `) NOT NULL,
+	object_hash BINARY(` + hs + `) NOT NULL,
+	label_hash BINARY(` + hs + `),
+	id BIGINT,
+	ts timestamp
+);`,
+		FieldQuote:  '`',
+		Placeholder: func(n int) string { return "?" },
+		Indexes: func(options graph.Options) []string {
+			return []string{
+				`CREATE UNIQUE INDEX spo_unique ON quads (subject_hash, predicate_hash, object_hash);`,
+				`CREATE UNIQUE INDEX spol_unique ON quads (subject_hash, predicate_hash, object_hash, label_hash);`,
+				`CREATE INDEX spo_index ON quads (subject_hash);`,
+				`CREATE INDEX pos_index ON quads (predicate_hash);`,
+				`CREATE INDEX osp_index ON quads (object_hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT subject_hash_fk FOREIGN KEY (subject_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT predicate_hash_fk FOREIGN KEY (predicate_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT object_hash_fk FOREIGN KEY (object_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT label_hash_fk FOREIGN KEY (label_hash) REFERENCES nodes (hash);`,
+			}
+		},
+		Error: func(err error) error {
+			return err
+		},
+		Estimated: nil,
+		RunTx:     runTxMysql,
+	})
+}
+
+func runTxMysql(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
+	ignore := ""
+	if opts.IgnoreDup {
+		ignore = " IGNORE"
+	}
+
+	var (
+		insertQuad  *sql.Stmt
+		insertValue map[int]*sql.Stmt     // prepared statements for each value type
+		inserted    map[NodeHash]struct{} // tracks already inserted values
+
+		deleteQuad   *sql.Stmt
+		deleteTriple *sql.Stmt
+	)
+
+	var err error
+	for _, d := range in {
+		switch d.Action {
+		case graph.Add:
+			if insertQuad == nil {
+				insertQuad, err = tx.Prepare(`INSERT` + ignore + ` INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES (?, ?, ?, ?, ?, ?);`)
+				if err != nil {
+					return err
+				}
+				insertValue = make(map[int]*sql.Stmt)
+				inserted = make(map[NodeHash]struct{}, len(in))
+			}
+			var hs, hp, ho, hl NodeHash
+			for _, dir := range quad.Directions {
+				v := d.Quad.Get(dir)
+				if v == nil {
+					continue
+				}
+				h := hashOf(v)
+				switch dir {
+				case quad.Subject:
+					hs = h
+				case quad.Predicate:
+					hp = h
+				case quad.Object:
+					ho = h
+				case quad.Label:
+					hl = h
+				}
+				if !h.Valid() {
+					continue
+				} else if _, ok := inserted[h]; ok {
+					continue
+				}
+				nodeKey, values, err := nodeValues(h, v)
+				if err != nil {
+					return err
+				}
+				stmt, ok := insertValue[nodeKey]
+				if !ok {
+					var ph = make([]string, len(values)-1)
+					for i := range ph {
+						ph[i] = "?"
+					}
+					stmt, err = tx.Prepare(`INSERT IGNORE INTO nodes(hash, ` +
+						strings.Join(nodeInsertColumns[nodeKey], ", ") +
+						`) VALUES (?, ` +
+						strings.Join(ph, ", ") +
+						`);`)
+					if err != nil {
+						return err
+					}
+					insertValue[nodeKey] = stmt
+				}
+				_, err = stmt.Exec(values...)
+				err = convInsertErrorMySql(err)
+				if err != nil {
+					clog.Errorf("couldn't exec INSERT statement: %v", err)
+					return err
+				}
+				inserted[h] = struct{}{}
+			}
+			_, err := insertQuad.Exec(
+				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
+				d.ID.Int(),
+				d.Timestamp,
+			)
+			err = convInsertErrorMySql(err)
+			if err != nil {
+				clog.Errorf("couldn't exec INSERT statement: %v", err)
+				return err
+			}
+		case graph.Delete:
+			if deleteQuad == nil {
+				deleteQuad, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=? and predicate_hash=? and object_hash=? and label_hash=?;`)
+				if err != nil {
+					return err
+				}
+				deleteTriple, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=? and predicate_hash=? and object_hash=? and label_hash is null;`)
+				if err != nil {
+					return err
+				}
+			}
+			var result sql.Result
+			if d.Quad.Label == nil {
+				result, err = deleteTriple.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL())
+			} else {
+				result, err = deleteQuad.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL(), hashOf(d.Quad.Label).toSQL())
+			}
+			if err != nil {
+				clog.Errorf("couldn't exec DELETE statement: %v", err)
+				return err
+			}
+			affected, err := result.RowsAffected()
+			if err != nil {
+				clog.Errorf("couldn't get DELETE RowsAffected: %v", err)
+				return err
+			}
+			if affected != 1 && !opts.IgnoreMissing {
+				return graph.ErrQuadNotExist
+			}
+		default:
+			panic("unknown action")
+		}
+	}
+	return nil
+}
+
+func convInsertErrorMySql(err error) error {
+	return err // TODO
+}

--- a/graph/sql/mysql_test.go
+++ b/graph/sql/mysql_test.go
@@ -1,3 +1,5 @@
+// +build docker
+
 package sql
 
 import (

--- a/graph/sql/mysql_test.go
+++ b/graph/sql/mysql_test.go
@@ -1,0 +1,62 @@
+package sql
+
+import (
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/graphtest"
+	"github.com/cayleygraph/cayley/graph/path/pathtest"
+	"github.com/cayleygraph/cayley/internal/dock"
+	_ "github.com/go-sql-driver/mysql"
+	"net"
+	"testing"
+	"time"
+)
+
+func makeMysql(t testing.TB) (graph.QuadStore, graph.Options, func()) {
+	var conf dock.Config
+
+	conf.Image = "mysql:5.7"
+	conf.Tty = true
+	conf.Env = []string{
+		`MYSQL_ROOT_PASSWORD=root`,
+		`MYSQL_DATABASE=testdb`,
+	}
+
+	opts := graph.Options{"flavor": flavorMysql}
+
+	const wait = time.Second * 5
+	addr, closer := dock.RunAndWait(t, conf, func(addr string) bool {
+		start := time.Now()
+		c, err := net.DialTimeout("tcp", addr+":3306", wait)
+		if err == nil {
+			c.Close()
+		} else if dt := time.Since(start); dt < wait {
+			time.Sleep(wait - dt)
+		}
+		return err == nil
+	})
+	addr = `root:root@tcp(` + addr + `:3306)/testdb`
+	if err := createSQLTables(addr, opts); err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	qs, err := newQuadStore(addr, opts)
+	if err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	return qs, nil, func() {
+		qs.Close()
+		closer()
+	}
+}
+
+func TestMysqlAll(t *testing.T) {
+	graphtest.TestAll(t, makeMysql, &graphtest.Config{
+		TimeInMcs:               true,
+		SkipNodeDelAfterQuadDel: true,
+	})
+}
+
+func TestMysqlPaths(t *testing.T) {
+	pathtest.RunTestMorphisms(t, makeMysql)
+}

--- a/graph/sql/optimizers_test.go
+++ b/graph/sql/optimizers_test.go
@@ -28,7 +28,7 @@ func TestBuildIntersect(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	s, v := it.sql.buildSQL(true, nil)
+	s, v := it.sql.buildSQL(&Flavor{}, true, nil)
 	t.Log(s, v)
 }
 
@@ -44,7 +44,7 @@ func TestBuildHasa(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	s, v := it2.sql.buildSQL(true, nil)
+	s, v := it2.sql.buildSQL(&Flavor{}, true, nil)
 	t.Log(s, v)
 }
 
@@ -64,7 +64,7 @@ func TestBuildLinksTo(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	s, v := it3.sql.buildSQL(true, nil)
+	s, v := it3.sql.buildSQL(&Flavor{}, true, nil)
 	t.Log(s, v)
 }
 
@@ -114,7 +114,7 @@ func TestInterestingQuery(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	s, v := it8.sql.buildSQL(true, nil)
+	s, v := it8.sql.buildSQL(&Flavor{}, true, nil)
 	it8.Tagger().Add("id")
 	t.Log(s, v)
 	for it8.Next() {

--- a/graph/sql/postgres.go
+++ b/graph/sql/postgres.go
@@ -1,0 +1,263 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/lib/pq"
+	"strconv"
+	"strings"
+)
+
+const flavorPostgres = "postgres"
+
+const defaultFillFactor = 50
+
+func init() {
+	RegisterFlavor(Flavor{
+		Name: flavorPostgres,
+		NodesTable: `CREATE TABLE nodes (
+	hash BYTEA PRIMARY KEY,
+	value BYTEA,
+	value_string TEXT,
+	datatype TEXT,
+	language TEXT,
+	iri BOOLEAN,
+	bnode BOOLEAN,
+	value_int BIGINT,
+	value_bool BOOLEAN,
+	value_float double precision,
+	value_time timestamp with time zone
+);`,
+		QuadsTable: `CREATE TABLE quads (
+	horizon BIGSERIAL PRIMARY KEY,
+	subject_hash BYTEA NOT NULL,
+	predicate_hash BYTEA NOT NULL,
+	object_hash BYTEA NOT NULL,
+	label_hash BYTEA,
+	id BIGINT,
+	ts timestamp
+);`,
+		FieldQuote:  '"',
+		Placeholder: func(n int) string { return fmt.Sprintf("$%d", n) },
+		Indexes: func(options graph.Options) []string {
+			factor, factorOk, _ := options.IntKey("db_fill_factor")
+			if !factorOk {
+				factor = defaultFillFactor
+			}
+			return []string{
+				`CREATE UNIQUE INDEX spol_unique ON quads (subject_hash, predicate_hash, object_hash, label_hash) WHERE label_hash IS NOT NULL;`,
+				`CREATE UNIQUE INDEX spo_unique ON quads (subject_hash, predicate_hash, object_hash) WHERE label_hash IS NULL;`,
+				`ALTER TABLE quads ADD CONSTRAINT subject_hash_fk FOREIGN KEY (subject_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT predicate_hash_fk FOREIGN KEY (predicate_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT object_hash_fk FOREIGN KEY (object_hash) REFERENCES nodes (hash);`,
+				`ALTER TABLE quads ADD CONSTRAINT label_hash_fk FOREIGN KEY (label_hash) REFERENCES nodes (hash);`,
+				fmt.Sprintf(`CREATE INDEX spo_index ON quads (subject_hash) WITH (FILLFACTOR = %d);`, factor),
+				fmt.Sprintf(`CREATE INDEX pos_index ON quads (predicate_hash) WITH (FILLFACTOR = %d);`, factor),
+				fmt.Sprintf(`CREATE INDEX osp_index ON quads (object_hash) WITH (FILLFACTOR = %d);`, factor),
+			}
+		},
+		Error: func(err error) error {
+			e, ok := err.(*pq.Error)
+			if !ok {
+				return err
+			}
+			switch e.Code {
+			case "42P07":
+				return graph.ErrDatabaseExists
+			}
+			return err
+		},
+		Estimated: func(table string) string {
+			return "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='" + table + "';"
+		},
+		RunTx: runTxPostgres,
+	})
+}
+
+func convInsertErrorPG(err error) error {
+	if err == nil {
+		return err
+	}
+	if pe, ok := err.(*pq.Error); ok {
+		if pe.Code == "23505" {
+			return graph.ErrQuadExists
+		}
+	}
+	return err
+}
+
+func copyFromPG(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
+	panic("broken")
+	stmt, err := tx.Prepare(pq.CopyIn("quads", "subject", "predicate", "object", "label", "id", "ts", "subject_hash", "predicate_hash", "object_hash", "label_hash"))
+	if err != nil {
+		clog.Errorf("couldn't prepare COPY statement: %v", err)
+		return err
+	}
+	for _, d := range in {
+		s, p, o, l, err := marshalQuadDirections(d.Quad)
+		if err != nil {
+			clog.Errorf("couldn't marshal quads: %v", err)
+			return err
+		}
+		_, err = stmt.Exec(
+			s,
+			p,
+			o,
+			l,
+			d.ID.Int(),
+			d.Timestamp,
+			hashOf(d.Quad.Subject),
+			hashOf(d.Quad.Predicate),
+			hashOf(d.Quad.Object),
+			hashOf(d.Quad.Label),
+		)
+		if err != nil {
+			err = convInsertErrorPG(err)
+			clog.Errorf("couldn't execute COPY statement: %v", err)
+			return err
+		}
+	}
+	_, err = stmt.Exec()
+	if err != nil {
+		err = convInsertErrorPG(err)
+		return err
+	}
+	_ = stmt.Close() // COPY will be closed on last Exec, this will return non-nil error in all cases
+	return nil
+}
+
+func runTxPostgres(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
+	//allAdds := true
+	//for _, d := range in {
+	//	if d.Action != graph.Add {
+	//		allAdds = false
+	//	}
+	//}
+	//if allAdds && !opts.IgnoreDup {
+	//	return qs.copyFrom(tx, in, opts)
+	//}
+
+	end := ";"
+	if opts.IgnoreDup {
+		end = " ON CONFLICT DO NOTHING;"
+	}
+
+	var (
+		insertQuad  *sql.Stmt
+		insertValue map[int]*sql.Stmt     // prepared statements for each value type
+		inserted    map[NodeHash]struct{} // tracks already inserted values
+
+		deleteQuad   *sql.Stmt
+		deleteTriple *sql.Stmt
+	)
+
+	var err error
+	for _, d := range in {
+		switch d.Action {
+		case graph.Add:
+			if insertQuad == nil {
+				insertQuad, err = tx.Prepare(`INSERT INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES ($1, $2, $3, $4, $5, $6)` + end)
+				if err != nil {
+					return err
+				}
+				insertValue = make(map[int]*sql.Stmt)
+				inserted = make(map[NodeHash]struct{}, len(in))
+			}
+			var hs, hp, ho, hl NodeHash
+			for _, dir := range quad.Directions {
+				v := d.Quad.Get(dir)
+				if v == nil {
+					continue
+				}
+				h := hashOf(v)
+				switch dir {
+				case quad.Subject:
+					hs = h
+				case quad.Predicate:
+					hp = h
+				case quad.Object:
+					ho = h
+				case quad.Label:
+					hl = h
+				}
+				if !h.Valid() {
+					continue
+				} else if _, ok := inserted[h]; ok {
+					continue
+				}
+				nodeKey, values, err := nodeValues(h, v)
+				if err != nil {
+					return err
+				}
+				stmt, ok := insertValue[nodeKey]
+				if !ok {
+					var ph = make([]string, len(values)-1)
+					for i := range ph {
+						ph[i] = "$" + strconv.FormatInt(int64(i)+2, 10)
+					}
+					stmt, err = tx.Prepare(`INSERT INTO nodes(hash, ` +
+						strings.Join(nodeInsertColumns[nodeKey], ", ") +
+						`) VALUES ($1, ` +
+						strings.Join(ph, ", ") +
+						`) ON CONFLICT DO NOTHING;`)
+					if err != nil {
+						return err
+					}
+					insertValue[nodeKey] = stmt
+				}
+				_, err = stmt.Exec(values...)
+				err = convInsertErrorPG(err)
+				if err != nil {
+					clog.Errorf("couldn't exec INSERT statement: %v", err)
+					return err
+				}
+				inserted[h] = struct{}{}
+			}
+			_, err := insertQuad.Exec(
+				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
+				d.ID.Int(),
+				d.Timestamp,
+			)
+			err = convInsertErrorPG(err)
+			if err != nil {
+				clog.Errorf("couldn't exec INSERT statement: %v", err)
+				return err
+			}
+		case graph.Delete:
+			if deleteQuad == nil {
+				deleteQuad, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash=$4;`)
+				if err != nil {
+					return err
+				}
+				deleteTriple, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash is null;`)
+				if err != nil {
+					return err
+				}
+			}
+			var result sql.Result
+			if d.Quad.Label == nil {
+				result, err = deleteTriple.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL())
+			} else {
+				result, err = deleteQuad.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL(), hashOf(d.Quad.Label).toSQL())
+			}
+			if err != nil {
+				clog.Errorf("couldn't exec DELETE statement: %v", err)
+				return err
+			}
+			affected, err := result.RowsAffected()
+			if err != nil {
+				clog.Errorf("couldn't get DELETE RowsAffected: %v", err)
+				return err
+			}
+			if affected != 1 && !opts.IgnoreMissing {
+				return graph.ErrQuadNotExist
+			}
+		default:
+			panic("unknown action")
+		}
+	}
+	return nil
+}

--- a/graph/sql/postgres_test.go
+++ b/graph/sql/postgres_test.go
@@ -23,6 +23,8 @@ func makePostgres(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 	conf.Tty = true
 	conf.Env = []string{`POSTGRES_PASSWORD=postgres`}
 
+	opts := graph.Options{"flavor": flavorPostgres}
+
 	addr, closer := dock.RunAndWait(t, conf, func(addr string) bool {
 		conn, err := pq.Open(`postgres://postgres:postgres@` + addr + `/postgres?sslmode=disable`)
 		if err != nil {
@@ -32,11 +34,11 @@ func makePostgres(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 		return true
 	})
 	addr = `postgres://postgres:postgres@` + addr + `/postgres?sslmode=disable`
-	if err := createSQLTables(addr, nil); err != nil {
+	if err := createSQLTables(addr, opts); err != nil {
 		closer()
 		t.Fatal(err)
 	}
-	qs, err := newQuadStore(addr, nil)
+	qs, err := newQuadStore(addr, opts)
 	if err != nil {
 		closer()
 		t.Fatal(err)
@@ -59,7 +61,7 @@ func TestPostgresPaths(t *testing.T) {
 	pathtest.RunTestMorphisms(t, makePostgres)
 }
 
-func TestZeroRune(t *testing.T) {
+func TestPostgresZeroRune(t *testing.T) {
 	qs, opts, closer := makePostgres(t)
 	defer closer()
 

--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -2,13 +2,11 @@ package sql
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/lib/pq"
 
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
@@ -19,8 +17,6 @@ import (
 )
 
 const QuadStoreType = "sql"
-
-const defaultFillFactor = 50
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
@@ -96,7 +92,7 @@ func (q QuadHashes) Get(d quad.Direction) NodeHash {
 
 type QuadStore struct {
 	db           *sql.DB
-	sqlFlavor    string
+	flavor       Flavor
 	size         int64
 	ids          *lru.Cache
 	sizes        *lru.Cache
@@ -104,9 +100,30 @@ type QuadStore struct {
 	useEstimates bool
 }
 
-func connectSQLTables(addr string, _ graph.Options) (*sql.DB, error) {
-	// TODO(barakmich): Parse options for more friendly addr, other SQLs.
-	conn, err := sql.Open("postgres", addr)
+type Flavor struct {
+	Name        string
+	Driver      string
+	NodesTable  string
+	QuadsTable  string
+	FieldQuote  rune
+	Placeholder func(int) string
+	Indexes     func(graph.Options) []string
+	Error       func(error) error
+	Estimated   func(table string) string
+	RunTx       func(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error
+}
+
+var flavors = make(map[string]Flavor)
+
+func RegisterFlavor(f Flavor) {
+	flavors[f.Name] = f
+}
+
+const defaultFlavor = "postgres"
+
+func connect(addr string, flavor string, opts graph.Options) (*sql.DB, error) {
+	// TODO(barakmich): Parse options for more friendly addr
+	conn, err := sql.Open(flavor, addr)
 	if err != nil {
 		clog.Errorf("Couldn't open database at %s: %#v", addr, err)
 		return nil, err
@@ -148,42 +165,20 @@ var nodeInsertColumns = [][]string{
 	{"value_time"},
 }
 
-const nodesTableStatement = `CREATE TABLE nodes (
-	hash BYTEA PRIMARY KEY,
-	value BYTEA,
-	value_string TEXT,
-	datatype TEXT,
-	language TEXT,
-	iri BOOLEAN,
-	bnode BOOLEAN,
-	value_int BIGINT,
-	value_bool BOOLEAN,
-	value_float double precision,
-	value_time timestamp with time zone
-);`
-
-const quadsUniqueIndex = `
-	CREATE UNIQUE INDEX spol_unique ON quads (subject_hash, predicate_hash, object_hash, label_hash) WHERE label_hash IS NOT NULL;
-	CREATE UNIQUE INDEX spo_unique ON quads (subject_hash, predicate_hash, object_hash) WHERE label_hash IS NULL;
-	`
-
-const quadsForeignIndex = `
-	ALTER TABLE quads ADD CONSTRAINT subject_hash_fk FOREIGN KEY (subject_hash) REFERENCES nodes (hash);
-	ALTER TABLE quads ADD CONSTRAINT predicate_hash_fk FOREIGN KEY (predicate_hash) REFERENCES nodes (hash);
-	ALTER TABLE quads ADD CONSTRAINT object_hash_fk FOREIGN KEY (object_hash) REFERENCES nodes (hash);
-	ALTER TABLE quads ADD CONSTRAINT label_hash_fk FOREIGN KEY (label_hash) REFERENCES nodes (hash);
-	`
-
-func quadsSecondaryIndexes(factor int) string {
-	return fmt.Sprintf(`
-	CREATE INDEX spo_index ON quads (subject_hash) WITH (FILLFACTOR = %d);
-	CREATE INDEX pos_index ON quads (predicate_hash) WITH (FILLFACTOR = %d);
-	CREATE INDEX osp_index ON quads (object_hash) WITH (FILLFACTOR = %d);
-	`, factor, factor, factor)
-}
-
 func createSQLTables(addr string, options graph.Options) error {
-	conn, err := connectSQLTables(addr, options)
+	flavor, _, _ := options.StringKey("flavor")
+	if flavor == "" {
+		flavor = defaultFlavor
+	}
+	fl, ok := flavors[flavor]
+	if !ok {
+		return fmt.Errorf("unsupported sql flavor: %s", flavor)
+	}
+	dr := fl.Driver
+	if dr == "" {
+		dr = fl.Name
+	}
+	conn, err := connect(addr, dr, options)
 	if err != nil {
 		return err
 	}
@@ -194,55 +189,46 @@ func createSQLTables(addr string, options graph.Options) error {
 		return err
 	}
 
-	table, err := tx.Exec(nodesTableStatement)
+	_, err = tx.Exec(fl.NodesTable)
 	if err != nil {
 		tx.Rollback()
-		errd := err.(*pq.Error)
-		if errd.Code == "42P07" {
-			return graph.ErrDatabaseExists
+		err = fl.Error(err)
+		clog.Errorf("Cannot create nodes table: %v", err)
+		return err
+	}
+	_, err = tx.Exec(fl.QuadsTable)
+	if err != nil {
+		tx.Rollback()
+		err = fl.Error(err)
+		clog.Errorf("Cannot create quad table: %v", err)
+		return err
+	}
+	for _, index := range fl.Indexes(options) {
+		if _, err = tx.Exec(index); err != nil {
+			clog.Errorf("Cannot create index: %v", err)
+			tx.Rollback()
+			return err
 		}
-		clog.Errorf("Cannot create nodes table: %v", table)
-		return err
-	}
-	table, err = tx.Exec(`
-	CREATE TABLE quads (
-		horizon BIGSERIAL PRIMARY KEY,
-		subject_hash BYTEA NOT NULL,
-		predicate_hash BYTEA NOT NULL,
-		object_hash BYTEA NOT NULL,
-		label_hash BYTEA,
-		id BIGINT,
-		ts timestamp
-	);`)
-	if err != nil {
-		tx.Rollback()
-		errd := err.(*pq.Error)
-		if errd.Code == "42P07" {
-			return graph.ErrDatabaseExists
-		}
-		clog.Errorf("Cannot create quad table: %v", table)
-		return err
-	}
-	factor, factorOk, err := options.IntKey("db_fill_factor")
-	if !factorOk {
-		factor = defaultFillFactor
-	}
-	spoIndexes := quadsSecondaryIndexes(factor)
-
-	var index sql.Result
-	index, err = tx.Exec(quadsUniqueIndex + quadsForeignIndex + spoIndexes)
-	if err != nil {
-		clog.Errorf("Cannot create indices: %v", index)
-		tx.Rollback()
-		return err
 	}
 	tx.Commit()
 	return nil
 }
 
 func newQuadStore(addr string, options graph.Options) (graph.QuadStore, error) {
+	flavor, _, _ := options.StringKey("flavor")
+	if flavor == "" {
+		flavor = defaultFlavor
+	}
+	fl, ok := flavors[flavor]
+	if !ok {
+		return nil, fmt.Errorf("unsupported sql flavor: %s", flavor)
+	}
+	dr := fl.Driver
+	if dr == "" {
+		dr = fl.Name
+	}
 	var qs QuadStore
-	conn, err := connectSQLTables(addr, options)
+	conn, err := connect(addr, dr, options)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +237,7 @@ func newQuadStore(addr string, options graph.Options) (graph.QuadStore, error) {
 		return nil, err
 	}
 	qs.db = conn
-	qs.sqlFlavor = "postgres"
+	qs.flavor = fl
 	qs.size = -1
 	qs.sizes = lru.New(1024)
 	qs.ids = lru.New(1024)
@@ -269,18 +255,6 @@ func newQuadStore(addr string, options graph.Options) (graph.QuadStore, error) {
 	}
 
 	return &qs, nil
-}
-
-func convInsertError(err error) error {
-	if err == nil {
-		return err
-	}
-	if pe, ok := err.(*pq.Error); ok {
-		if pe.Code == "23505" {
-			return graph.ErrQuadExists
-		}
-	}
-	return err
 }
 
 func marshalQuadDirections(q quad.Quad) (s, p, o, l []byte, err error) {
@@ -301,46 +275,6 @@ func marshalQuadDirections(q quad.Quad) (s, p, o, l []byte, err error) {
 		return
 	}
 	return
-}
-
-func (qs *QuadStore) copyFrom(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
-	panic("broken")
-	stmt, err := tx.Prepare(pq.CopyIn("quads", "subject", "predicate", "object", "label", "id", "ts", "subject_hash", "predicate_hash", "object_hash", "label_hash"))
-	if err != nil {
-		clog.Errorf("couldn't prepare COPY statement: %v", err)
-		return err
-	}
-	for _, d := range in {
-		s, p, o, l, err := marshalQuadDirections(d.Quad)
-		if err != nil {
-			clog.Errorf("couldn't marshal quads: %v", err)
-			return err
-		}
-		_, err = stmt.Exec(
-			s,
-			p,
-			o,
-			l,
-			d.ID.Int(),
-			d.Timestamp,
-			hashOf(d.Quad.Subject),
-			hashOf(d.Quad.Predicate),
-			hashOf(d.Quad.Object),
-			hashOf(d.Quad.Label),
-		)
-		if err != nil {
-			err = convInsertError(err)
-			clog.Errorf("couldn't execute COPY statement: %v", err)
-			return err
-		}
-	}
-	_, err = stmt.Exec()
-	if err != nil {
-		err = convInsertError(err)
-		return err
-	}
-	_ = stmt.Close() // COPY will be closed on last Exec, this will return non-nil error in all cases
-	return nil
 }
 
 func escapeNullByte(s string) string {
@@ -395,156 +329,18 @@ func nodeValues(h NodeHash, v quad.Value) (int, []interface{}, error) {
 	return nodeKey, values, nil
 }
 
-func (qs *QuadStore) runTxPostgres(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
-	//allAdds := true
-	//for _, d := range in {
-	//	if d.Action != graph.Add {
-	//		allAdds = false
-	//	}
-	//}
-	//if allAdds && !opts.IgnoreDup {
-	//	return qs.copyFrom(tx, in, opts)
-	//}
-
-	end := ";"
-	if opts.IgnoreDup {
-		end = " ON CONFLICT DO NOTHING;"
-	}
-
-	var (
-		insertQuad  *sql.Stmt
-		insertValue map[int]*sql.Stmt     // prepared statements for each value type
-		inserted    map[NodeHash]struct{} // tracks already inserted values
-
-		deleteQuad   *sql.Stmt
-		deleteTriple *sql.Stmt
-	)
-
-	var err error
-	for _, d := range in {
-		switch d.Action {
-		case graph.Add:
-			if insertQuad == nil {
-				insertQuad, err = tx.Prepare(`INSERT INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES ($1, $2, $3, $4, $5, $6)` + end)
-				if err != nil {
-					return err
-				}
-				insertValue = make(map[int]*sql.Stmt)
-				inserted = make(map[NodeHash]struct{}, len(in))
-			}
-			var hs, hp, ho, hl NodeHash
-			for _, dir := range quad.Directions {
-				v := d.Quad.Get(dir)
-				if v == nil {
-					continue
-				}
-				h := hashOf(v)
-				switch dir {
-				case quad.Subject:
-					hs = h
-				case quad.Predicate:
-					hp = h
-				case quad.Object:
-					ho = h
-				case quad.Label:
-					hl = h
-				}
-				if !h.Valid() {
-					continue
-				} else if _, ok := inserted[h]; ok {
-					continue
-				}
-				nodeKey, values, err := nodeValues(h, v)
-				if err != nil {
-					return err
-				}
-				stmt, ok := insertValue[nodeKey]
-				if !ok {
-					var ph = make([]string, len(values)-1)
-					for i := range ph {
-						ph[i] = "$" + strconv.FormatInt(int64(i)+2, 10)
-					}
-					stmt, err = tx.Prepare(`INSERT INTO nodes(hash, ` +
-						strings.Join(nodeInsertColumns[nodeKey], ", ") +
-						`) VALUES ($1, ` +
-						strings.Join(ph, ", ") +
-						`) ON CONFLICT DO NOTHING;`)
-					if err != nil {
-						return err
-					}
-					insertValue[nodeKey] = stmt
-				}
-				_, err = stmt.Exec(values...)
-				err = convInsertError(err)
-				if err != nil {
-					clog.Errorf("couldn't exec INSERT statement: %v", err)
-					return err
-				}
-				inserted[h] = struct{}{}
-			}
-			_, err := insertQuad.Exec(
-				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
-				d.ID.Int(),
-				d.Timestamp,
-			)
-			err = convInsertError(err)
-			if err != nil {
-				clog.Errorf("couldn't exec INSERT statement: %v", err)
-				return err
-			}
-		case graph.Delete:
-			if deleteQuad == nil {
-				deleteQuad, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash=$4;`)
-				if err != nil {
-					return err
-				}
-				deleteTriple, err = tx.Prepare(`DELETE FROM quads WHERE subject_hash=$1 and predicate_hash=$2 and object_hash=$3 and label_hash is null;`)
-				if err != nil {
-					return err
-				}
-			}
-			var result sql.Result
-			if d.Quad.Label == nil {
-				result, err = deleteTriple.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL())
-			} else {
-				result, err = deleteQuad.Exec(hashOf(d.Quad.Subject).toSQL(), hashOf(d.Quad.Predicate).toSQL(), hashOf(d.Quad.Object).toSQL(), hashOf(d.Quad.Label).toSQL())
-			}
-			if err != nil {
-				clog.Errorf("couldn't exec DELETE statement: %v", err)
-				return err
-			}
-			affected, err := result.RowsAffected()
-			if err != nil {
-				clog.Errorf("couldn't get DELETE RowsAffected: %v", err)
-				return err
-			}
-			if affected != 1 && !opts.IgnoreMissing {
-				return graph.ErrQuadNotExist
-			}
-		default:
-			panic("unknown action")
-		}
-	}
-	qs.size = -1 // TODO(barakmich): Sync size with writes.
-	return nil
-}
-
 func (qs *QuadStore) ApplyDeltas(in []graph.Delta, opts graph.IgnoreOpts) error {
 	tx, err := qs.db.Begin()
 	if err != nil {
 		clog.Errorf("couldn't begin write transaction: %v", err)
 		return err
 	}
-	switch qs.sqlFlavor {
-	case "postgres":
-		err = qs.runTxPostgres(tx, in, opts)
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-	default:
-		panic("no support for flavor: " + qs.sqlFlavor)
+	err = qs.flavor.RunTx(tx, in, opts)
+	if err != nil {
+		tx.Rollback()
+		return err
 	}
+	qs.size = -1 // TODO(barakmich): Sync size with writes.
 	return tx.Commit()
 }
 
@@ -572,6 +368,43 @@ func (qs *QuadStore) QuadsAllIterator() graph.Iterator {
 
 func (qs *QuadStore) ValueOf(s quad.Value) graph.Value {
 	return NodeHash(hashOf(s))
+}
+
+// NullTime represents a time.Time that may be null. NullTime implements the
+// sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.NullString.
+type NullTime struct {
+	Time  time.Time
+	Valid bool // Valid is true if Time is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (nt *NullTime) Scan(value interface{}) error {
+	if value == nil {
+		nt.Time, nt.Valid = time.Time{}, false
+		return nil
+	}
+	switch value := value.(type) {
+	case time.Time:
+		nt.Time, nt.Valid = value, true
+	case []byte:
+		t, err := time.Parse("2006-01-02 15:04:05.999999", string(value))
+		if err != nil {
+			return err
+		}
+		nt.Time, nt.Valid = t, true
+	default:
+		return fmt.Errorf("unsupported time format: %T: %v", value, value)
+	}
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (nt NullTime) Value() (driver.Value, error) {
+	if !nt.Valid {
+		return nil, nil
+	}
+	return nt.Time, nil
 }
 
 func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
@@ -604,7 +437,7 @@ func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
 		value_bool,
 		value_float,
 		value_time
-	FROM nodes WHERE hash = $1 LIMIT 1;`
+	FROM nodes WHERE hash = ` + qs.flavor.Placeholder(1) + ` LIMIT 1;`
 	c := qs.db.QueryRow(query, hash.toSQL())
 	var (
 		data   []byte
@@ -616,7 +449,7 @@ func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
 		vint   sql.NullInt64
 		vbool  sql.NullBool
 		vfloat sql.NullFloat64
-		vtime  pq.NullTime
+		vtime  NullTime
 	)
 	if err := c.Scan(
 		&data,
@@ -680,13 +513,8 @@ func (qs *QuadStore) Size() int64 {
 	}
 
 	query := "SELECT COUNT(*) FROM quads;"
-	if qs.useEstimates {
-		switch qs.sqlFlavor {
-		case "postgres":
-			query = "SELECT reltuples::BIGINT AS estimate FROM pg_class WHERE relname='quads';"
-		default:
-			panic("no estimate support for flavor: " + qs.sqlFlavor)
-		}
+	if qs.useEstimates && qs.flavor.Estimated != nil {
+		query = qs.flavor.Estimated("quads")
 	}
 
 	c := qs.db.QueryRow(query)
@@ -745,7 +573,7 @@ func (qs *QuadStore) sizeForIterator(isAll bool, dir quad.Direction, hash NodeHa
 		clog.Infof("sql: getting size for select %s, %v", dir.String(), hash)
 	}
 	err = qs.db.QueryRow(
-		fmt.Sprintf("SELECT count(*) FROM quads WHERE %s_hash = $1;", dir.String()), hash.toSQL()).Scan(&size)
+		fmt.Sprintf("SELECT count(*) FROM quads WHERE %s_hash = "+qs.flavor.Placeholder(1)+";", dir.String()), hash.toSQL()).Scan(&size)
 	if err != nil {
 		clog.Errorf("Error getting size from SQL database: %v", err)
 		return 0

--- a/graph/sql/sql_link_iterator_test.go
+++ b/graph/sql/sql_link_iterator_test.go
@@ -27,7 +27,7 @@ var postgres_path = flag.String("postgres_path", "", "Path to running DB")
 
 func TestSQLLink(t *testing.T) {
 	it := NewSQLLinkIterator(nil, quad.Object, quad.Raw("cool"))
-	s, v := it.sql.buildSQL(true, nil)
+	s, v := it.sql.buildSQL(&Flavor{}, true, nil)
 	t.Log(s, v)
 }
 
@@ -45,7 +45,7 @@ func TestSQLLinkIteration(t *testing.T) {
 		fmt.Println(it.Result())
 	}
 	it = NewSQLLinkIterator(qs, quad.Subject, quad.Raw("/en/casablanca_1942"))
-	s, v := it.sql.buildSQL(true, nil)
+	s, v := it.sql.buildSQL(&qs.flavor, true, nil)
 	t.Log(s, v)
 	c := 0
 	for it.Next() {
@@ -65,10 +65,11 @@ func TestSQLNodeIteration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	link := NewSQLLinkIterator(db.(*QuadStore), quad.Object, quad.Raw("/en/humphrey_bogart"))
+	qs := db.(*QuadStore)
+	link := NewSQLLinkIterator(qs, quad.Object, quad.Raw("/en/humphrey_bogart"))
 	it := &SQLIterator{
 		uid: iterator.NextUID(),
-		qs:  db.(*QuadStore),
+		qs:  qs,
 		sql: &SQLNodeIterator{
 			tableName: newTableName(),
 			linkIt: sqlItDir{
@@ -77,7 +78,7 @@ func TestSQLNodeIteration(t *testing.T) {
 			},
 		},
 	}
-	s, v := it.sql.buildSQL(true, nil)
+	s, v := it.sql.buildSQL(&qs.flavor, true, nil)
 	t.Log(s, v)
 	c := 0
 	for it.Next() {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -48,8 +48,11 @@ import (
 
 const format = "cquad"
 
-var backend = flag.String("backend", "memstore", "Which backend to test. Loads test data to /tmp if not present.")
-var backendPath = flag.String("backend_path", "", "Path to the chosen backend. Will have sane testing defaults if not specified")
+var (
+	backend     = flag.String("backend", "memstore", "Which backend to test. Loads test data to /tmp if not present.")
+	backendPath = flag.String("backend_path", "", "Path to the chosen backend. Will have sane testing defaults if not specified")
+	sqlFlavor   = flag.String("flavor", "postgres", "SQL flavour")
+)
 
 var benchmarkQueries = []struct {
 	message string
@@ -462,6 +465,9 @@ func prepare(t testing.TB) {
 		remote = true
 	case "sql":
 		cfg.DatabasePath = "postgres://localhost/cayley_test"
+		cfg.DatabaseOptions = map[string]interface{}{
+			"flavor": *sqlFlavor,
+		}
 		remote = true
 	default:
 		t.Fatalf("Untestable backend store %s", *backend)
@@ -550,6 +556,9 @@ func TestDeletedAndRecreatedQueries(t *testing.T) {
 }
 
 func checkQueries(t *testing.T) {
+	if handle == nil {
+		t.Fatal("not initialized")
+	}
 	for _, test := range benchmarkQueries {
 		if testing.Short() && test.long {
 			continue


### PR DESCRIPTION
Adds `flavor` option to sql backend. Allowed values: `postgres` (default), `mysql`, `cockroach`.

**TODO**

- [ ] check integration tests

- [ ] update docs with examples of each configuration

- [ ] check [transaction retries](https://www.cockroachlabs.com/docs/transactions.html#transaction-retries) for CockroachDB

- [ ] test large queries in CockroachDB and maybe disable JOINs