### PR TITLE
Set CORS headers on gephi stream

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -187,7 +187,7 @@ func SetupRoutes(handle *graph.Handle, cfg *Config) {
 
 	gs := &gephi.GraphStreamHandler{QS: handle.QuadStore}
 	const gephiPath = "/gephi/gs"
-	r.GET(gephiPath, gs.ServeHTTP)
+	r.GET(gephiPath, CORS(gs.ServeHTTP))
 
 	r.GET("/docs/:docpage", docs.ServeHTTP)
 	r.GET("/ui/:ui_type", root.ServeHTTP)


### PR DESCRIPTION
This PR adds CORS headers to responses on the `/gephi/gs` endpoint.