### PR TITLE
Ignore duplicate quads by default

### DIFF
--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -135,7 +135,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("dbpath", "a", "", "path or address string for database")
 	rootCmd.PersistentFlags().Bool("read_only", false, "open database in read-only mode")
 
-	rootCmd.PersistentFlags().Bool("dup", false, "don't stop loading on duplicated on add")
+	rootCmd.PersistentFlags().Bool("dup", true, "don't stop loading on duplicated on add")
 	rootCmd.PersistentFlags().Bool("missing", false, "don't stop loading on missing key on delete")
 	rootCmd.PersistentFlags().Int("batch", quad.DefaultBatch, "size of quads batch to load at once")
 

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -119,7 +119,7 @@ func IsInvalidAction(err error) bool {
 var (
 	// IgnoreDuplicates specifies whether duplicate quads
 	// cause an error during loading or are ignored.
-	IgnoreDuplicates = false
+	IgnoreDuplicates = true
 
 	// IgnoreMissing specifies whether missing quads
 	// cause an error during deletion or are ignored.


### PR DESCRIPTION
Errors on writing duplicate quads is confusing for most new users. I propose to ignore duplicates by default.  

Such error should be caused by per-transaction operations like compare-and-insert, not in the data import code path.