### PR TITLE
Issue #286 init db and config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Its goal is to be a part of the developer's toolbox where [Linked Data](http://l
 * Built-in query editor and visualizer
 * Multiple query languages:
   * JavaScript, with a [Gremlin](http://gremlindocs.com/)-inspired\* graph object.
-  * (simplified) [MQL](https://developers.google.com/freebase/v1/mql-overview), for Freebase fans
+  * (simplified) MQL, for [Freebase](https://en.wikipedia.org/wiki/Freebase) fans
 * Plays well with multiple backend stores:
   * [LevelDB](https://github.com/google/leveldb)
   * [Bolt](https://github.com/boltdb/bolt)

--- a/docs/Quickstart-As-Application.md
+++ b/docs/Quickstart-As-Application.md
@@ -36,9 +36,11 @@ Those two options (db and dbpath) are always going to be present. If you feel li
 
 You can repeat the `--db` and `--dbpath` flags from here forward instead of the config flag, but let's assume you created `cayley.cfg.overview`
 
+Note: when you specify parameters in the config file the config flags (command line arguments) are ignored.
+
 ### Load Data Into A Graph
 
-First we load the data.
+After the database is initialized we load the data.
 
 ```bash
 ./cayley load --config=cayley.cfg.overview --quads=data/testdata.nq
@@ -113,6 +115,16 @@ Cayley now listening on 127.0.0.1:64210
 
 If you visit that address (often, [http://localhost:64210](http://localhost:64210)) you'll see the full web interface and also have a graph ready to serve queries via the [HTTP API](HTTP.md)
 
+#### Access from other machines ####
+When you want to reach the API or UI from another machine in the network you need to specify the host argument:
+```bash
+./cayley http --config=cayley.cfg.overview --host=0.0.0.0
+```
+This makes it listen on all interfaces. You can also give it the specific the IP address you want Cayley to bind to. 
+
+**Warning**: for security reasons you might not want to do this on a public accessible machine. 
+
+
 ## UI Overview
 
 ### Sidebar
@@ -144,11 +156,11 @@ For example:
 ```javascript
 [
 {
-  "source": "node1"
+  "source": "node1",
   "target": "node2"
 },
 {
-  "source": "node1"
+  "source": "node1",
   "target": "node3"
 },
 ]

--- a/docs/Quickstart-As-Application.md
+++ b/docs/Quickstart-As-Application.md
@@ -8,6 +8,17 @@ Grab the latest [release binary](http://github.com/cayleygraph/cayley/releases) 
 
 If you prefer to build from source, see [Contributing.md](Contributing.md) which has instructions. 
 
+### Quick preview ###
+If you downloaded the correct binary the fastest way to have a peak into Cayley is to load one of the example data file in the ./data directory, and query them by the web interface.
+
+```bash
+./cayley http --dbpath=./data/30kmoviedata.nq.gz --host 0.0.0.0
+Cayley now listening on 0.0.0.0:64210
+  ```
+You can now open the web-interface on: [localhost:64210](http://localhost:64210/)
+
+Or you can directly configure a backend storage engine like defined below and create your own graph.
+
 ### Initialize A Graph
 
 Now that Cayley is downloaded (or built), let's create our database. `init` is the subcommand to set up a database and the right indices.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -49,7 +49,7 @@ func Open(cfg *config.Config) (*graph.Handle, error) {
 
 func OpenQuadStore(cfg *config.Config) (graph.QuadStore, error) {
 	clog.Infof("Opening quad store %q at %s", cfg.DatabaseType, cfg.DatabasePath)
-	qs, err := graph.NewQuadStore(cfg.DatabaseType, cfg.DatabasePath, cfg.DatabaseOptions);
+	qs, err := graph.NewQuadStore(cfg.DatabaseType, cfg.DatabasePath, cfg.DatabaseOptions)
 
 	// override error to make it more informative
 	if os.IsNotExist(err) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/internal/config"
+	"os"
 )
 
 var ErrNotPersistent = errors.New("database type is not persistent")
@@ -48,7 +49,13 @@ func Open(cfg *config.Config) (*graph.Handle, error) {
 
 func OpenQuadStore(cfg *config.Config) (graph.QuadStore, error) {
 	clog.Infof("Opening quad store %q at %s", cfg.DatabaseType, cfg.DatabasePath)
-	qs, err := graph.NewQuadStore(cfg.DatabaseType, cfg.DatabasePath, cfg.DatabaseOptions)
+	qs, err := graph.NewQuadStore(cfg.DatabaseType, cfg.DatabasePath, cfg.DatabaseOptions);
+
+	// override error to make it more informative
+	if os.IsNotExist(err) {
+		err = errors.New(fmt.Sprintf("file does not exist: %s. Please use with --init or run ./cayley init when it is a new database (see docs for more information)", cfg.DatabasePath))
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,12 +17,12 @@ package db
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/cayleygraph/cayley/clog"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/internal/config"
-	"os"
 )
 
 var ErrNotPersistent = errors.New("database type is not persistent")
@@ -53,7 +53,7 @@ func OpenQuadStore(cfg *config.Config) (graph.QuadStore, error) {
 
 	// override error to make it more informative
 	if os.IsNotExist(err) {
-		err = errors.New(fmt.Sprintf("file does not exist: %s. Please use with --init or run ./cayley init when it is a new database (see docs for more information)", cfg.DatabasePath))
+		err = fmt.Errorf("file does not exist: %s. Please use with --init or run ./cayley init when it is a new database (see docs for more information)", cfg.DatabasePath)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Hopefully made the quickstart application a bit more clear for running init and then load/repl.
Also did a small fix of returning a more specific error message when a database file can not be opened. Not sure if this is necessary since there is a new CLI on its way.
And explained the binding on localhost and host 0.0.0.0 if people try to access it on a virtual machine / test-server.