### PR TITLE
Tiny Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN mkdir -p ${GOPATH} && \
     apk del --purge ${PKG_TMP} && \
     rm -rf ${PKG_CACHE}/*
 
-ENTRYPOINT [ "/usr/local/bin/cayley", "-assets", "/assets" ]
+ENTRYPOINT [ "/usr/local/bin/cayley" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p ${GOPATH} && \
     cd ${GOPATH}/src/${BUILD_LIB} && \
     git checkout ${BUILD_TAG} && \
     mkdir /assets && \
-    cp -a {docs,static,templates} /assets && \
+    sh -c "cp -a {docs,static,templates} /assets" && \
     glide install && \
     go install -v ./cmd/cayley && \
     cp -a ${GOPATH}/bin/* ${INSTALL_PATH} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ RUN mkdir -p ${GOPATH} && \
 
 ENV PATH=${INSTALL_PATH}
 
-EXPOSE [ "64210" ]
+EXPOSE 64210
 
 ENTRYPOINT [ "/usr/local/bin/cayley" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ RUN mkdir -p ${GOPATH} && \
     cd ${GOPATH}/src/${BUILD_LIB} && \
     git checkout ${BUILD_TAG} && \
     mkdir /assets && \
-    sh -c "cp -a {docs,static,templates} /assets" && \
+    cp -a docs /assets && \
+    cp -a static /assets && \
+    cp -a templates /assets && \
     glide install && \
     go install -v ./cmd/cayley && \
     cp -a ${GOPATH}/bin/* ${INSTALL_PATH} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.5
 LABEL maintainer "napalmbrain (psev)"
 LABEL email "github@napalmbrain.sugarush.io"
 LABEL github "github.com/sugarush"
+LABEL twitter "@iamnapalmbrain"
 
 ENV INSTALL_PATH="/usr/local/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN mkdir -p ${GOPATH} && \
     go get ${BUILD_LIB} && \
     cd ${GOPATH}/src/${BUILD_LIB} && \
     git checkout ${BUILD_TAG} && \
+    mkdir /assets && \
+    cp -a {docs,static,templates} /assets && \
     glide install && \
     go install -v ./cmd/cayley && \
     cp -a ${GOPATH}/bin/* ${INSTALL_PATH} && \
@@ -31,6 +33,4 @@ RUN mkdir -p ${GOPATH} && \
     apk del --purge ${PKG_TMP} && \
     rm -rf ${PKG_CACHE}/*
 
-EXPOSE 64210
-
-ENTRYPOINT [ "/usr/local/bin/cayley" ]
+ENTRYPOINT [ "/usr/local/bin/cayley", "-assets", "/assets" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
+FROM alpine:3.5
+
 LABEL maintainer "napalmbrain (psev)"
 LABEL email "github@napalmbrain.sugarush.io"
 LABEL github "github.com/sugarush"
-
-FROM alpine:3.5
 
 ENV INSTALL_PATH="/usr/local/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+LABEL maintainer "napalmbrain (psev)"
+LABEL email "github@napalmbrain.sugarush.io"
+LABEL github "github.com/sugarush"
+
 FROM alpine:3.5
 
 ENV INSTALL_PATH="/usr/local/bin"
@@ -26,8 +30,6 @@ RUN mkdir -p ${GOPATH} && \
     rm -rf /root/.glide && \
     apk del --purge ${PKG_TMP} && \
     rm -rf ${PKG_CACHE}/*
-
-ENV PATH=${INSTALL_PATH}
 
 EXPOSE 64210
 

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -15,4 +15,4 @@ RUN mkdir /data && \
 VOLUME [ "/data" ]
 EXPOSE 64210
 
-CMD [ "http", "-config", "/data/cayley.cfg", "-host", "0.0.0.0", "-port", "64210" ]
+CMD [ "http", "-assets", "/assets", "-config", "/data/cayley.cfg", "-host", "0.0.0.0", "-port", "64210" ]

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -11,7 +11,8 @@ COPY data/30kmoviedata.nq.gz /tmp/30kmoviedata.nq.gz
 RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg && \
     cayley init -db bolt -dbpath /data/cayley -quads /tmp/30kmoviedata.nq.gz && \
     rm /tmp/30kmoviedata.nq.gz
-    
+
 VOLUME [ "/data" ]
+EXPOSE 64210
 
 CMD [ "http", "-config", "/data/cayley.cfg", "-host", "0.0.0.0", "-port", "64210" ]

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -5,12 +5,13 @@ LABEL email "github@napalmbrain.sugarush.io"
 LABEL github "github.com/sugarush"
 
 RUN mkdir /data
-VOLUME [ "/data" ]
 
 COPY data/30kmoviedata.nq.gz /tmp/30kmoviedata.nq.gz
 
 RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg && \
     cayley init -db bolt -dbpath /data/cayley -quads /tmp/30kmoviedata.nq.gz && \
     rm /tmp/30kmoviedata.nq.gz
+    
+VOLUME [ "/data" ]
 
 CMD [ "http", "-config", "/data/cayley.cfg", "-host", "0.0.0.0", "-port", "64210" ]

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -9,7 +9,7 @@ VOLUME [ "/data" ]
 
 COPY data/30kmoviedata.nq.gz /tmp/30kmoviedata.nq.gz
 
-RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg &&
+RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg && \
     cayley init -db bolt -dbpath /data/cayley -quads /tmp/30kmoviedata.nq.gz && \
     rm /tmp/30kmoviedata.nq.gz
 

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -3,12 +3,12 @@ FROM sugarush/cayley
 LABEL maintainer "napalmbrain (psev)"
 LABEL email "github@napalmbrain.sugarush.io"
 LABEL github "github.com/sugarush"
-
-RUN mkdir /data
+LABEL twitter "@iamnapalmbrain"
 
 COPY data/30kmoviedata.nq.gz /tmp/30kmoviedata.nq.gz
 
-RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg && \
+RUN mkdir /data && \
+    echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg && \
     cayley init -db bolt -dbpath /data/cayley -quads /tmp/30kmoviedata.nq.gz && \
     rm /tmp/30kmoviedata.nq.gz
 

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -1,8 +1,8 @@
+FROM sugarush/cayley
+
 LABEL maintainer "napalmbrain (psev)"
 LABEL email "github@napalmbrain.sugarush.io"
 LABEL github "github.com/sugarush"
-
-FROM sugarush/cayley
 
 RUN mkdir /data
 VOLUME [ "/data" ]

--- a/Dockerfile-quickstart
+++ b/Dockerfile-quickstart
@@ -1,0 +1,16 @@
+LABEL maintainer "napalmbrain (psev)"
+LABEL email "github@napalmbrain.sugarush.io"
+LABEL github "github.com/sugarush"
+
+FROM sugarush/cayley
+
+RUN mkdir /data
+VOLUME [ "/data" ]
+
+COPY data/30kmoviedata.nq.gz /tmp/30kmoviedata.nq.gz
+
+RUN echo '{"database":"bolt","db_path":"/data/cayley","read_only":false}' > /data/cayley.cfg &&
+    cayley init -db bolt -dbpath /data/cayley -quads /tmp/30kmoviedata.nq.gz && \
+    rm /tmp/30kmoviedata.nq.gz
+
+CMD [ "http", "-config", "/data/cayley.cfg", "-host", "0.0.0.0", "-port", "64210" ]

--- a/docs/Container.md
+++ b/docs/Container.md
@@ -1,27 +1,75 @@
-# Running in a container
+# Docker Container
 
-A container exposing the HTTP API of cayley is available.
+## General Use Container
 
-## Running with default configuration
+*This container is for general use. It is approximately 40MB.*
 
-Container is configured to serve 30kmoviedata with BoltDB as a backend.
+### Build the Container
+
+*You don't need to build the container.*
 
 ```
-docker run -p 64210:64210 -d quay.io/cayleygraph/cayley
+cd <cayley source directory>
+docker build -t sugarush/cayley .
 ```
 
-Database will be available at http://localhost:64210.
+### Run the Container
 
-## Custom configuration
+To run the container:
 
-To run the container one must first setup a data directory that contains the configuration file and optionally contains persistent files (i.e. a boltdb database file).
+```
+docker run -it --rm sugarush/cayley <options/flags>
+```
+## Quickstart Container
+
+*This container is not for general use. It is approximately 500MB.*
+
+The quickstart container is configured to serve 30kmoviedata with BoltDB as a backend.
+
+### Build the Container
+
+*You don't need to build the container.*
+
+Make sure to build the general container first.
+
+```
+cd <cayley source directory>
+docker build -f Dockerfile-quickstart -t sugarush/cayley-quickstart .
+```
+
+### Run the Container
+
+To start a quickstart container prepopulated with 30kmoviedata, run:
+
+```
+docker run -it --rm -p 64210:64210 sugarush/cayley-quickstart
+```
+
+The database will be available at http://localhost:64210.
+
+### Docker Machine
+
+If you are using Docker Machine, on a Mac for example, your database will be available at the Docker hosts's IP. This can be found by running:
+
+```
+docker-machine env <your docker machine>
+```
+
+You'll then connect to your database at http://&lt;docker-machine ip&gt;:64210.
+
+### Persisting Data
+
+To persist data, the first step is to obtain the BoltDB data and Cayley configuration file.
 
 ```
 mkdir data
-cp my_config.cfg data/cayley.cfg
-cp my_data.nq data/my_data.nq
-# initialize and serve database
-docker run -v $PWD/data:/data -p 64210:64210 -d quay.io/cayleygraph/cayley -init -quads /data/my_data.nq
-# serve existing database
-docker run -v $PWD/data:/data -p 64210:64210 -d quay.io/cayleygraph/cayley
+docker run -it --rm -v $(pwd)/data:/tmp --entrypoint /bin/sh sugarush/cayley-quickstart
+cp -a /data/* /tmp
+exit
+```
+
+Then start the container with your data directory mounted.
+
+```
+docker run -it --rm -v $(pwd)/data:/data sugarush/cayley-quickstart
 ```

--- a/docs/Container.md
+++ b/docs/Container.md
@@ -20,9 +20,20 @@ To run the container:
 ```
 docker run -it --rm sugarush/cayley <options/flags>
 ```
+
+### HTTP Interface
+
+If you intend to use the HTTP interface, you must include the _-assets /assets_ flag. Your command may look something like:
+
+```
+docker run -it --rm sugarush/cayley http -assets /assets <...>
+```
+
 ## Quickstart Container
 
 *This container is not for general use. It is approximately 500MB.*
+
+*You do not need to set the -assets flag when using the quickstart container.*
 
 The quickstart container is configured to serve 30kmoviedata with BoltDB as a backend.
 


### PR DESCRIPTION
Reduce the Docker image size from 1.5GB to 38.03.MB.
Uses alpine:3.5 as a base container.