### PR TITLE
Make graph.Value safe again

### DIFF
--- a/cmd/cayley/command/dedup.go
+++ b/cmd/cayley/command/dedup.go
@@ -70,7 +70,7 @@ func (a sortProp) Len() int           { return len(a) }
 func (a sortProp) Less(i, j int) bool { return valueLess(a[i].Pred, a[j].Pred) }
 func (a sortProp) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
-func hashProperties(h hash.Hash, m map[graph.Value]property) string {
+func hashProperties(h hash.Hash, m map[interface{}]property) string {
 	props := make([]property, 0, len(m))
 	for _, p := range m {
 		if len(p.Values) > 1 {
@@ -142,7 +142,7 @@ func dedupProperties(ctx context.Context, h *graph.Handle, pred, typ quad.IRI) e
 		cnt++
 		it := qs.QuadIterator(quad.Subject, s)
 		defer it.Close()
-		m := make(map[graph.Value]property)
+		m := make(map[interface{}]property)
 		for it.Next() {
 			q := it.Result()
 			p := qs.QuadDirection(q, quad.Predicate)

--- a/graph/bolt/quadstore.go
+++ b/graph/bolt/quadstore.go
@@ -33,10 +33,10 @@ import (
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
-		NewFunc:           newQuadStore,
-		UpgradeFunc:       upgradeBolt,
-		InitFunc:          createNewBolt,
-		IsPersistent:      true,
+		NewFunc:      newQuadStore,
+		UpgradeFunc:  upgradeBolt,
+		InitFunc:     createNewBolt,
+		IsPersistent: true,
 	})
 }
 
@@ -49,8 +49,6 @@ const localFillPercent = 0.7
 const (
 	QuadStoreType = "bolt"
 )
-
-var _ graph.Keyer = (*Token)(nil)
 
 type Token struct {
 	nodes  bool

--- a/graph/bolt2/quadstore.go
+++ b/graph/bolt2/quadstore.go
@@ -350,3 +350,5 @@ func (qs *QuadStore) getPrimitive(val Int64Value) (*proto.Primitive, bool) {
 }
 
 type Int64Value uint64
+
+func (v Int64Value) Key() interface{} { return v }

--- a/graph/gaedatastore/quadstore.go
+++ b/graph/gaedatastore/quadstore.go
@@ -59,7 +59,8 @@ type Token struct {
 	Hash string
 }
 
-func (t Token) IsNode() bool { return t.Kind == nodeKind }
+func (t Token) IsNode() bool     { return t.Kind == nodeKind }
+func (t Token) Key() interface{} { return t }
 
 type QuadEntry struct {
 	Hash      string

--- a/graph/iterator/all.go
+++ b/graph/iterator/all.go
@@ -39,9 +39,13 @@ type Int64 struct {
 
 type Int64Node int64
 
+func (v Int64Node) Key() interface{} { return v }
+
 func (Int64Node) IsNode() bool { return true }
 
 type Int64Quad int64
+
+func (v Int64Quad) Key() interface{} { return v }
 
 func (Int64Quad) IsNode() bool { return false }
 
@@ -146,8 +150,8 @@ func (it *Int64) Size() (int64, bool) {
 	return Size, true
 }
 
-func valToInt64(v graph.Value) int64{
-	if v, ok := v.(Int64Node); ok{
+func valToInt64(v graph.Value) int64 {
+	if v, ok := v.(Int64Node); ok {
 		return int64(v)
 	}
 	return int64(v.(Int64Quad))

--- a/graph/iterator/count.go
+++ b/graph/iterator/count.go
@@ -5,18 +5,6 @@ import (
 	"github.com/cayleygraph/cayley/quad"
 )
 
-var (
-	_ graph.Value           = fetchedValue{}
-	_ graph.PreFetchedValue = fetchedValue{}
-)
-
-type fetchedValue struct {
-	Val quad.Value
-}
-
-func (v fetchedValue) IsNode() bool       { return true }
-func (v fetchedValue) NameOf() quad.Value { return v.Val }
-
 // Count iterator returns one element with size of underlying iterator.
 type Count struct {
 	uid    uint64
@@ -96,7 +84,7 @@ func (it *Count) Result() graph.Value {
 	if it.result == nil {
 		return nil
 	}
-	return fetchedValue{Val: it.result}
+	return graph.PreFetched(it.result)
 }
 
 func (it *Count) Contains(val graph.Value) bool {

--- a/graph/iterator/count_test.go
+++ b/graph/iterator/count_test.go
@@ -9,36 +9,36 @@ import (
 
 func TestCount(t *testing.T) {
 	fixed := NewFixed(Identity,
-		fetchedValue{Val: quad.String("a")},
-		fetchedValue{Val: quad.String("b")},
-		fetchedValue{Val: quad.String("c")},
-		fetchedValue{Val: quad.String("d")},
-		fetchedValue{Val: quad.String("e")},
+		graph.PreFetched(quad.String("a")),
+		graph.PreFetched(quad.String("b")),
+		graph.PreFetched(quad.String("c")),
+		graph.PreFetched(quad.String("d")),
+		graph.PreFetched(quad.String("e")),
 	)
 	it := NewCount(fixed, nil)
 	require.True(t, it.Next())
-	require.Equal(t, fetchedValue{Val: quad.Int(5)}, it.Result())
+	require.Equal(t, graph.PreFetched(quad.Int(5)), it.Result())
 	require.False(t, it.Next())
-	require.True(t, it.Contains(fetchedValue{Val: quad.Int(5)}))
-	require.False(t, it.Contains(fetchedValue{Val: quad.Int(3)}))
+	require.True(t, it.Contains(graph.PreFetched(quad.Int(5))))
+	require.False(t, it.Contains(graph.PreFetched(quad.Int(3))))
 
 	fixed.Reset()
 
 	fixed2 := NewFixed(Identity,
-		fetchedValue{Val: quad.String("b")},
-		fetchedValue{Val: quad.String("d")},
+		graph.PreFetched(quad.String("b")),
+		graph.PreFetched(quad.String("d")),
 	)
 	it = NewCount(NewAnd(nil, fixed, fixed2), nil)
 	require.True(t, it.Next())
-	require.Equal(t, fetchedValue{Val: quad.Int(2)}, it.Result())
+	require.Equal(t, graph.PreFetched(quad.Int(2)), it.Result())
 	require.False(t, it.Next())
-	require.False(t, it.Contains(fetchedValue{Val: quad.Int(5)}))
-	require.True(t, it.Contains(fetchedValue{Val: quad.Int(2)}))
+	require.False(t, it.Contains(graph.PreFetched(quad.Int(5))))
+	require.True(t, it.Contains(graph.PreFetched(quad.Int(2))))
 
 	it.Reset()
 	it.Tagger().Add("count")
 	require.True(t, it.Next())
 	m := make(map[string]graph.Value)
 	it.TagResults(m)
-	require.Equal(t, map[string]graph.Value{"count": fetchedValue{Val: quad.Int(2)}}, m)
+	require.Equal(t, map[string]graph.Value{"count": graph.PreFetched(quad.Int(2))}, m)
 }

--- a/graph/iterator/materialize.go
+++ b/graph/iterator/materialize.go
@@ -32,7 +32,7 @@ type result struct {
 type Materialize struct {
 	uid         uint64
 	tags        graph.Tagger
-	containsMap map[graph.Value]int
+	containsMap map[interface{}]int
 	values      [][]result
 	actualSize  int64
 	index       int
@@ -47,7 +47,7 @@ type Materialize struct {
 func NewMaterialize(sub graph.Iterator) *Materialize {
 	return &Materialize{
 		uid:         NextUID(),
-		containsMap: make(map[graph.Value]int),
+		containsMap: make(map[interface{}]int),
 		subIt:       sub,
 		index:       -1,
 	}

--- a/graph/iterator/recursive.go
+++ b/graph/iterator/recursive.go
@@ -18,10 +18,10 @@ type Recursive struct {
 
 	qs            graph.QuadStore
 	morphism      graph.ApplyMorphism
-	seen          map[graph.Value]seenAt
+	seen          map[interface{}]seenAt
 	nextIt        graph.Iterator
 	depth         int
-	pathMap       map[graph.Value][]map[string]graph.Value
+	pathMap       map[interface{}][]map[string]graph.Value
 	pathIndex     int
 	containsValue graph.Value
 	depthTags     graph.Tagger
@@ -45,10 +45,10 @@ func NewRecursive(qs graph.QuadStore, it graph.Iterator, morphism graph.ApplyMor
 
 		qs:            qs,
 		morphism:      morphism,
-		seen:          make(map[graph.Value]seenAt),
+		seen:          make(map[interface{}]seenAt),
 		nextIt:        &Null{},
 		baseIt:        qs.FixedIterator(),
-		pathMap:       make(map[graph.Value][]map[string]graph.Value),
+		pathMap:       make(map[interface{}][]map[string]graph.Value),
 		containsValue: nil,
 	}
 }
@@ -62,8 +62,8 @@ func (it *Recursive) Reset() {
 	it.result.depth = 0
 	it.err = nil
 	it.subIt.Reset()
-	it.seen = make(map[graph.Value]seenAt)
-	it.pathMap = make(map[graph.Value][]map[string]graph.Value)
+	it.seen = make(map[interface{}]seenAt)
+	it.pathMap = make(map[interface{}][]map[string]graph.Value)
 	it.containsValue = nil
 	it.pathIndex = 0
 	it.nextIt = &Null{}

--- a/graph/iterator/recursive_test.go
+++ b/graph/iterator/recursive_test.go
@@ -26,7 +26,7 @@ import (
 func singleHop(pred string) graph.ApplyMorphism {
 	return func(qs graph.QuadStore, it graph.Iterator) graph.Iterator {
 		fixed := qs.FixedIterator()
-		fixed.Add(quad.Raw(pred))
+		fixed.Add(graph.PreFetched(quad.Raw(pred)))
 		predlto := NewLinksTo(qs, fixed, quad.Predicate)
 		lto := NewLinksTo(qs, it.Clone(), quad.Subject)
 		and := NewAnd(qs)
@@ -51,7 +51,7 @@ var rec_test_qs = &store{
 func TestRecursiveNext(t *testing.T) {
 	qs := rec_test_qs
 	start := qs.FixedIterator()
-	start.Add(quad.Raw("alice"))
+	start.Add(graph.PreFetched(quad.Raw("alice")))
 	r := NewRecursive(qs, start, singleHop("parent"))
 	expected := []string{"bob", "charlie", "dani", "emily"}
 
@@ -69,7 +69,7 @@ func TestRecursiveNext(t *testing.T) {
 func TestRecursiveContains(t *testing.T) {
 	qs := rec_test_qs
 	start := qs.FixedIterator()
-	start.Add(quad.Raw("alice"))
+	start.Add(graph.PreFetched(quad.Raw("alice")))
 	r := NewRecursive(qs, start, singleHop("parent"))
 	values := []string{"charlie", "bob", "not"}
 	expected := []bool{true, true, false}
@@ -90,7 +90,7 @@ func TestRecursiveNextPath(t *testing.T) {
 	and := NewAnd(qs)
 	and.AddSubIterator(it)
 	fixed := qs.FixedIterator()
-	fixed.Add(quad.Raw("alice"))
+	fixed.Add(graph.PreFetched(quad.Raw("alice")))
 	and.AddSubIterator(fixed)
 	r := NewRecursive(qs, and, singleHop("parent"))
 

--- a/graph/iterator/unique.go
+++ b/graph/iterator/unique.go
@@ -72,10 +72,7 @@ func (it *Unique) Next() bool {
 
 	for it.subIt.Next() {
 		curr := it.subIt.Result()
-		var key interface{} = curr
-		if v, ok := curr.(graph.Keyer); ok {
-			key = v.Key()
-		}
+		key := graph.ToKey(curr)
 		if ok := it.seen[key]; !ok {
 			it.result = curr
 			it.seen[key] = true

--- a/graph/iterator/value_comparison_test.go
+++ b/graph/iterator/value_comparison_test.go
@@ -56,6 +56,7 @@ func mixedFixedIterator() *Fixed {
 type stringNode string
 
 func (stringNode) IsNode() bool { return true }
+func (s stringNode) Key() interface{} { return s }
 
 var comparisonTests = []struct {
 	message  string

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -33,10 +33,10 @@ import (
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
-		NewFunc:           newQuadStore,
-		UpgradeFunc:       upgradeLevelDB,
-		InitFunc:          createNewLevelDB,
-		IsPersistent:      true,
+		NewFunc:      newQuadStore,
+		UpgradeFunc:  upgradeLevelDB,
+		InitFunc:     createNewLevelDB,
+		IsPersistent: true,
 	})
 }
 
@@ -50,8 +50,6 @@ const (
 )
 
 var order = binary.LittleEndian
-
-var _ graph.Keyer = (Token)(nil)
 
 type Token []byte
 

--- a/graph/mongo/quadstore.go
+++ b/graph/mongo/quadstore.go
@@ -36,20 +36,22 @@ const QuadStoreType = "mongo"
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
-		NewFunc:           newQuadStore,
-		UpgradeFunc:       nil,
-		InitFunc:          createNewMongoGraph,
-		IsPersistent:      true,
+		NewFunc:      newQuadStore,
+		UpgradeFunc:  nil,
+		InitFunc:     createNewMongoGraph,
+		IsPersistent: true,
 	})
 }
 
 type NodeHash string
 
-func (NodeHash) IsNode() bool { return false }
+func (NodeHash) IsNode() bool       { return false }
+func (v NodeHash) Key() interface{} { return v }
 
 type QuadHash string
 
-func (QuadHash) IsNode() bool { return false }
+func (QuadHash) IsNode() bool       { return false }
+func (v QuadHash) Key() interface{} { return v }
 
 func (h QuadHash) Get(d quad.Direction) string {
 	var offset int

--- a/graph/proto/primitive_helpers.go
+++ b/graph/proto/primitive_helpers.go
@@ -35,6 +35,10 @@ func (p Primitive) IsNode() bool {
 	return len(p.Value) != 0
 }
 
+func (p Primitive) Key() interface{} {
+	return p.ID
+}
+
 func (p *Primitive) IsSameLink(q *Primitive) bool {
 	return p.Subject == q.Subject && p.Predicate == q.Predicate && p.Object == q.Object && p.Label == q.Label
 }

--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -20,16 +20,17 @@ const QuadStoreType = "sql"
 
 func init() {
 	graph.RegisterQuadStore(QuadStoreType, graph.QuadStoreRegistration{
-		NewFunc:           newQuadStore,
-		UpgradeFunc:       nil,
-		InitFunc:          createSQLTables,
-		IsPersistent:      true,
+		NewFunc:      newQuadStore,
+		UpgradeFunc:  nil,
+		InitFunc:     createSQLTables,
+		IsPersistent: true,
 	})
 }
 
 type NodeHash [quad.HashSize]byte
 
-func (NodeHash) IsNode() bool { return true }
+func (NodeHash) IsNode() bool       { return true }
+func (h NodeHash) Key() interface{} { return h }
 func (h NodeHash) Valid() bool {
 	return h != NodeHash{}
 }
@@ -74,7 +75,8 @@ func hashOf(s quad.Value) (out NodeHash) {
 
 type QuadHashes [4]NodeHash
 
-func (QuadHashes) IsNode() bool { return false }
+func (QuadHashes) IsNode() bool       { return false }
+func (q QuadHashes) Key() interface{} { return q }
 func (q QuadHashes) Get(d quad.Direction) NodeHash {
 	switch d {
 	case quad.Subject:


### PR DESCRIPTION
As per an old discussion, we should not allow to pass arbitrary data types as `graph.Value`.

Also, since we need these values to be comparable anyway, promote `Keyer` interface as a part of `Value`.