### PR TITLE
Add optional max recursion depth to FollowRecursive

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alexander Peters <info@alexanderpeters.de>
 Andrew Dunham <andrew@du.nham.ca>
 Bram Leenders <bcleenders@gmail.com>
 Denys Smirnov <denis.smirnov.91@gmail.com>
+Derek Liang <fr.derekliang@gmail.com>
 Google Inc.
 Jay Graves <jaywgraves@gmail.com>
 Jeremy Jay <jeremy@pbnjay.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Andrew Dunham <andrew@du.nham.ca>
 Barak Michener <barakmich@google.com> <barak@cayley.io> <me@barakmich.com>
 Bram Leenders <bcleenders@gmail.com>
 Denys Smirnov <denis.smirnov.91@gmail.com>
+Derek Liang <fr.derekliang@gmail.com>
 Jay Graves <jaywgraves@gmail.com>
 Jeremy Jay <jeremy@pbnjay.com>
 Pius Uzamere <pius+github@alum.mit.edu>

--- a/graph/iterator/recursive.go
+++ b/graph/iterator/recursive.go
@@ -104,7 +104,7 @@ func (it *Recursive) TagResults(dst map[string]graph.Value) {
 }
 
 func (it *Recursive) Clone() graph.Iterator {
-	n := NewRecursive(it.qs, it.subIt.Clone(), it.morphism, DefaultMaxRecursiveSteps)
+	n := NewRecursive(it.qs, it.subIt.Clone(), it.morphism, it.maxDepth)
 	n.tags.CopyFrom(it)
 	n.depthTags.CopyFromTagger(&it.depthTags)
 	return n
@@ -131,7 +131,7 @@ func (it *Recursive) Next() bool {
 			}
 		}
 	}
-	if it.depth == it.maxDepth {
+	if it.depth >= it.maxDepth {
 		return graph.NextLogOut(it, false)
 	}
 	for {

--- a/graph/iterator/recursive_test.go
+++ b/graph/iterator/recursive_test.go
@@ -54,7 +54,7 @@ func TestRecursiveNext(t *testing.T) {
 	qs := rec_test_qs
 	start := qs.FixedIterator()
 	start.Add(graph.PreFetched(quad.Raw("alice")))
-	r := NewRecursive(qs, start, singleHop("parent"))
+	r := NewRecursive(qs, start, singleHop("parent"), 0)
 	expected := []string{"bob", "charlie", "dani", "emily"}
 
 	var got []string
@@ -72,7 +72,7 @@ func TestRecursiveContains(t *testing.T) {
 	qs := rec_test_qs
 	start := qs.FixedIterator()
 	start.Add(graph.PreFetched(quad.Raw("alice")))
-	r := NewRecursive(qs, start, singleHop("parent"))
+	r := NewRecursive(qs, start, singleHop("parent"), 0)
 	values := []string{"charlie", "bob", "not"}
 	expected := []bool{true, true, false}
 
@@ -94,7 +94,7 @@ func TestRecursiveNextPath(t *testing.T) {
 	fixed := qs.FixedIterator()
 	fixed.Add(graph.PreFetched(quad.Raw("alice")))
 	and.AddSubIterator(fixed)
-	r := NewRecursive(qs, and, singleHop("parent"))
+	r := NewRecursive(qs, and, singleHop("parent"), 0)
 
 	expected := []string{"fred", "fred", "fred", "fred", "greg", "greg", "greg", "greg"}
 	var got []string

--- a/graph/path/morphism_apply_functions.go
+++ b/graph/path/morphism_apply_functions.go
@@ -306,16 +306,16 @@ func (s iteratorBuilder) Optimize(r shape.Optimizer) (shape.Shape, bool) {
 	return s, false
 }
 
-func followRecursiveMorphism(p *Path, depthTags []string) morphism {
+func followRecursiveMorphism(p *Path, maxDepth int, depthTags []string) morphism {
 	return morphism{
 		Name: "follow_recursive",
 		Reversal: func(ctx *pathContext) (morphism, *pathContext) {
-			return followRecursiveMorphism(p.Reverse(), depthTags), ctx
+			return followRecursiveMorphism(p.Reverse(), maxDepth, depthTags), ctx
 		},
 		Apply: func(in shape.Shape, ctx *pathContext) (shape.Shape, *pathContext) {
 			return iteratorBuilder(func(qs graph.QuadStore) graph.Iterator {
 				in := in.BuildIterator(qs)
-				it := iterator.NewRecursive(qs, in, p.Morphism())
+				it := iterator.NewRecursive(qs, in, p.Morphism(), maxDepth)
 				for _, s := range depthTags {
 					it.AddDepthTag(s)
 				}

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -364,7 +364,13 @@ func (p *Path) FollowReverse(path *Path) *Path {
 // ancestors", by repeatedly following the "parent" connection on the result of
 // the parent nodes.
 //
-// The second argument, "depthTags" is a set of tags that will return strings of
+// The second argument, "maxDepth" is the maximum number of recursive steps before
+// stopping and returning.
+// If -1 is passed, it will have no limit.
+// If 0 is passed, it will use the default value of 50 steps before returning.
+// If 1 is passed, it will stop after 1 step before returning, and so on.
+//
+// The third argument, "depthTags" is a set of tags that will return strings of
 // numeric values relating to how many applications of the path were applied the
 // first time the result node was seen.
 //

--- a/graph/path/path.go
+++ b/graph/path/path.go
@@ -88,7 +88,7 @@ func StartPath(qs graph.QuadStore, nodes ...quad.Value) *Path {
 		stack: []morphism{
 			isMorphism(nodes...),
 		},
-		qs:    qs,
+		qs: qs,
 	}
 }
 
@@ -98,7 +98,7 @@ func StartPathNodes(qs graph.QuadStore, nodes ...graph.Value) *Path {
 		stack: []morphism{
 			isNodeMorphism(nodes...),
 		},
-		qs:    qs,
+		qs: qs,
 	}
 }
 
@@ -114,7 +114,7 @@ func PathFromIterator(qs graph.QuadStore, it graph.Iterator) *Path {
 // NewPath creates a new, empty Path.
 func NewPath(qs graph.QuadStore) *Path {
 	return &Path{
-		qs:    qs,
+		qs: qs,
 	}
 }
 
@@ -369,7 +369,7 @@ func (p *Path) FollowReverse(path *Path) *Path {
 // first time the result node was seen.
 //
 // This is a very expensive operation in practice. Be sure to use it wisely.
-func (p *Path) FollowRecursive(via interface{}, depthTags []string) *Path {
+func (p *Path) FollowRecursive(via interface{}, maxDepth int, depthTags []string) *Path {
 	var path *Path
 	switch v := via.(type) {
 	case string:
@@ -382,7 +382,7 @@ func (p *Path) FollowRecursive(via interface{}, depthTags []string) *Path {
 		panic("did not pass a string predicate or a Path to FollowRecursive")
 	}
 	np := p.clone()
-	np.stack = append(p.stack, followRecursiveMorphism(path, depthTags))
+	np.stack = append(p.stack, followRecursiveMorphism(path, maxDepth, depthTags))
 	return np
 }
 

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -350,7 +350,7 @@ func testSet(qs graph.QuadStore) []test {
 		},
 		{
 			message: "follow recursive",
-			path:    StartPath(qs, vCharlie).FollowRecursive(vFollows, nil),
+			path:    StartPath(qs, vCharlie).FollowRecursive(vFollows, 0, nil),
 			expect:  []quad.Value{vBob, vDani, vFred, vGreg},
 		},
 		{
@@ -420,7 +420,7 @@ func testFollowRecursive(t testing.TB, fnc graphtest.DatabaseFunc) {
 	defer closer()
 
 	qu := StartPath(qs, quad.IRI("a")).FollowRecursive(
-		StartMorphism().Out(quad.IRI("parent")), nil,
+		StartMorphism().Out(quad.IRI("parent")), 0, nil,
 	).Has(quad.IRI("labels"), quad.IRI("tag"))
 
 	expect := []quad.Value{quad.IRI("c"), quad.IRI("d")}

--- a/query/gizmo/environ.go
+++ b/query/gizmo/environ.go
@@ -274,16 +274,16 @@ func exportArgs(args []goja.Value) []interface{} {
 	return out
 }
 
-func toInt(o interface{}) int {
+func toInt(o interface{}) (int, bool) {
 	switch v := o.(type) {
 	case int:
-		return v
+		return v, true
 	case int64:
-		return int(v)
+		return int(v), true
 	case float64:
-		return int(v)
+		return int(v), true
 	default:
-		return 0
+		return 0, false
 	}
 }
 
@@ -397,10 +397,14 @@ func toViaDepthData(objs []interface{}) (predicates []interface{}, maxDepth int,
 		predicates = toVia([]interface{}{objs[0]})
 	}
 	if len(objs) > 1 {
-		maxDepth = toInt(objs[1])
-	}
-	if len(objs) > 2 {
-		tags = toStrings(objs[2:])
+		maxDepth, ok = toInt(objs[1])
+		if ok {
+			if len(objs) > 2 {
+				tags = toStrings(objs[2:])
+			}
+		} else {
+			tags = toStrings(objs[1:])
+		}
 	}
 	ok = true
 	return

--- a/query/gizmo/environ.go
+++ b/query/gizmo/environ.go
@@ -392,6 +392,20 @@ func toViaData(objs []interface{}) (predicates []interface{}, tags []string, ok 
 	return
 }
 
+func toViaDepthData(objs []interface{}) (predicates []interface{}, maxDepth int, tags []string, ok bool) {
+	if len(objs) != 0 {
+		predicates = toVia([]interface{}{objs[0]})
+	}
+	if len(objs) > 1 {
+		maxDepth = toInt(objs[1])
+	}
+	if len(objs) > 2 {
+		tags = toStrings(objs[2:])
+	}
+	ok = true
+	return
+}
+
 func throwErr(vm *goja.Runtime, err error) goja.Value {
 	panic(vm.ToValue(err))
 }

--- a/query/gizmo/finals.go
+++ b/query/gizmo/finals.go
@@ -43,7 +43,7 @@ func (p *pathObject) toArray(call goja.FunctionCall, withTags bool) goja.Value {
 	}
 	limit := -1
 	if len(args) > 0 {
-		limit = toInt(args[0])
+		limit, _ = toInt(args[0])
 	}
 	it := p.buildIteratorTree()
 	it.Tagger().Add(TopResultTag)
@@ -145,7 +145,7 @@ func (p *pathObject) ForEach(call goja.FunctionCall) goja.Value {
 	args := exportArgs(call.Arguments[:len(call.Arguments)-1])
 	limit := -1
 	if len(args) != 0 {
-		limit = toInt(args[0])
+		limit, _ = toInt(args[0])
 	}
 	err := p.s.runIteratorWithCallback(it, callback, call, limit)
 	if err != nil {

--- a/query/gizmo/traversals.go
+++ b/query/gizmo/traversals.go
@@ -247,14 +247,14 @@ func (p *pathObject) FollowR(path *pathObject) *pathObject {
 //	// Returns bob and dani (from charlie), fred (from bob) and greg (from dani).
 //	g.V("<charlie>").FollowRecursive(friend).All()
 func (p *pathObject) FollowRecursive(call goja.FunctionCall) goja.Value {
-	preds, tags, ok := toViaData(exportArgs(call.Arguments))
+	preds, maxDepth, tags, ok := toViaDepthData(exportArgs(call.Arguments))
 	if !ok || len(preds) == 0 {
 		return throwErr(p.s.vm, errNoVia)
 	} else if len(preds) != 1 {
 		return throwErr(p.s.vm, fmt.Errorf("expected one predicate or path for recursive follow"))
 	}
 	np := p.clonePath()
-	np = np.FollowRecursive(preds[0], tags)
+	np = np.FollowRecursive(preds[0], maxDepth, tags)
 	return p.newVal(np)
 }
 


### PR DESCRIPTION
First stab at adding an optional parameter max recursion depth for `FollowRecursive`.

Also noticed `MaxRecursiveSteps ` wasn't being used anywhere and decided to add a max default recursive depth of 50.

Related Issue: https://github.com/cayleygraph/cayley/issues/624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/639)
<!-- Reviewable:end -->
