### PR TITLE
http: use formats - implement write api v2; resolves #176

### DIFF
--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -176,7 +176,7 @@ func WriterMethods() []string {
 }
 
 type BatchWriter interface {
-	quad.Writer
+	quad.WriteCloser
 	quad.BatchWriter
 }
 

--- a/internal/http/accept.go
+++ b/internal/http/accept.go
@@ -1,0 +1,144 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package http
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Octet types from RFC 2616.
+var octetTypes [256]octetType
+
+type octetType byte
+
+const (
+	isToken octetType = 1 << iota
+	isSpace
+)
+
+func init() {
+	// OCTET      = <any 8-bit sequence of data>
+	// CHAR       = <any US-ASCII character (octets 0 - 127)>
+	// CTL        = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
+	// CR         = <US-ASCII CR, carriage return (13)>
+	// LF         = <US-ASCII LF, linefeed (10)>
+	// SP         = <US-ASCII SP, space (32)>
+	// HT         = <US-ASCII HT, horizontal-tab (9)>
+	// <">        = <US-ASCII double-quote mark (34)>
+	// CRLF       = CR LF
+	// LWS        = [CRLF] 1*( SP | HT )
+	// TEXT       = <any OCTET except CTLs, but including LWS>
+	// separators = "(" | ")" | "<" | ">" | "@" | "," | ";" | ":" | "\" | <">
+	//              | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+	// token      = 1*<any CHAR except CTLs or separators>
+	// qdtext     = <any TEXT except <">>
+
+	for c := 0; c < 256; c++ {
+		var t octetType
+		isCtl := c <= 31 || c == 127
+		isChar := 0 <= c && c <= 127
+		isSeparator := strings.IndexRune(" \t\"(),/:;<=>?@[]\\{}", rune(c)) >= 0
+		if strings.IndexRune(" \t\r\n", rune(c)) >= 0 {
+			t |= isSpace
+		}
+		if isChar && !isCtl && !isSeparator {
+			t |= isToken
+		}
+		octetTypes[c] = t
+	}
+}
+
+// AcceptSpec describes an Accept* header.
+type AcceptSpec struct {
+	Value string
+	Q     float64
+}
+
+// ParseAccept parses Accept* headers.
+func ParseAccept(header http.Header, key string) (specs []AcceptSpec) {
+loop:
+	for _, s := range header[key] {
+		for {
+			var spec AcceptSpec
+			spec.Value, s = expectTokenSlash(s)
+			if spec.Value == "" {
+				continue loop
+			}
+			spec.Q = 1.0
+			s = skipSpace(s)
+			if strings.HasPrefix(s, ";") {
+				s = skipSpace(s[1:])
+				if !strings.HasPrefix(s, "q=") {
+					continue loop
+				}
+				spec.Q, s = expectQuality(s[2:])
+				if spec.Q < 0.0 {
+					continue loop
+				}
+			}
+			specs = append(specs, spec)
+			s = skipSpace(s)
+			if !strings.HasPrefix(s, ",") {
+				continue loop
+			}
+			s = skipSpace(s[1:])
+		}
+	}
+	return
+}
+
+func skipSpace(s string) (rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		if octetTypes[s[i]]&isSpace == 0 {
+			break
+		}
+	}
+	return s[i:]
+}
+
+func expectTokenSlash(s string) (token, rest string) {
+	i := 0
+	for ; i < len(s); i++ {
+		b := s[i]
+		if (octetTypes[b]&isToken == 0) && b != '/' {
+			break
+		}
+	}
+	return s[:i], s[i:]
+}
+
+func expectQuality(s string) (q float64, rest string) {
+	switch {
+	case len(s) == 0:
+		return -1, ""
+	case s[0] == '0':
+		q = 0
+	case s[0] == '1':
+		q = 1
+	default:
+		return -1, ""
+	}
+	s = s[1:]
+	if !strings.HasPrefix(s, ".") {
+		return q, s
+	}
+	s = s[1:]
+	i := 0
+	n := 0
+	d := 1
+	for ; i < len(s); i++ {
+		b := s[i]
+		if b < '0' || b > '9' {
+			break
+		}
+		n = n*10 + int(b) - '0'
+		d *= 10
+	}
+	return q + float64(n)/float64(d), s[i:]
+}

--- a/internal/http/write.go
+++ b/internal/http/write.go
@@ -15,8 +15,10 @@
 package http
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -137,5 +139,167 @@ func (api *API) ServeV1Delete(w http.ResponseWriter, r *http.Request, params htt
 		}
 	}
 	fmt.Fprintf(w, "{\"result\": \"Successfully deleted %d quads.\"}", len(quads))
+	return 200
+}
+
+const (
+	defaultFormat      = "nquads"
+	hdrContentType     = "Content-Type"
+	hdrContentEncoding = "Content-Encoding"
+	hdrAccept          = "Accept"
+	hdrAcceptEncoding  = "Accept-Encoding"
+	contentTypeJSON    = "application/json"
+)
+
+func getFormat(r *http.Request, formKey string, acceptName string) *quad.Format {
+	var format *quad.Format
+	if formKey != "" {
+		if name := r.FormValue("format"); name != "" {
+			format = quad.FormatByName(name)
+		}
+	}
+	if acceptName != "" && format == nil {
+		specs := ParseAccept(r.Header, acceptName)
+		// TODO: sort by Q
+		if len(specs) != 0 {
+			format = quad.FormatByMime(specs[0].Value)
+		}
+	}
+	if format == nil {
+		format = quad.FormatByName(defaultFormat)
+	}
+	return format
+}
+
+func readerFrom(r *http.Request, acceptName string) (io.ReadCloser, error) {
+	if specs := ParseAccept(r.Header, acceptName); len(specs) != 0 {
+		if s := specs[0]; s.Value == "gzip" {
+			zr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				return nil, err
+			}
+			return zr, nil
+		}
+	}
+	return r.Body, nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error { return nil }
+
+func writerFrom(w http.ResponseWriter, r *http.Request, acceptName string) io.WriteCloser {
+	if specs := ParseAccept(r.Header, acceptName); len(specs) != 0 {
+		if s := specs[0]; s.Value == "gzip" {
+			w.Header().Set(hdrContentEncoding, s.Value)
+			zw := gzip.NewWriter(w)
+			return zw
+		}
+	}
+	return nopWriteCloser{Writer: w}
+}
+
+func (api *API) ServeV2Write(w http.ResponseWriter, r *http.Request, _ httprouter.Params) int {
+	defer r.Body.Close()
+	format := getFormat(r, "", hdrContentType)
+	if format == nil || format.Reader == nil {
+		return jsonResponse(w, http.StatusBadRequest, fmt.Errorf("format is not supported for reading data"))
+	}
+	rd, err := readerFrom(r, hdrContentEncoding)
+	if err != nil {
+		return jsonResponse(w, http.StatusBadRequest, err)
+	}
+	defer rd.Close()
+	qr := format.Reader(rd)
+	defer qr.Close()
+	h, err := api.GetHandleForRequest(r)
+	if err != nil {
+		return jsonResponse(w, http.StatusBadRequest, err)
+	}
+	qw := graph.NewWriter(h.QuadWriter)
+	defer qw.Close()
+	n, err := quad.CopyBatch(qw, qr, api.config.LoadSize)
+	if err != nil {
+		return jsonResponse(w, http.StatusInternalServerError, err)
+	}
+	w.Header().Set(hdrContentType, contentTypeJSON)
+	fmt.Fprintf(w, `{"result": "Successfully wrote %d quads.", "count": %d}`+"\n", n, n)
+	return 200
+}
+
+func (api *API) ServeV2Delete(w http.ResponseWriter, r *http.Request, _ httprouter.Params) int {
+	defer r.Body.Close()
+	format := getFormat(r, "", hdrContentType)
+	if format == nil || format.Reader == nil {
+		return jsonResponse(w, http.StatusBadRequest, fmt.Errorf("format is not supported for reading data"))
+	}
+	rd, err := readerFrom(r, hdrContentEncoding)
+	if err != nil {
+		return jsonResponse(w, http.StatusBadRequest, err)
+	}
+	defer rd.Close()
+	qr := format.Reader(r.Body)
+	defer qr.Close()
+	h, err := api.GetHandleForRequest(r)
+	if err != nil {
+		return jsonResponse(w, http.StatusBadRequest, err)
+	}
+	qw := graph.NewRemover(h.QuadWriter)
+	defer qw.Close()
+	n, err := quad.CopyBatch(qw, qr, api.config.LoadSize)
+	if err != nil {
+		return jsonResponse(w, http.StatusInternalServerError, err)
+	}
+	w.Header().Set(hdrContentType, contentTypeJSON)
+	fmt.Fprintf(w, `{"result": "Successfully wrote %d quads.", "count": %d}`+"\n", n, n)
+	return 200
+}
+
+type checkWriter struct {
+	w       io.Writer
+	written bool
+}
+
+func (w *checkWriter) Write(p []byte) (int, error) {
+	w.written = true
+	return w.w.Write(p)
+}
+
+func (api *API) ServeV2Read(w http.ResponseWriter, r *http.Request, _ httprouter.Params) int {
+	format := getFormat(r, "format", hdrAccept)
+	if format == nil || format.Writer == nil {
+		return jsonResponse(w, http.StatusBadRequest, fmt.Errorf("format is not supported for reading data"))
+	}
+	h, err := api.GetHandleForRequest(r)
+	if err != nil {
+		return jsonResponse(w, http.StatusBadRequest, err)
+	}
+	qr := graph.NewQuadStoreReader(h.QuadStore)
+	defer qr.Close()
+
+	wr := writerFrom(w, r, hdrAcceptEncoding)
+	defer wr.Close()
+
+	cw := &checkWriter{w: wr}
+	qw := format.Writer(cw)
+	defer qw.Close()
+	if len(format.Mime) != 0 {
+		w.Header().Set(hdrContentType, format.Mime[0])
+	}
+	if bw, ok := qw.(quad.BatchWriter); ok {
+		_, err = quad.CopyBatch(bw, qr, api.config.LoadSize)
+	} else {
+		_, err = quad.Copy(qw, qr)
+	}
+	if err != nil && !cw.written {
+		return jsonResponse(w, http.StatusInternalServerError, err)
+	} else if err != nil {
+		// can do nothing here, since first byte (and header) was written
+		// TODO: check if client just gone away
+		clog.Errorf("read quads error: %v", err)
+		return 500
+	}
 	return 200
 }


### PR DESCRIPTION
* New api endpoints: `/api/v2/read,write,delete`.
* All endpoints use streaming - supports large import/export operations.
* Selects format based on Accept or Content-Type HTTP header.
* Supports gzip compression (Accept-Encoding and Content-Encoding HTTP headers).