### PR TITLE
Switch release tooling from goxc to relego

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -1,6 +1,0 @@
-{
-	"Arch": "arm amd64 386",
-	"Os": "linux darwin windows",
-	"ResourcesInclude": "README.md,static,templates,LICENSE,AUTHORS,CONTRIBUTORS,docs,cayley.cfg.example,data",
-	"ConfigVersion": "0.9"
-}

--- a/.relego.yaml
+++ b/.relego.yaml
@@ -1,0 +1,33 @@
+build:
+  - platform: src
+  - platform: linux
+    arch:
+      - amd64
+      - arm64
+      - arm
+      - "386"
+  - platform: darwin
+    arch:
+      - "386"
+      - amd64
+  - platform: windows
+    arch:
+      - "386"
+      - amd64
+ld:
+  versionPath: "main.Version"
+  buildDatePath: "main.BuildDate"
+mains:
+  - "./cmd/cayley"
+  - "./cmd/cayleyupgrade"
+include:
+  - README.md
+  - LICENSE
+  - AUTHORS
+  - CONTRIBUTORS
+  - docs
+  - static
+  - templates
+  - cayley.cfg.example
+  - data
+outputDir: "$GOPATH/bin"

--- a/glide.lock
+++ b/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/badgerodon/peg
   version: 9e5f7f4d07ca576562618c23e8abadda278b684f
 - name: github.com/boltdb/bolt
-  version: 04a3e85793043e76d41164037d0d7f9d53eecae3
+  version: a705895fdad108f053eae7ee011ed94a0541ee13
 - name: github.com/cznic/mathutil
   version: f9551431b78e71ee24939a1e9d8f49f43898b5cd
 - name: github.com/davecgh/go-spew


### PR DESCRIPTION
Bump the Bolt dependency and (in so doing) support arm64