### PR TITLE
The -host option was missing the port argument

### DIFF
--- a/docs/Quickstart-As-Application.md
+++ b/docs/Quickstart-As-Application.md
@@ -12,7 +12,7 @@ If you prefer to build from source, see [Contributing.md](Contributing.md) which
 If you downloaded the correct binary the fastest way to have a peak into Cayley is to load one of the example data file in the ./data directory, and query them by the web interface.
 
 ```bash
-./cayley http --dbpath=./data/30kmoviedata.nq.gz --host 0.0.0.0
+./cayley http --dbpath=./data/30kmoviedata.nq.gz --host 0.0.0.0:64210
 Cayley now listening on 0.0.0.0:64210
   ```
 You can now open the web-interface on: [localhost:64210](http://localhost:64210/)


### PR DESCRIPTION
When running the example, I had as a result:
```shell
I0420 21:27:49.606456    2853 cayley.go:67] Cayley version: 0.7.0-alpha (dev snapshot)
I0420 21:27:49.607930    2853 database.go:174] using backend "memstore" (./data/30kmoviedata.nq.gz)
Serving Gephi GraphStream at http://localhost:/gephi/gs
I0420 21:27:49.610088    2853 http.go:59] listening on 0.0.0.0, web interface at http://0.0.0.0
Error: listen tcp: address 0.0.0.0: missing port in address
```

Adding the :port to the command line works:

```shell
cayley http --dbpath=./data/30kmoviedata.nq.gz --host 0.0.0.0:64210
I0420 21:28:17.251777    2870 cayley.go:67] Cayley version: 0.7.0-alpha (dev snapshot)
I0420 21:28:17.253495    2870 database.go:174] using backend "memstore" (./data/30kmoviedata.nq.gz)
Serving Gephi GraphStream at http://localhost:/gephi/gs
I0420 21:28:17.261681    2870 http.go:59] listening on 0.0.0.0:64210, web interface at http://0.0.0.0:64210
```