### PR TITLE
Add labels morphism and Gizmo API

### DIFF
--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -226,6 +226,26 @@ func labelContextMorphism(tags []string, via ...interface{}) morphism {
 	}
 }
 
+// labelsMorphism iterates to the uniqified set of labels from
+// the given set of nodes in the path.
+func labelsMorphism() morphism {
+	m := morphism{
+		Name: "labels",
+		Reversal: func(ctx *pathContext) (morphism, *pathContext) {
+			panic("not implemented")
+		},
+		Apply: func(qs graph.QuadStore, in graph.Iterator, ctx *pathContext) (graph.Iterator, *pathContext) {
+			inLinks := iterator.NewLinksTo(qs, in, quad.Object)
+			outLinks := iterator.NewLinksTo(qs, in.Clone(), quad.Subject)
+			both := iterator.NewOr(inLinks, outLinks)
+			hasa := iterator.NewHasA(qs, both, quad.Label)
+			return iterator.NewUnique(hasa), ctx
+		},
+	}
+
+	return m
+}
+
 // predicatesMorphism iterates to the uniqified set of predicates from
 // the given set of nodes in the path.
 func predicatesMorphism(isIn bool) morphism {

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -268,6 +268,13 @@ func (p *Path) BothWithTags(tags []string, via ...interface{}) *Path {
 	np.stack = append(np.stack, bothMorphism(tags, via...))
 	return np
 }
+// Labels updates this path to represent the nodes of the labels
+// of inbound and outbound quads.
+func (p *Path) Labels() *Path {
+	np := p.clone()
+	np.stack = append(np.stack, labelsMorphism())
+	return np
+}
 
 // InPredicates updates this path to represent the nodes of the valid inbound
 // predicates from the current nodes.

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -280,6 +280,11 @@ func testSet(qs graph.QuadStore) []test {
 			expect:  []quad.Value{vDani},
 		},
 		{
+			message: "Labels()",
+			path:    StartPath(qs, vGreg).Labels(),
+			expect:  []quad.Value{vSmartGraph},
+		},
+		{
 			message: "InPredicates()",
 			path:    StartPath(qs, vBob).InPredicates(),
 			expect:  []quad.Value{vFollows},

--- a/query/gizmo/gizmo_test.go
+++ b/query/gizmo/gizmo_test.go
@@ -401,6 +401,13 @@ var testQueries = []struct {
 		expect: []string{"<follows>"},
 	},
 	{
+		message: "list all labels",
+		query: `
+		  g.V().Labels().All()
+		`,
+		expect: []string{"", "<smart_graph>"},
+	},
+	{
 		message: "list all in predicates",
 		query: `
 		  g.V().InPredicates().All()

--- a/query/gizmo/traversals.go
+++ b/query/gizmo/traversals.go
@@ -493,6 +493,12 @@ func (p *pathObject) Difference(path *pathObject) *pathObject {
 	return p.Except(path)
 }
 
+// Labels gets the list of inbound and outbound quad labels
+func (p *pathObject) Labels() *pathObject {
+	np := p.clonePath().Labels()
+	return p.new(np)
+}
+
 // InPredicates gets the list of predicates that are pointing in to a node.
 //
 // Example:


### PR DESCRIPTION
This PR adds support for querying for labels from the Gizmo API, by adding a morphism which returns all labels associated with the quad.