### PR TITLE
docs: fix a typo in Quickstart-As-Application.md

### DIFF
--- a/docs/Quickstart-As-Application.md
+++ b/docs/Quickstart-As-Application.md
@@ -132,7 +132,7 @@ This makes it listen on all interfaces. You can also give it the specific the IP
 Along the side are the various actions or views you can take. From the top, these are:
 
 * Run Query (run the query)
-* Gremlin (a dropdown, to pick your query language, MPL is the other)
+* Gremlin (a dropdown, to pick your query language, MQL is the other)
   * [GremlinAPI.md](GremlinAPI.md): This is the one of the two query languages used either via the REPL or HTTP interface.
   * [MQL.md](MQL.md): The *other* query language the interfaces support. 
 


### PR DESCRIPTION
I found a typo in Quickstart-As-Application.md.
MPL => MQL