### PR TITLE
path: Traverse individual quad directions

### DIFF
--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -391,7 +391,10 @@ func buildSysSave(
 	if !ok || reverse || optional {
 		return nil
 	}
-	dir := iriToDir[iri]
+	dir, ok := iriToDir[iri]
+	if !ok {
+		return nil
+	}
 
 	allNodes := qs.NodesAllIterator()
 	allNodes.Tagger().Add(tag)
@@ -446,7 +449,10 @@ func inOutSysIterator(qs graph.QuadStore, via []interface{}, from graph.Iterator
 		return nil // TODO(dennwc): allow multiple directions
 	}
 	iri := iris[0]
-	dir := iriToDir[iri]
+	dir, ok := iriToDir[iri]
+	if !ok {
+		return nil
+	}
 	if inIterator {
 		return iterator.NewLinksTo(qs, from, dir)
 	}

--- a/graph/path/path_test.go
+++ b/graph/path/path_test.go
@@ -23,3 +23,7 @@ import (
 func TestMorphisms(t *testing.T) {
 	pathtest.RunTestMorphisms(t, nil)
 }
+
+func TestMorphismsTags(t *testing.T) {
+	pathtest.RunTestSystemMorphisms(t, nil)
+}

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -373,3 +373,58 @@ func RunTestMorphisms(t testing.TB, fnc graphtest.DatabaseFunc) {
 		}
 	}
 }
+
+type sysTest struct {
+	message string
+	path    *Path
+	expect  []map[string]quad.Value
+}
+
+const (
+	vSubject = quad.IRI("rdf:subject")
+	vPred    = quad.IRI("rdf:predicate")
+	vObject  = quad.IRI("rdf:object")
+	vLabel   = quad.IRI("rdf:label")
+)
+
+func testSysSet(qs graph.QuadStore) []sysTest {
+	return []sysTest{
+		{
+			message: "in and out of quad directions",
+			path:    StartPath(qs, vBob).In(vSubject).Out(vObject).Tag("o"),
+			expect: []map[string]quad.Value{
+				{"o": vFred}, {"o": vCool},
+			},
+		},
+		{
+			message: "save full triple",
+			path: StartPath(qs, vBob).In(vSubject).
+				Save(quad.IRI("rdf:subject"), "s").
+				Save(quad.IRI("rdf:predicate"), "p").
+				Save(quad.IRI("rdf:object"), "o"),
+			expect: []map[string]quad.Value{
+				{"s": vBob, "p": vFollows, "o": vFred},
+				{"s": vBob, "p": vStatus, "o": vCool},
+			},
+		},
+	}
+}
+
+func RunTestSystemMorphisms(t testing.TB, fnc graphtest.DatabaseFunc) {
+	qs, closer := makeTestStore(t, fnc)
+	defer closer()
+
+	for _, test := range testSysSet(qs) {
+		t.Log("now testing", test.message)
+		var got []map[string]quad.Value
+		err := test.path.Iterate(nil).TagValues(qs, func(m map[string]quad.Value) {
+			got = append(got, m)
+		})
+		if err != nil {
+			t.Errorf("Failed to %s: %v", test.message, err)
+			continue
+		} else if !reflect.DeepEqual(test.expect, got) {
+			t.Errorf("Failed to %s, got: %v(%d) expected: %v(%d)", test.message, got, len(got), test.expect, len(test.expect))
+		}
+	}
+}


### PR DESCRIPTION
Work in progress implementation of #469.

Implementation is not checking types yet (nodes vs quads), thus incorrect queries may crash.

PR makes it easier to work with quads in general, for example, save all quads for specific subject:
```js
p = g.V("node").In("<rdf:subject>") // now we have links!
// save each quad "direction"
p = p.Save("<rdf:subject>","s").Save("<rdf:predicate>","p").Save("<rdf:object>","o")
arr = p.TagArray()
```