### PR TITLE
Gephi support

### DIFF
--- a/data/30kmoviedata_gephi_meta.nq
+++ b/data/30kmoviedata_gephi_meta.nq
@@ -1,0 +1,3 @@
+</film/performance/character> <gephi:inline> "true"^^<schema:Boolean> .
+<type> <gephi:inline> "true"^^<schema:Boolean> .
+<name> <gephi:inline> "true"^^<schema:Boolean> .

--- a/docs/GephiGraphStream.md
+++ b/docs/GephiGraphStream.md
@@ -19,18 +19,25 @@ Values less than 0 interpreted as "no limit".
 
 Sets streaming mode. Supported values:
 
-* `raw` (default) - all nodes and quads in database
+* `raw` (default) - all or selected quads
 * `nodes` - nodes with properties
 
 #### Raw mode
 
-Example URL: `/gephi/gs?mode=raw&limit=-1`
+In this mode Cayley directly streams selected quads to Gephi.
 
-In this mode Cayley streams all nodes and quads to Gephi.
+Example URLs:
 
-Limit corresponds to a number of quads returned.
+`/gephi/gs?mode=raw&pred=<follows>&limit=-1` (all quads)
 
-This mode may be useful to visualize small graphs, or graphs without metadata such as types and properties.
+`/gephi/gs?mode=raw&sub=<bob>&pred=<follows>,<status>&limit=-1` (links from `<bob>` via either `<follows>` or `<status>`)
+
+Parameters:
+
+* `limit` - maximal number of quads returned
+* `sub`,`pred`,`obj`,`label` - only show quads with specified values of Subject, Predicate, Object or Label
+
+This mode may be useful to visualize small subgraphs, or graphs without metadata such as types and properties.
 In case of later, large number of quads will be pointing to nodes describing common types or property names.
 For this kind of graphs `nodes` mode should be used.
 

--- a/docs/GephiGraphStream.md
+++ b/docs/GephiGraphStream.md
@@ -1,0 +1,69 @@
+# Gephi GraphStream
+
+Cayley supports graph visualisation in Gephi using GraphStream API.
+
+Enpoint can be accessed by adding URL `http://localhost:64210/gephi/gs` to Gephi GraphStream client.
+
+## Options
+
+### `limit`
+
+Default: `10000`
+
+Sets a maximal number of object that will be streamed.
+Depending on stream mode this could be either nodes or quads.
+
+Values less than 0 interpreted as "no limit".
+
+### `mode`
+
+Sets streaming mode. Supported values:
+
+* `raw` (default) - all nodes and quads in database
+* `nodes` - nodes with properties
+
+#### Raw mode
+
+Example URL: `/gephi/gs?mode=raw&limit=-1`
+
+In this mode Cayley streams all nodes and quads to Gephi.
+
+Limit corresponds to a number of quads returned.
+
+This mode may be useful to visualize small graphs, or graphs without metadata such as types and properties.
+In case of later, large number of quads will be pointing to nodes describing common types or property names.
+For this kind of graphs `nodes` mode should be used.
+
+#### Nodes with properties
+
+Example URL: `/gephi/gs?mode=nodes&limit=-1`
+
+In this mode Cayley streams all nodes and links associated with them, but instead of streaming common quads such as types
+it will inline them as Gephi properties.
+ 
+ Limit corresponds to a number of nodes returned.
+
+By default, all predicate will be streamed as in `raw` mode, except well-known predicates and ones with `<gephi:inline> = "true"`.
+
+List of well-known predicates includes:
+
+* `<rdf:type>` (`<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>`)
+* `<rdfs:label>` (`<http://www.w3.org/2000/01/rdf-schema#label>`)
+* `<schema:name>` (`<http://schema.org/name>`)
+
+To add custom predicates, write a special triple to database:
+
+```nquads
+<myCustomProperty> <gephi:inline> "true"^^<schema:Boolean> .
+```
+
+This allows to partition nodes by type or specific property values.
+
+Note: Only one value per predicate is supported for inlined properties.
+
+By default nodes will have random positions. To specify an exact position for specific node add `<gephi:x>` and `<gephi:y>` properties:
+
+```nquads
+<node> <gephi:x> "10"^^<schema:Integer>
+<node> <gephi:y> "-12.3"^^<schema:Float>
+```

--- a/docs/HTTP.md
+++ b/docs/HTTP.md
@@ -1,5 +1,9 @@
 # HTTP Methods
 
+## Gephi
+
+Cayley supports streaming to Gephi via [GraphStream](GephiGraphStream.md).
+
 ## API v1
 
 Unless otherwise noted, all URIs take a POST command.

--- a/graph/iterate.go
+++ b/graph/iterate.go
@@ -233,6 +233,21 @@ func (c *IterateChain) EachValue(qs QuadStore, fnc func(quad.Value)) error {
 	})
 }
 
+// EachValuePair is an analog of Each, but it will additionally call NameOf
+// for each graph.Value before passing it to a callback. Original value will be passed as well.
+func (c *IterateChain) EachValuePair(qs QuadStore, fnc func(Value, quad.Value)) error {
+	if qs != nil {
+		c.qs = qs
+	}
+	if c.qs == nil {
+		return errNoQuadStore
+	}
+	// TODO(dennwc): batch NameOf?
+	return c.Each(func(v Value) {
+		fnc(v, c.qs.NameOf(v))
+	})
+}
+
 // AllValues is an analog of All, but it will additionally call NameOf
 // for each graph.Value before returning the results slice.
 func (c *IterateChain) AllValues(qs QuadStore) ([]quad.Value, error) {

--- a/internal/gephi/stream.go
+++ b/internal/gephi/stream.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/net/context"
@@ -211,8 +212,28 @@ type graphStreamEvent struct {
 	DelEdges    map[string]streamEdge `json:"de,omitempty"`
 }
 
-func (s *GraphStreamHandler) serveRawQuads(ctx context.Context, gs *GraphStream, limit int) {
-	it := s.QS.QuadsAllIterator()
+func (s *GraphStreamHandler) serveRawQuads(ctx context.Context, gs *GraphStream, sub, pred, obj, label []quad.Value, limit int) {
+	var it graph.Iterator
+	if len(sub)+len(pred)+len(obj)+len(label) == 0 {
+		it = s.QS.QuadsAllIterator()
+	} else {
+		var subIt []graph.Iterator
+		linksTo := func(d quad.Direction, vals []quad.Value) {
+			if len(vals) == 0 {
+				return
+			}
+			fixed := s.QS.FixedIterator()
+			for _, v := range vals {
+				fixed.Add(s.QS.ValueOf(v))
+			}
+			subIt = append(subIt, iterator.NewLinksTo(s.QS, fixed, d))
+		}
+		linksTo(quad.Subject, sub)
+		linksTo(quad.Predicate, pred)
+		linksTo(quad.Object, obj)
+		linksTo(quad.Label, label)
+		it = iterator.NewAnd(s.QS, subIt...)
+	}
 	defer it.Close()
 
 	var sh, oh valHash
@@ -328,6 +349,18 @@ func (s *GraphStreamHandler) serveNodesWithProps(ctx context.Context, gs *GraphS
 	})
 }
 
+func valuesFromString(s string) []quad.Value {
+	if s == "" {
+		return nil
+	}
+	arr := strings.Split(s, ",")
+	out := make([]quad.Value, 0, len(arr))
+	for _, s := range arr {
+		out = append(out, quad.StringToValue(s))
+	}
+	return out
+}
+
 func (s *GraphStreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 	ctx := context.TODO()
 	var limit int
@@ -348,7 +381,11 @@ func (s *GraphStreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, p
 	case "nodes":
 		s.serveNodesWithProps(ctx, gs, limit)
 	case "raw":
-		s.serveRawQuads(ctx, gs, limit)
+		sub := valuesFromString(r.FormValue("sub"))
+		pred := valuesFromString(r.FormValue("pred"))
+		obj := valuesFromString(r.FormValue("obj"))
+		label := valuesFromString(r.FormValue("label"))
+		s.serveRawQuads(ctx, gs, sub, pred, obj, label, limit)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/internal/gephi/stream.go
+++ b/internal/gephi/stream.go
@@ -1,0 +1,345 @@
+package gephi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+
+	"github.com/julienschmidt/httprouter"
+	"golang.org/x/net/context"
+
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
+	"github.com/cayleygraph/cayley/graph/path"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/cayleygraph/cayley/voc/rdf"
+	"github.com/cayleygraph/cayley/voc/rdfs"
+	"github.com/cayleygraph/cayley/voc/schema"
+)
+
+const (
+	defaultLimit = 10000
+	defaultSize  = 20
+	limitCoord   = 500
+)
+
+const (
+	iriInlinePred = quad.IRI("gephi:inline")
+	iriPosX       = quad.IRI("gephi:x")
+	iriPosY       = quad.IRI("gephi:y")
+)
+
+var defaultInline = []quad.IRI{
+	iriPosX, iriPosY,
+
+	rdf.Type,
+	rdfs.Label,
+	schema.Name,
+}
+
+type GraphStreamHandler struct {
+	QS graph.QuadStore
+}
+
+type valHash [quad.HashSize]byte
+
+type GraphStream struct {
+	seen map[valHash]int
+	buf  *bytes.Buffer
+	w    io.Writer
+}
+
+func printNodeID(id int) string {
+	return strconv.FormatInt(int64(id), 16)
+}
+
+func NewGraphStream(w io.Writer) *GraphStream {
+	return &GraphStream{
+		w:    w,
+		seen: make(map[valHash]int),
+		buf:  bytes.NewBuffer(nil),
+	}
+}
+func toNodeLabel(v quad.Value) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v.Native())
+}
+
+func randCoord() float64 {
+	return (rand.Float64() - 0.5) * limitCoord * 2
+}
+func randPos() (x float64, y float64) {
+	x = randCoord()
+	x2 := x * x
+	for y = randCoord(); x2+y*y > limitCoord*limitCoord; y = randCoord() {
+	}
+	return
+}
+
+func setStringProp(v *string, props map[quad.Value]quad.Value, name quad.IRI) {
+	if p, ok := props[name]; ok {
+		if s, ok := p.Native().(string); ok {
+			*v = s
+		}
+	}
+}
+
+func (gs *GraphStream) makeOneNode(id string, v quad.Value, props map[quad.Value]quad.Value) map[string]streamNode {
+	x, y := randPos()
+	var xok, yok bool
+	if p, ok := props[iriPosX]; ok {
+		xok = true
+		switch p := p.(type) {
+		case quad.Int:
+			x = float64(p)
+		case quad.Float:
+			x = float64(p)
+		default:
+			xok = false
+		}
+	}
+	if p, ok := props[iriPosY]; ok {
+		yok = true
+		switch p := p.(type) {
+		case quad.Int:
+			y = float64(p)
+		case quad.Float:
+			y = float64(p)
+		default:
+			yok = false
+		}
+	}
+	var slabel string
+	setStringProp(&slabel, props, rdfs.Label)
+	setStringProp(&slabel, props, schema.Name)
+
+	var label interface{}
+	if slabel != "" {
+		label = slabel
+	} else {
+		label = v.Native()
+	}
+
+	node := streamNode{
+		"label": label,
+		"size":  defaultSize, "x": x, "y": y,
+	}
+	for k, v := range props {
+		if k == nil || v == nil ||
+			(k == iriPosX && xok) ||
+			(k == iriPosY && yok) {
+			continue
+		}
+		node[toNodeLabel(k)] = toNodeLabel(v)
+	}
+	return map[string]streamNode{id: node}
+}
+func (gs *GraphStream) AddNode(v quad.Value, props map[quad.Value]quad.Value) string {
+	var h valHash
+	quad.HashTo(v, h[:])
+	return gs.addNode(v, h, props)
+}
+func (gs *GraphStream) encode(o interface{}) {
+	data, _ := json.Marshal(o)
+	gs.buf.Write(data)
+	// Gephi requires \r character at the end of each line
+	gs.buf.WriteString("\r\n")
+}
+func (gs *GraphStream) addNode(v quad.Value, h valHash, props map[quad.Value]quad.Value) string {
+	id, ok := gs.seen[h]
+	if ok {
+		return printNodeID(id)
+	} else if v == nil {
+		return ""
+	}
+	id = len(gs.seen)
+	gs.seen[h] = id
+	sid := printNodeID(id)
+
+	m := gs.makeOneNode(sid, v, props)
+	gs.encode(graphStreamEvent{AddNodes: m})
+	return sid
+}
+func (gs *GraphStream) ChangeNode(v quad.Value, sid string, props map[quad.Value]quad.Value) {
+	m := gs.makeOneNode(sid, v, props)
+	gs.encode(graphStreamEvent{ChangeNodes: m})
+}
+func (gs *GraphStream) AddEdge(i int, s, o string, p quad.Value) {
+	id := "q" + strconv.FormatInt(int64(i), 16)
+	ps := toNodeLabel(p)
+	gs.encode(graphStreamEvent{
+		AddEdges: map[string]streamEdge{id: {
+			Subject:   s,
+			Predicate: ps, Label: ps,
+			Object: o,
+		}},
+	})
+}
+func (gs *GraphStream) Flush() error {
+	if gs.buf.Len() == 0 {
+		return nil
+	}
+	_, err := gs.buf.WriteTo(gs.w)
+	if err == nil {
+		gs.buf.Reset()
+	}
+	return err
+}
+
+type streamNode map[string]interface{}
+type streamEdge struct {
+	Subject   string `json:"source"`
+	Label     string `json:"label"`
+	Predicate string `json:"pred"`
+	Object    string `json:"target"`
+}
+type graphStreamEvent struct {
+	AddNodes    map[string]streamNode `json:"an,omitempty"`
+	ChangeNodes map[string]streamNode `json:"cn,omitempty"`
+	DelNodes    map[string]streamNode `json:"dn,omitempty"`
+
+	AddEdges    map[string]streamEdge `json:"ae,omitempty"`
+	ChangeEdges map[string]streamEdge `json:"ce,omitempty"`
+	DelEdges    map[string]streamEdge `json:"de,omitempty"`
+}
+
+func (s *GraphStreamHandler) serveRawQuads(ctx context.Context, gs *GraphStream, limit int) {
+	it := s.QS.QuadsAllIterator()
+	defer it.Close()
+
+	var sh, oh valHash
+	for i := 0; (limit < 0 || i < limit) && it.Next(); i++ {
+		qv := it.Result()
+		if qv == nil {
+			continue
+		}
+		q := s.QS.Quad(qv)
+		quad.HashTo(q.Subject, sh[:])
+		quad.HashTo(q.Object, oh[:])
+		s, o := gs.addNode(q.Subject, sh, nil), gs.addNode(q.Object, oh, nil)
+		if s == "" || o == "" {
+			continue
+		}
+		gs.AddEdge(i, s, o, q.Predicate)
+		if err := gs.Flush(); err != nil {
+			return
+		}
+	}
+}
+
+func (s *GraphStreamHandler) serveNodesWithProps(ctx context.Context, gs *GraphStream, limit int) {
+	propsPath := path.NewPath(s.QS).Has(iriInlinePred, quad.Bool(true))
+
+	// list of predicates marked as inline properties for gephi
+	inline := make(map[quad.Value]struct{})
+	err := propsPath.Iterate(ctx).EachValue(s.QS, func(v quad.Value) {
+		inline[v] = struct{}{}
+	})
+	if err != nil {
+		clog.Errorf("cannot iterate over properties: %v", err)
+		return
+	}
+	// inline some well-known predicates
+	for _, iri := range defaultInline {
+		inline[iri] = struct{}{}
+		inline[iri.Full()] = struct{}{}
+	}
+
+	ignore := make(map[quad.Value]struct{})
+
+	nodes := iterator.NewNot(propsPath.BuildIterator(), s.QS.NodesAllIterator())
+	defer nodes.Close()
+
+	ictx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	itc := graph.Iterate(ictx, nodes).On(s.QS).Limit(limit)
+
+	qi := 0
+	_ = itc.EachValuePair(s.QS, func(v graph.Value, nv quad.Value) {
+		if _, skip := ignore[nv]; skip {
+			return
+		}
+		// list of inline properties
+		props := make(map[quad.Value]quad.Value)
+
+		var (
+			sid   string
+			h, oh valHash
+		)
+		quad.HashTo(nv, h[:])
+
+		predIt := s.QS.QuadIterator(quad.Subject, nodes.Result())
+		defer predIt.Close()
+		for predIt.Next() {
+			// this check helps us ignore nodes with no links
+			if sid == "" {
+				sid = gs.addNode(nv, h, props)
+			}
+			q := s.QS.Quad(predIt.Result())
+			if _, ok := inline[q.Predicate]; ok {
+				props[q.Predicate] = q.Object
+				ignore[q.Object] = struct{}{}
+			} else {
+				quad.HashTo(q.Object, oh[:])
+				o := gs.addNode(q.Object, oh, nil)
+				if o == "" {
+					continue
+				}
+				gs.AddEdge(qi, sid, o, q.Predicate)
+				qi++
+				if err := gs.Flush(); err != nil {
+					cancel()
+					return
+				}
+			}
+		}
+		if err := predIt.Err(); err != nil {
+			cancel()
+			return
+		} else if sid == "" {
+			return
+		}
+		if len(props) != 0 {
+			gs.ChangeNode(nv, sid, props)
+		}
+		if err := gs.Flush(); err != nil {
+			cancel()
+			return
+		}
+	})
+}
+
+func (s *GraphStreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	ctx := context.TODO()
+	var limit int
+	if s := r.FormValue("limit"); s != "" {
+		limit, _ = strconv.Atoi(s)
+	}
+	if limit == 0 {
+		limit = defaultLimit
+	}
+	mode := "raw"
+	if s := r.FormValue("mode"); s != "" {
+		mode = s
+	}
+
+	w.Header().Set("Content-Type", "application/stream+json")
+	gs := NewGraphStream(w)
+	switch mode {
+	case "nodes":
+		s.serveNodesWithProps(ctx, gs, limit)
+	case "raw":
+		s.serveRawQuads(ctx, gs, limit)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+}

--- a/internal/gephi/stream_test.go
+++ b/internal/gephi/stream_test.go
@@ -1,0 +1,19 @@
+package gephi
+
+import (
+	"bytes"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStreamEncoder(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	gs := NewGraphStream(buf)
+	p := map[quad.Value]quad.Value{iriPosX: quad.Float(0), iriPosY: quad.Float(0)}
+	gs.AddNode(quad.String("aaa"), p)
+	gs.AddNode(quad.String("bbb"), p)
+	gs.Flush()
+	const expect = "{\"an\":{\"0\":{\"label\":\"aaa\",\"size\":20,\"x\":0,\"y\":0}}}\r\n{\"an\":{\"1\":{\"label\":\"bbb\",\"size\":20,\"x\":0,\"y\":0}}}\r\n"
+	require.Equal(t, expect, buf.String())
+}

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/internal/config"
 	"github.com/cayleygraph/cayley/internal/db"
+	"github.com/cayleygraph/cayley/internal/gephi"
 )
 
 type ResponseHandler func(http.ResponseWriter, *http.Request, httprouter.Params) int
@@ -170,6 +171,10 @@ func SetupRoutes(handle *graph.Handle, cfg *config.Config) {
 	api := &API{config: cfg, handle: handle}
 	api.APIv1(r)
 	api.APIv2(r)
+	gs := &gephi.GraphStreamHandler{QS: handle.QuadStore}
+	const gephiPath = "/gephi/gs"
+	r.GET(gephiPath, gs.ServeHTTP)
+	fmt.Printf("Serving Gephi GraphStream at http://localhost:%s%s\n", cfg.ListenPort, gephiPath)
 
 	//m.Use(martini.Static("static", martini.StaticOptions{Prefix: "/static", SkipLogging: true}))
 	//r.Handler("GET", "/static", http.StripPrefix("/static", http.FileServer(http.Dir("static/"))))

--- a/voc/schema/schema.go
+++ b/voc/schema/schema.go
@@ -48,5 +48,6 @@ const (
 
 const (
 	// The name of the item.
-	Name = Prefix + `name`
+	Name    = Prefix + `name`
+	UrlProp = Prefix + `url`
 )

--- a/voc/schema/schema.go
+++ b/voc/schema/schema.go
@@ -45,3 +45,8 @@ const (
 	// A property, used to indicate attributes and relationships of some Thing; equivalent to rdf:Property.
 	Property = Prefix + "Property"
 )
+
+const (
+	// The name of the item.
+	Name = Prefix + `name`
+)


### PR DESCRIPTION
Implement GraphStream HTTP endpoint.

**Support two modes:**

* "Raw" nodes and quads

* Nodes with properties (use metadata in graph to inline some properties) 

Example of the last mode for movies dataset:

![screenshot_201001](https://cloud.githubusercontent.com/assets/676724/22856226/3cb98af6-f096-11e6-95c0-4742f11ac1f1.png)

P.S. I'm not a visualization expert :P

**TODO:**

- [x] Inline common properties (`-type-> person`).
- [ ] Replace blank node patterns with a single edge (`-starring-> (bnode) -actor->`).

More information in `docs/GephiGraphStream.md`.

Note: there is a [bug](https://github.com/gephi/gephi/issues/1668) that prevents loading over 200k nodes.