### PR TITLE
Allow tag removal.

### DIFF
--- a/graph/iterator.go
+++ b/graph/iterator.go
@@ -47,6 +47,25 @@ func (t *Tagger) Add(tag ...string) {
 	t.tags = append(t.tags, tag...)
 }
 
+// Remove tags from the iterator
+func (t *Tagger) Remove(tags []string) {
+	newTags := []string{}
+	for _, tag := range t.tags {
+		keep := true
+		for _, rem := range tags {
+			if tag == rem {
+				keep = false
+			}
+		}
+
+		if keep {
+			newTags = append(newTags, tag)
+		}
+	}
+
+	t.tags = newTags
+}
+
 func (t *Tagger) AddFixed(tag string, value Value) {
 	if t.fixedTags == nil {
 		t.fixedTags = make(map[string]Value)

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -138,6 +138,17 @@ func hasReverseMorphism(via interface{}, nodes ...quad.Value) morphism {
 	}
 }
 
+func untagMorphism(tags ...string) morphism {
+	return morphism{
+		Name:     "untag",
+		Reversal: func(ctx *pathContext) (morphism, *pathContext) { return untagMorphism(tags...), ctx },
+		Apply: func(in shape.Shape, ctx *pathContext) (shape.Shape, *pathContext) {
+			return shape.UnSave{From: in, Tags: tags}, ctx
+		},
+		tags: tags,
+	}
+}
+
 func tagMorphism(tags ...string) morphism {
 	return morphism{
 		Name:     "tag",

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -202,6 +202,12 @@ func (p *Path) Tag(tags ...string) *Path {
 	return np
 }
 
+func (p *Path) UnTag(tags ...string) *Path {
+	np := p.clone()
+	np.stack = append(np.stack, untagMorphism(tags...))
+	return np
+}
+
 // Out updates this Path to represent the nodes that are adjacent to the
 // current nodes, via the given outbound predicate.
 //


### PR DESCRIPTION
Allow tag removal across a whole path. 
Useful if you have some path with a tag, and want to exclude some results from TagResults:

```go
newPath := oldPath.Except(
    oldPath.Has("edge", quad.String("UnwantedEdge"))
    .Untag("someTag"))

it := newPath.BuildIteratorOn(store)
it.Next()
it.TagResults(someMap)
```

Without untag, the expected value of `someMap["someTag"]` may have been overwritten by the value in the excepted path.