### PR TITLE
Rewrite PK and modify Delta

### DIFF
--- a/graph/bolt/bolt_test.go
+++ b/graph/bolt/bolt_test.go
@@ -76,6 +76,7 @@ func makeBolt(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestBoltAll(t *testing.T) {
 	graphtest.TestAll(t, makeBolt, &graphtest.Config{
+		NoPrimitives:            true,
 		SkipNodeDelAfterQuadDel: true,
 	})
 }
@@ -131,8 +132,8 @@ func TestLoadDatabase(t *testing.T) {
 
 	//Test horizon
 	horizon := qs.Horizon()
-	if horizon.Int() != 1 {
-		t.Errorf("Unexpected horizon value, got:%d expect:1", horizon.Int())
+	if v, _ := horizon.Int(); v != 1 {
+		t.Errorf("Unexpected horizon value, got:%d expect:1", v)
 	}
 
 	w.AddQuadSet(graphtest.MakeQuadSet())
@@ -143,8 +144,8 @@ func TestLoadDatabase(t *testing.T) {
 		t.Errorf("Unexpected quadstore size, got:%d expect:5", s)
 	}
 	horizon = qs.Horizon()
-	if horizon.Int() != 12 {
-		t.Errorf("Unexpected horizon value, got:%d expect:12", horizon.Int())
+	if v, _ := horizon.Int(); v != 12 {
+		t.Errorf("Unexpected horizon value, got:%d expect:12", v)
 	}
 
 	w.RemoveQuad(quad.MakeRaw(

--- a/graph/bolt/migrate.go
+++ b/graph/bolt/migrate.go
@@ -17,6 +17,7 @@ package bolt
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/boltdb/bolt"
 	"github.com/cayleygraph/cayley/clog"
@@ -94,13 +95,15 @@ func upgrade1To2(db *bolt.DB) error {
 	fmt.Println("Upgrading bucket", string(logBucket))
 	lb := tx.Bucket(logBucket)
 	c := lb.Cursor()
+	id := int64(0)
 	for k, v := c.First(); k != nil; k, v = c.Next() {
 		var delta graph.Delta
 		err := json.Unmarshal(v, &delta)
 		if err != nil {
 			return err
 		}
-		newd := deltaToProto(delta)
+		id++
+		newd := deltaToProto(delta, id, time.Now())
 		data, err := newd.Marshal()
 		if err != nil {
 			return err

--- a/graph/gaedatastore/quadstore_test.go
+++ b/graph/gaedatastore/quadstore_test.go
@@ -92,6 +92,7 @@ func makeGAE(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestGAEAll(t *testing.T) {
 	graphtest.TestAll(t, makeGAE, &graphtest.Config{
+		NoPrimitives:   true,
 		SkipIntHorizon: true,
 		UnTyped:        true,
 	})

--- a/graph/iterate.go
+++ b/graph/iterate.go
@@ -236,14 +236,18 @@ func (c *IterateChain) TagEach(fnc func(map[string]Value)) error {
 	defer c.end()
 	done := c.ctx.Done()
 
+	mn := 0
 	for c.next() {
 		select {
 		case <-done:
 			return c.ctx.Err()
 		default:
 		}
-		tags := make(map[string]Value)
+		tags := make(map[string]Value, mn)
 		c.it.TagResults(tags)
+		if n := len(tags); n > mn {
+			mn = n
+		}
 		fnc(tags)
 		for c.nextPath() {
 			select {
@@ -251,8 +255,11 @@ func (c *IterateChain) TagEach(fnc func(map[string]Value)) error {
 				return c.ctx.Err()
 			default:
 			}
-			tags := make(map[string]Value)
+			tags := make(map[string]Value, mn)
 			c.it.TagResults(tags)
+			if n := len(tags); n > mn {
+				mn = n
+			}
 			fnc(tags)
 		}
 	}

--- a/graph/iterator/hasa.go
+++ b/graph/iterator/hasa.go
@@ -165,6 +165,9 @@ func (it *HasA) Contains(val graph.Value) bool {
 // result iterator (a quad iterator based on the last checked value) and returns true if
 // another match is made.
 func (it *HasA) NextContains() bool {
+	if it.resultIt == nil {
+		return false
+	}
 	for it.resultIt.Next() {
 		it.runstats.ContainsNext += 1
 		link := it.resultIt.Result()
@@ -218,7 +221,6 @@ func (it *HasA) Next() bool {
 	if it.resultIt != nil {
 		it.resultIt.Close()
 	}
-	it.resultIt = &Null{}
 
 	if !it.primaryIt.Next() {
 		it.err = it.primaryIt.Err()

--- a/graph/iterator/materialize.go
+++ b/graph/iterator/materialize.go
@@ -255,6 +255,7 @@ func (it *Materialize) NextPath() bool {
 
 func (it *Materialize) materializeSet() {
 	i := 0
+	mn := 0
 	for it.subIt.Next() {
 		i++
 		if i > abortMaterializeAt {
@@ -268,8 +269,11 @@ func (it *Materialize) materializeSet() {
 			it.values = append(it.values, nil)
 		}
 		index := it.containsMap[val]
-		tags := make(map[string]graph.Value)
+		tags := make(map[string]graph.Value, mn)
 		it.subIt.TagResults(tags)
+		if n := len(tags); n > mn {
+			n = mn
+		}
 		it.values[index] = append(it.values[index], result{id: id, tags: tags})
 		it.actualSize += 1
 		for it.subIt.NextPath() {
@@ -278,8 +282,11 @@ func (it *Materialize) materializeSet() {
 				it.aborted = true
 				break
 			}
-			tags := make(map[string]graph.Value)
+			tags := make(map[string]graph.Value, mn)
 			it.subIt.TagResults(tags)
+			if n := len(tags); n > mn {
+				n = mn
+			}
 			it.values[index] = append(it.values[index], result{id: id, tags: tags})
 			it.actualSize += 1
 		}

--- a/graph/kv/kvtest/kvtest.go
+++ b/graph/kv/kvtest/kvtest.go
@@ -19,6 +19,7 @@ type Config struct{}
 
 func (c Config) quadStore() *graphtest.Config {
 	return &graphtest.Config{
+		NoPrimitives:            true,
 		SkipNodeDelAfterQuadDel: true,
 		SkipIntHorizon:          true,
 	}

--- a/graph/leveldb/leveldb_test.go
+++ b/graph/leveldb/leveldb_test.go
@@ -74,6 +74,7 @@ func makeLevelDB(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestLevelDBAll(t *testing.T) {
 	graphtest.TestAll(t, makeLevelDB, &graphtest.Config{
+		NoPrimitives:            true,
 		SkipDeletedFromIterator: true,
 		SkipNodeDelAfterQuadDel: true,
 	})
@@ -133,8 +134,8 @@ func TestLoadDatabase(t *testing.T) {
 
 	//Test horizon
 	horizon := qs.Horizon()
-	if horizon.Int() != 1 {
-		t.Errorf("Unexpected horizon value, got:%d expect:1", horizon.Int())
+	if v, _ := horizon.Int(); v != 1 {
+		t.Errorf("Unexpected horizon value, got:%d expect:1", v)
 	}
 
 	w.AddQuadSet(graphtest.MakeQuadSet())
@@ -145,8 +146,8 @@ func TestLoadDatabase(t *testing.T) {
 		t.Errorf("Unexpected quadstore size, got:%d expect:5", s)
 	}
 	horizon = qs.Horizon()
-	if horizon.Int() != 12 {
-		t.Errorf("Unexpected horizon value, got:%d expect:12", horizon.Int())
+	if v, _ := horizon.Int(); v != 12 {
+		t.Errorf("Unexpected horizon value, got:%d expect:12", v)
 	}
 
 	w.RemoveQuad(quad.MakeRaw(

--- a/graph/leveldb/migrate.go
+++ b/graph/leveldb/migrate.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
@@ -151,6 +152,7 @@ func upgrade1To2(db *leveldb.DB) error {
 	{
 		fmt.Println("Upgrading bucket d")
 		it := db.NewIterator(&util.Range{Start: []byte{'d'}, Limit: []byte{'d' + 1}}, nil)
+		h := int64(0)
 		for it.Next() {
 			k, v := it.Key(), it.Value()
 			id, err := strconv.ParseInt(string(k[1:]), 16, 64)
@@ -162,7 +164,8 @@ func upgrade1To2(db *leveldb.DB) error {
 			if err := json.Unmarshal(v, &val); err != nil {
 				return err
 			}
-			p := deltaToProto(val)
+			h++
+			p := deltaToProto(val, h, time.Now())
 			nv, err := p.Marshal()
 			if err != nil {
 				return err

--- a/graph/leveldb/quadstore.go
+++ b/graph/leveldb/quadstore.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -239,11 +240,11 @@ var (
 	cps = [4]quad.Direction{quad.Label, quad.Predicate, quad.Subject, quad.Object}
 )
 
-func deltaToProto(delta graph.Delta) proto.LogDelta {
+func deltaToProto(delta graph.Delta, id int64, t time.Time) proto.LogDelta {
 	var newd proto.LogDelta
-	newd.ID = uint64(delta.ID.Int())
+	newd.ID = uint64(id)
 	newd.Action = int32(delta.Action)
-	newd.Timestamp = delta.Timestamp.UnixNano()
+	newd.Timestamp = t.UnixNano()
 	newd.Quad = pquads.MakeQuad(delta.Quad)
 	return newd
 }
@@ -252,17 +253,19 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 	batch := &leveldb.Batch{}
 	resizeMap := make(map[quad.Value]int64)
 	sizeChange := int64(0)
+	h, t := qs.horizon, time.Now()
 	for _, d := range deltas {
 		if d.Action != graph.Add && d.Action != graph.Delete {
 			return &graph.DeltaError{Delta: d, Err: graph.ErrInvalidAction}
 		}
-		p := deltaToProto(d)
+		h++
+		p := deltaToProto(d, h, t)
 		bytes, err := p.Marshal()
 		if err != nil {
 			return &graph.DeltaError{Delta: d, Err: err}
 		}
-		batch.Put(createDeltaKeyFor(d.ID.Int()), bytes)
-		err = qs.buildQuadWrite(batch, d.Quad, d.ID.Int(), d.Action == graph.Add)
+		batch.Put(createDeltaKeyFor(h), bytes)
+		err = qs.buildQuadWrite(batch, d.Quad, h, d.Action == graph.Add)
 		if err != nil {
 			if err == graph.ErrQuadExists && ignoreOpts.IgnoreDup {
 				continue
@@ -283,7 +286,7 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 			resizeMap[d.Quad.Label] += delta
 		}
 		sizeChange += delta
-		qs.horizon = d.ID.Int()
+		qs.horizon = h
 	}
 	for k, v := range resizeMap {
 		if v != 0 {

--- a/graph/memstore/Makefile
+++ b/graph/memstore/Makefile
@@ -24,5 +24,5 @@ specify:
 	git clone https://github.com/cznic/b
 	cd b && git checkout $(pinned)
 	go test ./b
-	@sed -e 's|interface{}[^{]*/\*K\*/|int64|g' -e 's|interface{}[^{]*/\*V\*/|struct{}|g' b/btree.go >keys.go
+	@sed -e 's|interface{}[^{]*/\*K\*/|int64|g' -e 's|interface{}[^{]*/\*V\*/|\*primitive|g' b/btree.go >keys.go
 	rm -rf b

--- a/graph/memstore/all_iterator.go
+++ b/graph/memstore/all_iterator.go
@@ -19,72 +19,144 @@ import (
 	"github.com/cayleygraph/cayley/graph/iterator"
 )
 
+var _ graph.Iterator = (*AllIterator)(nil)
+
 type AllIterator struct {
-	iterator.Int64
-	qs *QuadStore
+	uid  uint64
+	tags graph.Tagger
+
+	qs    *QuadStore
+	maxid int64 // id of last observed insert (prim id)
+	nodes bool
+
+	i    int // index into qs.all
+	cur  *primitive
+	done bool
 }
 
-type (
-	nodesAllIterator AllIterator
-	quadsAllIterator AllIterator
-)
-
-func newNodesAllIterator(qs *QuadStore) *nodesAllIterator {
-	var out nodesAllIterator
-	out.Int64 = *iterator.NewInt64(1, qs.nextID-1, true)
-	out.qs = qs
-	return &out
-}
-
-// No subiterators.
-func (it *nodesAllIterator) SubIterators() []graph.Iterator {
-	return nil
-}
-
-func (it *nodesAllIterator) Next() bool {
-	for {
-		if !it.Int64.Next() {
-			return false
-		}
-		_, ok := it.qs.revIDMap[int64(it.Int64.Result().(iterator.Int64Node))]
-		if !ok {
-			continue
-		}
-		return true
+func newAllIterator(qs *QuadStore, nodes bool, maxid int64) *AllIterator {
+	return &AllIterator{
+		uid: iterator.NextUID(),
+		qs:  qs, nodes: nodes,
+		i: -1, maxid: maxid,
 	}
 }
 
-func (it *nodesAllIterator) Err() error {
+func (it *AllIterator) Clone() graph.Iterator {
+	it2 := newAllIterator(it.qs, it.nodes, it.maxid)
+	it2.tags.CopyFrom(it)
+	return it2
+}
+
+func (it *AllIterator) Reset() {
+	it.i = -1
+	it.cur = nil
+	it.done = false
+}
+
+func (it *AllIterator) ok(p *primitive) bool {
+	if p.ID > it.maxid {
+		return false
+	} else if it.nodes && p.Value != nil {
+		return true
+	} else if !it.nodes && p.internalQuad != (internalQuad{}) {
+		return true
+	}
+	return false
+}
+
+func (it *AllIterator) Next() bool {
+	it.cur = nil
+	if it.done {
+		return false
+	}
+	all := it.qs.all
+	if it.i >= len(all) {
+		it.done = true
+		return false
+	}
+	it.i++
+	for ; it.i < len(all); it.i++ {
+		p := all[it.i]
+		if p.ID > it.maxid {
+			break
+		}
+		if it.ok(p) {
+			it.cur = p
+			return true
+		}
+	}
+	it.done = true
+	return false
+}
+
+func (it *AllIterator) Contains(v graph.Value) bool {
+	it.cur = nil
+	if it.done {
+		return false
+	}
+	id, ok := asID(v)
+	if !ok {
+		return false
+	}
+	p := it.qs.prim[id]
+	if p.ID > it.maxid {
+		return false
+	}
+	if !it.ok(p) {
+		return false
+	}
+	it.cur = p
+	return true
+}
+func (it *AllIterator) Result() graph.Value {
+	if it.cur == nil {
+		return nil
+	}
+	return graph.NewSequentialKey(it.cur.ID)
+}
+
+func (it *AllIterator) Err() error { return nil }
+func (it *AllIterator) Close() error {
+	it.done = true
 	return nil
 }
-
-func newQuadsAllIterator(qs *QuadStore) *quadsAllIterator {
-	var out quadsAllIterator
-	out.Int64 = *iterator.NewInt64(1, qs.nextQuadID-1, false)
-	out.qs = qs
-	return &out
+func (it *AllIterator) Tagger() *graph.Tagger {
+	return &it.tags
 }
 
-func (it *quadsAllIterator) Next() bool {
-	for {
-		if !it.Int64.Next() {
-			return false
-		}
-		i64 := int64(it.Int64.Result().(iterator.Int64Quad))
-		if int(i64) >= len(it.qs.log) {
-			return false
-		}
-		if it.qs.log[i64].DeletedBy != 0 || it.qs.log[i64].Action == graph.Delete {
-			continue
-		}
-		return true
+func (it *AllIterator) TagResults(dst map[string]graph.Value) {
+	for _, tag := range it.tags.Tags() {
+		dst[tag] = it.Result()
+	}
+
+	for tag, value := range it.tags.Fixed() {
+		dst[tag] = value
 	}
 }
 
-// Override Optimize from it.Int64 - it will hide our Next implementation in other cases.
+func (it *AllIterator) SubIterators() []graph.Iterator   { return nil }
+func (it *AllIterator) Optimize() (graph.Iterator, bool) { return it, false }
 
-func (it *nodesAllIterator) Optimize() (graph.Iterator, bool) { return it, false }
-func (it *quadsAllIterator) Optimize() (graph.Iterator, bool) { return it, false }
+func (it *AllIterator) UID() uint64 {
+	return it.uid
+}
+func (it *AllIterator) Type() graph.Type { return graph.All }
+func (it *AllIterator) Describe() graph.Description {
+	return graph.Description{
+		UID:  it.UID(),
+		Type: it.Type(),
+		Tags: it.tags.Tags(),
+	}
+}
+func (it *AllIterator) NextPath() bool { return false }
 
-var _ graph.Iterator = &nodesAllIterator{}
-var _ graph.Iterator = &quadsAllIterator{}
+func (it *AllIterator) Size() (int64, bool) {
+	// TODO: use maxid?
+	return int64(len(it.qs.all)), true
+}
+func (it *AllIterator) Stats() graph.IteratorStats {
+	st := graph.IteratorStats{NextCost: 1, ContainsCost: 1}
+	st.Size, st.ExactSize = it.Size()
+	return st
+}

--- a/graph/memstore/all_iterator.go
+++ b/graph/memstore/all_iterator.go
@@ -59,7 +59,7 @@ func (it *AllIterator) ok(p *primitive) bool {
 		return false
 	} else if it.nodes && p.Value != nil {
 		return true
-	} else if !it.nodes && p.internalQuad != (internalQuad{}) {
+	} else if !it.nodes && !p.Quad.Zero() {
 		return true
 	}
 	return false
@@ -113,7 +113,10 @@ func (it *AllIterator) Result() graph.Value {
 	if it.cur == nil {
 		return nil
 	}
-	return graph.NewSequentialKey(it.cur.ID)
+	if !it.cur.Quad.Zero() {
+		return qprim{p: it.cur}
+	}
+	return bnode(it.cur.ID)
 }
 
 func (it *AllIterator) Err() error { return nil }

--- a/graph/memstore/gen.go
+++ b/graph/memstore/gen.go
@@ -14,4 +14,4 @@
 
 //go:generate make specify
 
-package b
+package memstore

--- a/graph/memstore/keys.go
+++ b/graph/memstore/keys.go
@@ -54,7 +54,7 @@
 //	BenchmarkPrev1e3	  200000	      8843 ns/op
 //	ok  	command-line-arguments	25.071s
 //	$
-package b
+package memstore
 
 import (
 	"fmt"
@@ -118,7 +118,7 @@ type (
 
 	de struct { // d element
 		k int64
-		v struct{}
+		v *primitive
 	}
 
 	// Enumerator captures the state of enumerating a tree. It is returned
@@ -383,7 +383,7 @@ func (t *Tree) Delete(k int64) (ok bool) {
 	}
 }
 
-func (t *Tree) extract(q *d, i int) { // (r struct{}) {
+func (t *Tree) extract(q *d, i int) { // (r *primitive) {
 	t.ver++
 	//r = q.d[i].v // prepared for Extract
 	q.c--
@@ -433,7 +433,7 @@ func (t *Tree) find(q interface{}, k int64) (i int, ok bool) {
 
 // First returns the first item of the tree in the key collating order, or
 // (zero-value, zero-value) if the tree is empty.
-func (t *Tree) First() (k int64, v struct{}) {
+func (t *Tree) First() (k int64, v *primitive) {
 	if q := t.first; q != nil {
 		q := &q.d[0]
 		k, v = q.k, q.v
@@ -443,7 +443,7 @@ func (t *Tree) First() (k int64, v struct{}) {
 
 // Get returns the value associated with k and true if it exists. Otherwise Get
 // returns (zero-value, false).
-func (t *Tree) Get(k int64) (v struct{}, ok bool) {
+func (t *Tree) Get(k int64) (v *primitive, ok bool) {
 	q := t.r
 	if q == nil {
 		return
@@ -469,7 +469,7 @@ func (t *Tree) Get(k int64) (v struct{}, ok bool) {
 	}
 }
 
-func (t *Tree) insert(q *d, i int, k int64, v struct{}) *d {
+func (t *Tree) insert(q *d, i int, k int64, v *primitive) *d {
 	t.ver++
 	c := q.c
 	if i < c {
@@ -484,7 +484,7 @@ func (t *Tree) insert(q *d, i int, k int64, v struct{}) *d {
 
 // Last returns the last item of the tree in the key collating order, or
 // (zero-value, zero-value) if the tree is empty.
-func (t *Tree) Last() (k int64, v struct{}) {
+func (t *Tree) Last() (k int64, v *primitive) {
 	if q := t.last; q != nil {
 		q := &q.d[q.c-1]
 		k, v = q.k, q.v
@@ -497,7 +497,7 @@ func (t *Tree) Len() int {
 	return t.c
 }
 
-func (t *Tree) overflow(p *x, q *d, pi, i int, k int64, v struct{}) {
+func (t *Tree) overflow(p *x, q *d, pi, i int, k int64, v *primitive) {
 	t.ver++
 	l, r := p.siblings(pi)
 
@@ -577,7 +577,7 @@ func (t *Tree) SeekLast() (e *Enumerator, err error) {
 }
 
 // Set sets the value associated with k.
-func (t *Tree) Set(k int64, v struct{}) {
+func (t *Tree) Set(k int64, v *primitive) {
 	//dbg("--- PRE Set(%v, %v)\n%s", k, v, t.dump())
 	//defer func() {
 	//	dbg("--- POST\n%s\n====\n", t.dump())
@@ -642,11 +642,11 @@ func (t *Tree) Set(k int64, v struct{}) {
 // 	tree.Put(k, func(int64, bool){ return v, true })
 //
 // modulo the differing return values.
-func (t *Tree) Put(k int64, upd func(oldV struct{}, exists bool) (newV struct{}, write bool)) (oldV struct{}, written bool) {
+func (t *Tree) Put(k int64, upd func(oldV *primitive, exists bool) (newV *primitive, write bool)) (oldV *primitive, written bool) {
 	pi := -1
 	var p *x
 	q := t.r
-	var newV struct{}
+	var newV *primitive
 	if q == nil {
 		// new KV pair in empty tree
 		newV, written = upd(newV, false)
@@ -708,7 +708,7 @@ func (t *Tree) Put(k int64, upd func(oldV struct{}, exists bool) (newV struct{},
 	}
 }
 
-func (t *Tree) split(p *x, q *d, pi, i int, k int64, v struct{}) {
+func (t *Tree) split(p *x, q *d, pi, i int, k int64, v *primitive) {
 	t.ver++
 	r := btDPool.Get().(*d)
 	if q.n != nil {
@@ -863,7 +863,7 @@ func (e *Enumerator) Close() {
 // Next returns the currently enumerated item, if it exists and moves to the
 // next item in the key collation order. If there is no item to return, err ==
 // io.EOF is returned.
-func (e *Enumerator) Next() (k int64, v struct{}, err error) {
+func (e *Enumerator) Next() (k int64, v *primitive, err error) {
 	if err = e.err; err != nil {
 		return
 	}
@@ -917,7 +917,7 @@ func (e *Enumerator) next() error {
 // Prev returns the currently enumerated item, if it exists and moves to the
 // previous item in the key collation order. If there is no item to return, err
 // == io.EOF is returned.
-func (e *Enumerator) Prev() (k int64, v struct{}, err error) {
+func (e *Enumerator) Prev() (k int64, v *primitive, err error) {
 	if err = e.err; err != nil {
 		return
 	}

--- a/graph/memstore/keys_test.go
+++ b/graph/memstore/keys_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package b
+package memstore
 
 import (
 	"math"
@@ -19,10 +19,6 @@ func rng() *mathutil.FC32 {
 	}
 
 	return x
-}
-
-func cmp(a, b int64) int {
-	return int(a - b)
 }
 
 func BenchmarkSetSeq1e3(b *testing.B) {
@@ -49,7 +45,7 @@ func benchmarkSetSeq(b *testing.B, n int) {
 		debug.FreeOSMemory()
 		b.StartTimer()
 		for j := int64(0); j < int64(n); j++ {
-			r.Set(j, struct{}{})
+			r.Set(j, nil)
 		}
 		b.StopTimer()
 		r.Close()
@@ -76,7 +72,7 @@ func BenchmarkGetSeq1e6(b *testing.B) {
 func benchmarkGetSeq(b *testing.B, n int) {
 	r := TreeNew(cmp)
 	for i := int64(0); i < int64(n); i++ {
-		r.Set(i, struct{}{})
+		r.Set(i, nil)
 	}
 	debug.FreeOSMemory()
 	b.ResetTimer()
@@ -118,7 +114,7 @@ func benchmarkSetRnd(b *testing.B, n int) {
 		debug.FreeOSMemory()
 		b.StartTimer()
 		for _, v := range a {
-			r.Set(int64(v), struct{}{})
+			r.Set(int64(v), nil)
 		}
 		b.StopTimer()
 		r.Close()
@@ -150,7 +146,7 @@ func benchmarkGetRnd(b *testing.B, n int) {
 		a[i] = int64(rng.Next())
 	}
 	for _, v := range a {
-		r.Set(v, struct{}{})
+		r.Set(v, nil)
 	}
 	debug.FreeOSMemory()
 	b.ResetTimer()
@@ -185,7 +181,7 @@ func benchmarkDelSeq(b *testing.B, n int) {
 		b.StopTimer()
 		r := TreeNew(cmp)
 		for j := int64(0); j < int64(n); j++ {
-			r.Set(j, struct{}{})
+			r.Set(j, nil)
 		}
 		debug.FreeOSMemory()
 		b.StartTimer()
@@ -223,7 +219,7 @@ func benchmarkDelRnd(b *testing.B, n int) {
 		b.StopTimer()
 		r := TreeNew(cmp)
 		for _, v := range a {
-			r.Set(v, struct{}{})
+			r.Set(v, nil)
 		}
 		debug.FreeOSMemory()
 		b.StartTimer()
@@ -257,7 +253,7 @@ func benchmarkSeekSeq(b *testing.B, n int) {
 		b.StopTimer()
 		t := TreeNew(cmp)
 		for j := int64(0); j < int64(n); j++ {
-			t.Set(j, struct{}{})
+			t.Set(j, nil)
 		}
 		debug.FreeOSMemory()
 		b.StartTimer()
@@ -295,7 +291,7 @@ func benchmarkSeekRnd(b *testing.B, n int) {
 		a[i] = int64(rng.Next())
 	}
 	for _, v := range a {
-		r.Set(v, struct{}{})
+		r.Set(v, nil)
 	}
 	debug.FreeOSMemory()
 	b.ResetTimer()
@@ -328,7 +324,7 @@ func BenchmarkNext1e6(b *testing.B) {
 func benchmarkNext(b *testing.B, n int) {
 	t := TreeNew(cmp)
 	for i := int64(0); i < int64(n); i++ {
-		t.Set(i, struct{}{})
+		t.Set(i, nil)
 	}
 	debug.FreeOSMemory()
 	b.ResetTimer()
@@ -372,7 +368,7 @@ func BenchmarkPrev1e6(b *testing.B) {
 func benchmarkPrev(b *testing.B, n int) {
 	t := TreeNew(cmp)
 	for i := int64(0); i < int64(n); i++ {
-		t.Set(i, struct{}{})
+		t.Set(i, nil)
 	}
 	debug.FreeOSMemory()
 	b.ResetTimer()

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -16,9 +16,7 @@ package memstore
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/cayleygraph/cayley/clog"
+	"strconv"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/iterator"
@@ -33,9 +31,9 @@ func init() {
 		NewFunc: func(string, graph.Options) (graph.QuadStore, error) {
 			return newQuadStore(), nil
 		},
-		UpgradeFunc:       nil,
-		InitFunc:          nil,
-		IsPersistent:      false,
+		UpgradeFunc:  nil,
+		InitFunc:     nil,
+		IsPersistent: false,
 	})
 }
 
@@ -78,23 +76,54 @@ func (qdi QuadDirectionIndex) Get(d quad.Direction, id int64) (*b.Tree, bool) {
 	return tree, ok
 }
 
-type LogEntry struct {
-	ID        int64
-	Quad      quad.Quad
-	IDs       [4]int64
-	Action    graph.Procedure
-	Timestamp time.Time
-	DeletedBy int64
+type primitive struct {
+	ID int64
+	internalQuad
+	Value quad.Value
+}
+
+type internalQuad struct {
+	S, P, O, L int64
+}
+
+func (q *internalQuad) SetDir(d quad.Direction, n int64) {
+	switch d {
+	case quad.Subject:
+		q.S = n
+	case quad.Predicate:
+		q.P = n
+	case quad.Object:
+		q.O = n
+	case quad.Label:
+		q.L = n
+	default:
+		panic(fmt.Errorf("unknown dir: %v", d))
+	}
+}
+func (q internalQuad) Dir(d quad.Direction) int64 {
+	var n int64
+	switch d {
+	case quad.Subject:
+		n = q.S
+	case quad.Predicate:
+		n = q.P
+	case quad.Object:
+		n = q.O
+	case quad.Label:
+		n = q.L
+	}
+	return n
 }
 
 type QuadStore struct {
-	nextID     int64
-	nextQuadID int64
-	idMap      map[string]int64
-	revIDMap   map[int64]quad.Value
-	log        []LogEntry
-	size       int64
-	index      QuadDirectionIndex
+	last int64
+	// TODO: string -> quad.Value once Raw -> typed resolution is unnecessary
+	vals    map[string]int64
+	quads   map[internalQuad]int64
+	prim    map[int64]*primitive
+	all     []*primitive // might not be sorted by id
+	index   QuadDirectionIndex
+	horizon int64 // used only to assign ids to tx
 	// vip_index map[string]map[int64]map[string]map[int64]*b.Tree
 }
 
@@ -102,44 +131,175 @@ type QuadStore struct {
 func New(quads ...quad.Quad) *QuadStore {
 	qs := newQuadStore()
 	for _, q := range quads {
-		h := qs.Horizon()
-		err := qs.AddDelta(graph.Delta{
-			ID:        h.Next(),
-			Quad:      q,
-			Action:    graph.Add,
-			Timestamp: time.Now(),
-		})
-		if graph.IsQuadExist(err) {
-			continue
-		} else if err != nil {
-			panic(fmt.Errorf("memstore failed to add delta: %v", err))
-		}
+		qs.AddQuad(q)
 	}
 	return qs
 }
 
 func newQuadStore() *QuadStore {
 	return &QuadStore{
-		idMap:    make(map[string]int64),
-		revIDMap: make(map[int64]quad.Value),
-
-		// Sentinel null entry so indices start at 1
-		log: make([]LogEntry, 1, 200),
-
-		index:      NewQuadDirectionIndex(),
-		nextID:     1,
-		nextQuadID: 1,
+		vals:  make(map[string]int64),
+		quads: make(map[internalQuad]int64),
+		prim:  make(map[int64]*primitive),
+		index: NewQuadDirectionIndex(),
 	}
 }
 
+func (qs *QuadStore) addPrimitive(p primitive) int64 {
+	qs.last++
+	id := qs.last
+	p.ID = id
+	qs.appendPrimitive(p)
+	return id
+}
+
+func (qs *QuadStore) appendPrimitive(p primitive) {
+	qs.prim[p.ID] = &p
+	qs.all = append(qs.all, &p)
+}
+
+func (qs *QuadStore) resolveVal(v quad.Value, add bool) (int64, bool) {
+	if v == nil {
+		return 0, false
+	}
+	if n, ok := v.(quad.BNode); ok && len(n) > 1 && n[0] == 'n' {
+		n = n[1:]
+		id, err := strconv.ParseInt(string(n), 10, 64)
+		if err == nil && id != 0 {
+			_, ok := qs.prim[id]
+			if ok || !add {
+				return id, ok
+			}
+			qs.appendPrimitive(primitive{ID: id})
+			return id, true
+		}
+	}
+	vs := v.String()
+	if id, exists := qs.vals[vs]; exists || !add {
+		return id, exists
+	}
+	id := qs.addPrimitive(primitive{Value: v})
+	qs.vals[vs] = id
+	return id, true
+}
+
+func (qs *QuadStore) resolveQuad(q quad.Quad, add bool) (internalQuad, bool) {
+	var p internalQuad
+	for dir := quad.Subject; dir <= quad.Label; dir++ {
+		v := q.Get(dir)
+		if v == nil {
+			continue
+		}
+		if vid, _ := qs.resolveVal(v, add); vid != 0 {
+			p.SetDir(dir, vid)
+		} else if !add {
+			return internalQuad{}, false
+		}
+	}
+	return p, true
+}
+
+func (qs *QuadStore) lookupVal(id int64) quad.Value {
+	pv := qs.prim[id]
+	if pv == nil || pv.Value == nil {
+		return quad.BNode("n" + strconv.FormatInt(id, 10))
+	}
+	return pv.Value
+}
+
+func (qs *QuadStore) lookupQuadDirs(p internalQuad) quad.Quad {
+	var q quad.Quad
+	for dir := quad.Subject; dir <= quad.Label; dir++ {
+		vid := p.Dir(dir)
+		if vid == 0 {
+			continue
+		}
+		v := qs.lookupVal(vid)
+		q.Set(dir, v)
+	}
+	return q
+}
+
+// AddNode adds a blank node (with no value) to quad store. It returns an id of the node.
+func (qs *QuadStore) AddBNode() int64 {
+	return qs.addPrimitive(primitive{})
+}
+
+// AddNode adds a value to quad store. It returns an id of the value.
+// False is returned as a second parameter if value exists already.
+func (qs *QuadStore) AddValue(v quad.Value) (int64, bool) {
+	id, exists := qs.resolveVal(v, true)
+	return id, !exists
+}
+
+func (qs *QuadStore) indexesForQuad(q internalQuad) []*b.Tree {
+	trees := make([]*b.Tree, 0, 4)
+	for dir := quad.Subject; dir <= quad.Label; dir++ {
+		v := q.Dir(dir)
+		if v == 0 {
+			continue
+		}
+		trees = append(trees, qs.index.Tree(dir, v))
+	}
+	return trees
+}
+
+// AddQuad adds a quad to quad store. It returns an id of the quad.
+// False is returned as a second parameter if quad exists already.
+func (qs *QuadStore) AddQuad(q quad.Quad) (int64, bool) {
+	p, _ := qs.resolveQuad(q, true)
+	if id := qs.quads[p]; id != 0 {
+		return id, false
+	}
+	id := qs.addPrimitive(primitive{internalQuad: p})
+	qs.quads[p] = id
+	for _, t := range qs.indexesForQuad(p) {
+		t.Set(id, struct{}{})
+	}
+	// TODO(barakmich): Add VIP indexing
+	return id, true
+}
+
+// WriteQuad adds a quad to quad store.
+//
+// Deprecated: use AddQuad instead.
 func (qs *QuadStore) WriteQuad(q quad.Quad) error {
-	h := qs.Horizon()
-	return qs.AddDelta(graph.Delta{
-		ID:        h.Next(),
-		Quad:      q,
-		Action:    graph.Add,
-		Timestamp: time.Now(),
-	})
+	qs.AddQuad(q)
+	return nil
+}
+
+func (qs *QuadStore) Delete(id int64) bool {
+	p := qs.prim[id]
+	if p == nil {
+		return false
+	}
+	// remove from value index
+	if p.Value != nil {
+		delete(qs.vals, p.Value.String())
+	}
+	// remove from quad indexes
+	for _, t := range qs.indexesForQuad(p.internalQuad) {
+		t.Delete(id)
+	}
+	delete(qs.quads, p.internalQuad)
+	// remove primitive
+	delete(qs.prim, id)
+	for i, p2 := range qs.all {
+		if p == p2 {
+			qs.all = append(qs.all[:i], qs.all[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+func (qs *QuadStore) findQuad(q quad.Quad) (int64, internalQuad, bool) {
+	p, ok := qs.resolveQuad(q, false)
+	if !ok {
+		return 0, p, false
+	}
+	id := qs.quads[p]
+	return id, p, id != 0
 }
 
 func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
@@ -149,13 +309,13 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 			switch d.Action {
 			case graph.Add:
 				if !ignoreOpts.IgnoreDup {
-					if _, exists := qs.indexOf(d.Quad); exists {
+					if _, _, ok := qs.findQuad(d.Quad); ok {
 						return &graph.DeltaError{Delta: d, Err: graph.ErrQuadExists}
 					}
 				}
 			case graph.Delete:
 				if !ignoreOpts.IgnoreMissing {
-					if _, exists := qs.indexOf(d.Quad); !exists {
+					if _, _, ok := qs.findQuad(d.Quad); !ok {
 						return &graph.DeltaError{Delta: d, Err: graph.ErrQuadNotExist}
 					}
 				}
@@ -166,168 +326,99 @@ func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOp
 	}
 
 	for _, d := range deltas {
-		var err error
 		switch d.Action {
 		case graph.Add:
-			err = qs.AddDelta(d)
-			if err != nil && ignoreOpts.IgnoreDup {
-				err = nil
-			}
+			qs.AddQuad(d.Quad)
 		case graph.Delete:
-			err = qs.RemoveDelta(d)
-			if err != nil && ignoreOpts.IgnoreMissing {
-				err = nil
+			if id, _, ok := qs.findQuad(d.Quad); ok {
+				qs.Delete(id)
 			}
 		default:
-			err = &graph.DeltaError{Delta: d, Err: graph.ErrInvalidAction}
-		}
-		if err != nil {
-			return err
+			// TODO: ideally we should rollback it
+			return &graph.DeltaError{Delta: d, Err: graph.ErrInvalidAction}
 		}
 	}
+	qs.horizon++
 	return nil
 }
 
-const maxInt = int(^uint(0) >> 1)
-
-func (qs *QuadStore) indexOf(t quad.Quad) (int64, bool) {
-	min := maxInt
-	var tree *b.Tree
-	for d := quad.Subject; d <= quad.Label; d++ {
-		sid := t.Get(d)
-		if d == quad.Label && sid == nil {
-			continue
-		}
-		id, ok := qs.idMap[quad.StringOf(sid)]
-		// If we've never heard about a node, it must not exist
-		if !ok {
-			return 0, false
-		}
-		index, ok := qs.index.Get(d, id)
-		if !ok {
-			// If it's never been indexed in this direction, it can't exist.
-			return 0, false
-		}
-		if l := index.Len(); l < min {
-			min, tree = l, index
-		}
+func asID(v graph.Value) (int64, bool) {
+	pk, ok := v.(graph.PrimaryKey)
+	if !ok {
+		return 0, false
 	}
-
-	it := NewIterator(tree, qs, 0, nil)
-	for it.Next() {
-		if t == qs.log[it.result].Quad {
-			return it.result, true
-		}
-	}
-	return 0, false
+	return pk.Int()
 }
 
-func (qs *QuadStore) AddDelta(d graph.Delta) error {
-	if _, exists := qs.indexOf(d.Quad); exists {
-		return &graph.DeltaError{Delta: d, Err: graph.ErrQuadExists}
+func (qs *QuadStore) quad(index graph.Value) (internalQuad, bool) {
+	id, ok := asID(index)
+	if !ok {
+		return internalQuad{}, false
 	}
-	qid := qs.nextQuadID
-	qs.log = append(qs.log, LogEntry{
-		ID:        d.ID.Int(),
-		Quad:      d.Quad,
-		Action:    d.Action,
-		Timestamp: d.Timestamp,
-	})
-	qs.size++
-	qs.nextQuadID++
-	l := &qs.log[qid]
-
-	for dir := quad.Subject; dir <= quad.Label; dir++ {
-		sid := d.Quad.Get(dir)
-		if dir == quad.Label && sid == nil {
-			continue
-		}
-		ssid := quad.StringOf(sid)
-		id, ok := qs.idMap[ssid]
-		if !ok {
-			id = qs.nextID
-			qs.idMap[ssid] = id
-			qs.revIDMap[id] = sid
-			qs.nextID++
-		}
-		tree := qs.index.Tree(dir, id)
-		tree.Set(qid, struct{}{})
-		l.IDs[int(dir)-1] = id
+	p := qs.prim[id]
+	if p == nil {
+		return internalQuad{}, false
 	}
-
-	// TODO(barakmich): Add VIP indexing
-	return nil
-}
-
-func (qs *QuadStore) RemoveDelta(d graph.Delta) error {
-	prevQuadID, exists := qs.indexOf(d.Quad)
-	if !exists {
-		return &graph.DeltaError{Delta: d, Err: graph.ErrQuadNotExist}
-	}
-
-	quadID := qs.nextQuadID
-	qs.log = append(qs.log, LogEntry{
-		ID:        d.ID.Int(),
-		Quad:      d.Quad,
-		Action:    d.Action,
-		Timestamp: d.Timestamp,
-	})
-	qs.log[prevQuadID].DeletedBy = quadID
-	qs.size--
-	qs.nextQuadID++
-	return nil
-}
-
-func (qs *QuadStore) logEntry(index graph.Value) LogEntry {
-	return qs.log[index.(iterator.Int64Quad)]
+	return p.internalQuad, p.internalQuad != (internalQuad{})
 }
 
 func (qs *QuadStore) Quad(index graph.Value) quad.Quad {
-	return qs.log[index.(iterator.Int64Quad)].Quad
+	q, ok := qs.quad(index)
+	if !ok {
+		return quad.Quad{}
+	}
+	return qs.lookupQuadDirs(q)
 }
 
 func (qs *QuadStore) QuadIterator(d quad.Direction, value graph.Value) graph.Iterator {
-	index, ok := qs.index.Get(d, int64(value.(iterator.Int64Node)))
+	id, ok := asID(value)
+	if !ok {
+		return iterator.NewNull()
+	}
+	index, ok := qs.index.Get(d, id)
 	if ok {
 		return NewIterator(index, qs, d, value)
 	}
-	return &iterator.Null{}
+	return iterator.NewNull()
 }
 
 func (qs *QuadStore) Horizon() graph.PrimaryKey {
-	return graph.NewSequentialKey(qs.log[len(qs.log)-1].ID)
+	return graph.NewSequentialKey(qs.horizon)
 }
 
 func (qs *QuadStore) Size() int64 {
-	return qs.size
-}
-
-func (qs *QuadStore) DebugPrint() {
-	for i, l := range qs.log {
-		if i == 0 {
-			continue
-		}
-		if clog.V(2) {
-			clog.Infof("%d: %#v", i, l)
-		}
-	}
+	return int64(len(qs.prim))
 }
 
 func (qs *QuadStore) ValueOf(name quad.Value) graph.Value {
-	return iterator.Int64Node(qs.idMap[quad.StringOf(name)])
+	if name == nil {
+		return nil
+	}
+	id := qs.vals[name.String()]
+	if id == 0 {
+		return nil
+	}
+	return graph.NewSequentialKey(id)
 }
 
-func (qs *QuadStore) NameOf(id graph.Value) quad.Value {
-	if id == nil {
+func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
+	if v == nil {
 		return nil
-	} else if v, ok := id.(graph.PreFetchedValue); ok {
+	} else if v, ok := v.(graph.PreFetchedValue); ok {
 		return v.NameOf()
 	}
-	return qs.revIDMap[int64(id.(iterator.Int64Node))]
+	n, ok := asID(v)
+	if !ok {
+		return nil
+	}
+	if _, ok = qs.prim[n]; !ok {
+		return nil
+	}
+	return qs.lookupVal(n)
 }
 
 func (qs *QuadStore) QuadsAllIterator() graph.Iterator {
-	return newQuadsAllIterator(qs)
+	return newAllIterator(qs, false, qs.last)
 }
 
 func (qs *QuadStore) FixedIterator() graph.FixedIterator {
@@ -335,27 +426,23 @@ func (qs *QuadStore) FixedIterator() graph.FixedIterator {
 }
 
 func (qs *QuadStore) QuadDirection(val graph.Value, d quad.Direction) graph.Value {
-	l := qs.logEntry(val)
-	if l.Action != graph.Delete {
-		return iterator.Int64Node(l.IDs[int(d)-1])
+	q, ok := qs.quad(val)
+	if !ok {
+		return nil
 	}
-	name := l.Quad.Get(d)
-	return qs.ValueOf(name)
+	id := q.Dir(d)
+	if _, ok = qs.prim[id]; !ok {
+		return nil
+	}
+	return graph.NewSequentialKey(id)
 }
 
 func (qs *QuadStore) NodesAllIterator() graph.Iterator {
-	return newNodesAllIterator(qs)
+	return newAllIterator(qs, true, qs.last)
 }
 
 func (qs *QuadStore) Close() error { return nil }
 
 func (qs *QuadStore) Type() string {
 	return QuadStoreType
-}
-
-func (qs *QuadStore) isNode(v graph.Value) bool {
-	if _, ok := v.(iterator.Int64Node); ok {
-		return true
-	}
-	return false
 }

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/quad"
 	"github.com/cayleygraph/cayley/writer"
+	"github.com/stretchr/testify/require"
 )
 
 // This is a simple test graph.
@@ -72,6 +73,7 @@ func makeTestStore(data []quad.Quad) (*QuadStore, graph.QuadWriter, []pair) {
 		}
 
 		writer.AddQuad(t)
+		val++
 	}
 	return qs, writer, ind
 }
@@ -91,18 +93,16 @@ type pair struct {
 
 func TestMemstore(t *testing.T) {
 	qs, _, index := makeTestStore(simpleGraph)
-	if size := qs.Size(); size != int64(len(simpleGraph)) {
-		t.Errorf("Quad store has unexpected size, got:%d expected %d", size, len(simpleGraph))
-	}
+	require.Equal(t, int64(22), qs.Size())
+
 	for _, test := range index {
 		v := qs.ValueOf(quad.Raw(test.query))
 		switch v := v.(type) {
 		default:
 			t.Errorf("ValueOf(%q) returned unexpected type, got:%T expected int64", test.query, v)
-		case iterator.Int64Node:
-			if int64(v) != test.value {
-				t.Errorf("ValueOf(%q) returned unexpected value, got:%d expected:%d", test.query, v, test.value)
-			}
+		case graph.PrimaryKey:
+			n, _ := v.Int()
+			require.Equal(t, test.value, n)
 		}
 	}
 }
@@ -139,7 +139,7 @@ func TestIteratorsAndNextResultOrderA(t *testing.T) {
 		expect = []string{"B", "D"}
 	)
 	for {
-		got = append(got, qs.NameOf(all.Result()).String())
+		got = append(got, quad.StringOf(qs.NameOf(all.Result())))
 		if !outerAnd.NextPath() {
 			break
 		}

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -100,9 +100,8 @@ func TestMemstore(t *testing.T) {
 		switch v := v.(type) {
 		default:
 			t.Errorf("ValueOf(%q) returned unexpected type, got:%T expected int64", test.query, v)
-		case graph.PrimaryKey:
-			n, _ := v.Int()
-			require.Equal(t, test.value, n)
+		case bnode:
+			require.Equal(t, test.value, int64(v))
 		}
 	}
 }

--- a/graph/mongo/indexed_linksto.go
+++ b/graph/mongo/indexed_linksto.go
@@ -110,9 +110,9 @@ func (it *LinksTo) Optimize() (graph.Iterator, bool) {
 
 func (it *LinksTo) Next() bool {
 	var result struct {
-		ID      string  `bson:"_id"`
-		Added   []int64 `bson:"Added"`
-		Deleted []int64 `bson:"Deleted"`
+		ID      string     `bson:"_id"`
+		Added   []bson.Raw `bson:"Added"`
+		Deleted []bson.Raw `bson:"Deleted"`
 	}
 	graph.NextLogIn(it)
 next:

--- a/graph/mongo/iterator.go
+++ b/graph/mongo/iterator.go
@@ -136,9 +136,9 @@ func (it *Iterator) Clone() graph.Iterator {
 
 func (it *Iterator) Next() bool {
 	var result struct {
-		ID      string  `bson:"_id"`
-		Added   []int64 `bson:"Added"`
-		Deleted []int64 `bson:"Deleted"`
+		ID      string     `bson:"_id"`
+		Added   []bson.Raw `bson:"Added"`
+		Deleted []bson.Raw `bson:"Deleted"`
 	}
 	if it.iter == nil {
 		it.iter = it.makeMongoIterator()

--- a/graph/mongo/quadstore_test.go
+++ b/graph/mongo/quadstore_test.go
@@ -3,10 +3,10 @@
 package mongo
 
 import (
-	"testing"
+	"bytes"
 	"math/rand"
 	"sync"
-	"bytes"
+	"testing"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/graphtest"
@@ -41,6 +41,7 @@ func makeMongo(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestMongoAll(t *testing.T) {
 	graphtest.TestAll(t, makeMongo, &graphtest.Config{
+		NoPrimitives:             true,
 		TimeInMs:                 true,
 		OptimizesComparison:      true,
 		SkipDeletedFromIterator:  true,

--- a/graph/primarykey_test.go
+++ b/graph/primarykey_test.go
@@ -24,33 +24,26 @@ import (
 func TestSequentialKeyCreation(t *testing.T) {
 	{
 		seqKey := NewSequentialKey(666)
-		seqKey.Next()
 
-		var expected int64 = 667
-		result := seqKey.Int()
+		var expected int64 = 666
+		result, _ := seqKey.Int()
 		if expected != result {
 			t.Errorf("Expected %q got %q", expected, result)
 		}
 	}
 	{
 		seqKey := NewSequentialKey(0)
-		seqKey.Next()
 
-		var expected int64 = 1
-		result := seqKey.Int()
-		if expected != result {
-			t.Errorf("Expected %q got %q", expected, result)
+		result, ok := seqKey.Int()
+		if !ok || result != 0 {
+			t.Errorf("Expected %q got %q", 0, result)
 		}
 	}
 }
 
 func TestUniqueKeyCreation(t *testing.T) {
-	uniqueKey := NewUniqueKey("")
-	if uuid.Parse(uniqueKey.String()) == nil {
-		t.Error("Invalid uuid generated")
-	}
-	uniqueKey.Next()
-	if uuid.Parse(uniqueKey.String()) == nil {
+	k := NewUniqueKey("")
+	if s, _ := k.Unique(); uuid.Parse(s) == nil {
 		t.Error("Invalid uuid generated")
 	}
 }
@@ -67,8 +60,10 @@ func TestSequentialKeyMarshaling(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unmarshaling of sequential key failed with : %v", err)
 	}
-	if seqKey.Int() != seqKey2.Int() {
-		t.Errorf("Unmarshaling failed: Expected: %d, got: %d", seqKey.Int(), seqKey2.Int())
+	n1, _ := seqKey.Int()
+	n2, _ := seqKey2.Int()
+	if seqKey != seqKey2 || n1 != n2 {
+		t.Errorf("Unmarshaling failed: Expected: %d, got: %d", n1, n2)
 	}
 }
 
@@ -84,10 +79,11 @@ func TestUniqueKeyMarshaling(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unmarshaling of unique key failed with : %v", err)
 	}
-	if uuid.Parse(uniqueKey2.String()) == nil {
+	s2, _ := uniqueKey2.Unique()
+	if uuid.Parse(s2) == nil {
 		t.Error("Unique Key incorrectly unmarshaled")
 	}
-	if uniqueKey.String() != uniqueKey2.String() {
+	if s1, _ := uniqueKey.Unique(); uniqueKey != uniqueKey2 || s1 != s2 {
 		t.Error("Unique Key incorrectly unmarshaled")
 	}
 }

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -24,7 +24,6 @@ package graph
 import (
 	"errors"
 	"io"
-	"time"
 
 	"github.com/cayleygraph/cayley/quad"
 )
@@ -49,10 +48,8 @@ const (
 )
 
 type Delta struct {
-	ID        PrimaryKey
-	Quad      quad.Quad
-	Action    Procedure
-	Timestamp time.Time
+	Quad   quad.Quad
+	Action Procedure
 }
 
 type Handle struct {

--- a/graph/sql/cockroach.go
+++ b/graph/sql/cockroach.go
@@ -40,7 +40,6 @@ func init() {
 	predicate_hash BYTEA NOT NULL,
 	object_hash BYTEA NOT NULL,
 	label_hash BYTEA,
-	id BIGINT,
 	ts timestamp
 );`,
 		FieldQuote:  '"',
@@ -154,7 +153,7 @@ func tryRunTxCockroach(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) erro
 		switch d.Action {
 		case graph.Add:
 			if insertQuad == nil {
-				insertQuad, err = tx.Prepare(`INSERT INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES ($1, $2, $3, $4, $5, $6)` + end)
+				insertQuad, err = tx.Prepare(`INSERT INTO quads(subject_hash, predicate_hash, object_hash, label_hash, ts) VALUES ($1, $2, $3, $4, now())` + end)
 				if err != nil {
 					return err
 				}
@@ -212,8 +211,6 @@ func tryRunTxCockroach(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) erro
 			}
 			_, err := insertQuad.Exec(
 				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
-				d.ID.Int(),
-				d.Timestamp,
 			)
 			if err != nil {
 				clog.Errorf("couldn't exec INSERT statement: %v", err)

--- a/graph/sql/cockroach_test.go
+++ b/graph/sql/cockroach_test.go
@@ -18,7 +18,7 @@ import (
 func makeCockroach(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 	var conf dock.Config // TODO
 
-	conf.Image = "cockroachdb/cockroach:v1.0.1"
+	conf.Image = "cockroachdb/cockroach:v1.0.4"
 	conf.Cmd = []string{"start", "--insecure"}
 
 	opts := graph.Options{"flavor": flavorCockroach}
@@ -58,6 +58,7 @@ func makeCockroach(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestCockroachAll(t *testing.T) {
 	graphtest.TestAll(t, makeCockroach, &graphtest.Config{
+		NoPrimitives:            true,
 		TimeInMcs:               true,
 		TimeRound:               true,
 		OptimizesHasAToUnique:   true,

--- a/graph/sql/mysql.go
+++ b/graph/sql/mysql.go
@@ -81,7 +81,7 @@ func runTxMysql(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
 		switch d.Action {
 		case graph.Add:
 			if insertQuad == nil {
-				insertQuad, err = tx.Prepare(`INSERT` + ignore + ` INTO quads(subject_hash, predicate_hash, object_hash, label_hash, id, ts) VALUES (?, ?, ?, ?, ?, ?);`)
+				insertQuad, err = tx.Prepare(`INSERT` + ignore + ` INTO quads(subject_hash, predicate_hash, object_hash, label_hash, ts) VALUES (?, ?, ?, ?, now());`)
 				if err != nil {
 					return err
 				}
@@ -140,8 +140,6 @@ func runTxMysql(tx *sql.Tx, in []graph.Delta, opts graph.IgnoreOpts) error {
 			}
 			_, err := insertQuad.Exec(
 				hs.toSQL(), hp.toSQL(), ho.toSQL(), hl.toSQL(),
-				d.ID.Int(),
-				d.Timestamp,
 			)
 			err = convInsertErrorMySql(err)
 			if err != nil {

--- a/graph/sql/mysql_test.go
+++ b/graph/sql/mysql_test.go
@@ -54,6 +54,7 @@ func makeMysql(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestMysqlAll(t *testing.T) {
 	graphtest.TestAll(t, makeMysql, &graphtest.Config{
+		NoPrimitives:            true,
 		TimeInMcs:               true,
 		OptimizesHasAToUnique:   true,
 		SkipNodeDelAfterQuadDel: true,

--- a/graph/sql/postgres_test.go
+++ b/graph/sql/postgres_test.go
@@ -51,6 +51,7 @@ func makePostgres(t testing.TB) (graph.QuadStore, graph.Options, func()) {
 
 func TestPostgresAll(t *testing.T) {
 	graphtest.TestAll(t, makePostgres, &graphtest.Config{
+		NoPrimitives:            true,
 		TimeInMcs:               true,
 		TimeRound:               true,
 		OptimizesHasAToUnique:   true,

--- a/query/gizmo/gizmo_test.go
+++ b/query/gizmo/gizmo_test.go
@@ -404,7 +404,7 @@ var testQueries = []struct {
 		query: `
 		  g.V().Labels().All()
 		`,
-		expect: []string{"", "<smart_graph>"},
+		expect: []string{"<smart_graph>"},
 	},
 	{
 		message: "list all in predicates",


### PR DESCRIPTION
Primary key was broken in many ways, for example it carried mutex, but all updates happened with Next that copied the value (with mutex).
Most backends are able to provide their own PK for log entries, so it's better to use it instead of emulating one.

Delta was changed in incompatible way: ID and Timestamp was removed.
As described above, ID should be set by QuadStore in case of successful after TX, while Timestamp should not be sent from client, since it's unreliable. Both values are now set in backend code.

Memstore was partially rewritten to reflect changes. It was also updated to use Primitives instead of nodes/quads.

Optimizations of memstore:
```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkNamePredicate-8                      197366        197153        -0.11%
BenchmarkLargeSetsNoIntersection-8            3241034       2018119       -37.73%
BenchmarkVeryLargeSetsSmallIntersection-8     5988325       4358409       -27.22%
BenchmarkHelplessContainsChecker-8            2116829       2061208       -2.63%
BenchmarkHelplessNotContainsFilms-8           695745        608946        -12.48%
BenchmarkHelplessNotContainsActors-8          6796812       5750716       -15.39%
BenchmarkNetAndSpeed-8                        807330        755597        -6.41%
BenchmarkKeanuAndNet-8                        627513        613111        -2.30%
BenchmarkKeanuAndSpeed-8                      711354        666505        -6.30%
BenchmarkKeanuOther-8                         2253536       1859483       -17.49%
BenchmarkKeanuBullockOther-8                  3951789       3321211       -15.96%
BenchmarkSaveBogartPerformances-8             308244        293941        -4.64%

benchmark                                     old allocs     new allocs     delta
BenchmarkNamePredicate-8                      458            452            -1.31%
BenchmarkLargeSetsNoIntersection-8            11652          6322           -45.74%
BenchmarkVeryLargeSetsSmallIntersection-8     26005          16231          -37.59%
BenchmarkHelplessContainsChecker-8            10868          8255           -24.04%
BenchmarkHelplessNotContainsFilms-8           3072           2475           -19.43%
BenchmarkHelplessNotContainsActors-8          40348          27421          -32.04%
BenchmarkNetAndSpeed-8                        4534           4144           -8.60%
BenchmarkKeanuAndNet-8                        3441           3323           -3.43%
BenchmarkKeanuAndSpeed-8                      3856           3561           -7.65%
BenchmarkKeanuOther-8                         11770          8539           -27.45%
BenchmarkKeanuBullockOther-8                  18591          13196          -29.02%
BenchmarkSaveBogartPerformances-8             1151           1079           -6.26%

benchmark                                     old bytes     new bytes     delta
BenchmarkNamePredicate-8                      28943         28174         -2.66%
BenchmarkLargeSetsNoIntersection-8            520249        400564        -23.01%
BenchmarkVeryLargeSetsSmallIntersection-8     1241740       950372        -23.46%
BenchmarkHelplessContainsChecker-8            758950        711689        -6.23%
BenchmarkHelplessNotContainsFilms-8           182826        166566        -8.89%
BenchmarkHelplessNotContainsActors-8          1313465       1158931       -11.77%
BenchmarkNetAndSpeed-8                        301581        286143        -5.12%
BenchmarkKeanuAndNet-8                        227941        220895        -3.09%
BenchmarkKeanuAndSpeed-8                      247413        236689        -4.33%
BenchmarkKeanuOther-8                         659190        584743        -11.29%
BenchmarkKeanuBullockOther-8                  966314        841981        -12.87%
BenchmarkSaveBogartPerformances-8             68837         65634         -4.65%
```