### PR TITLE
Updated documentation based on Issue #349

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,7 +45,7 @@ All command line flags take precedence over the configuration file.
   * Type: String
   * Default: "127.0.0.1"
 
-  The hostname or IP address for Cayley's HTTP server to listen on. Defaults to all interfaces.
+  The hostname or IP address for Cayley's HTTP server to listen on. Defaults to localhost. If you need to have it available from other machines use either 0.0.0.0 to make it available on all interfaces or listen on a specific IP addrss.
 
 #### **`listen_port`**
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,7 +45,7 @@ All command line flags take precedence over the configuration file.
   * Type: String
   * Default: "127.0.0.1"
 
-  The hostname or IP address for Cayley's HTTP server to listen on. Defaults to localhost. If you need to have it available from other machines use either 0.0.0.0 to make it available on all interfaces or listen on a specific IP addrss.
+  The hostname or IP address for Cayley's HTTP server to listen on. Defaults to localhost. If you need to have it available from other machines use either 0.0.0.0 to make it available on all interfaces or listen on a specific IP address.
 
 #### **`listen_port`**
 


### PR DESCRIPTION
127.0.0.1 is not equal to all interfaces. And all interfaces shouldn't be the default because of security reasons. I updated this in the docs and I also updated this in the new_cli branch that I will push later.
This info was already updated before in the quickstart for application.