### PR TITLE
Support wildcards and regexp queries

### DIFF
--- a/graph/nosql/nosql.go
+++ b/graph/nosql/nosql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/pborman/uuid"
 )
@@ -91,6 +92,7 @@ const (
 	GTE
 	LT
 	LTE
+	Regexp
 )
 
 // FieldFilter represents a single field comparison operation.
@@ -146,6 +148,17 @@ func (f FieldFilter) Matches(d Document) bool {
 		case LTE:
 			return dn <= 0
 		}
+	case Regexp:
+		pattern, ok := f.Value.(String)
+		if !ok {
+			return false
+		}
+		s, ok := val.(String)
+		if !ok {
+			return false
+		}
+		ok, _ = regexp.MatchString(string(pattern), string(s))
+		return ok
 	}
 	panic(fmt.Errorf("unsupported operation: %v", f.Filter))
 }

--- a/graph/nosql/quadstore.go
+++ b/graph/nosql/quadstore.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/internal/lru"
 	"github.com/cayleygraph/cayley/quad"
 	"github.com/cayleygraph/cayley/quad/pquads"
@@ -531,7 +532,11 @@ func (qs *QuadStore) Quad(val graph.Value) quad.Quad {
 }
 
 func (qs *QuadStore) QuadIterator(d quad.Direction, val graph.Value) graph.Iterator {
-	return NewLinksToIterator(qs, "quads", []Linkage{{Dir: d, Val: val.(NodeHash)}})
+	h, ok := val.(NodeHash)
+	if !ok {
+		return iterator.NewNull()
+	}
+	return NewLinksToIterator(qs, "quads", []Linkage{{Dir: d, Val: h}})
 }
 
 func (qs *QuadStore) NodesAllIterator() graph.Iterator {

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -256,11 +256,13 @@ func testSet(qs graph.QuadStore) []test {
 			expect: []quad.Value{vBob},
 		},
 		{
-			message: "three letters",
+			message: "three letters and range",
 			path: StartPath(qs).Filters(shape.Wildcard{
 				Pattern: `???`,
+			}, shape.Comparison{
+				Op: iterator.CompareGT, Val: quad.IRI("b"),
 			}),
-			expect: []quad.Value{vAre, vBob},
+			expect: []quad.Value{vBob},
 		},
 		{
 			message: "part in string",

--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -249,6 +249,27 @@ func testSet(qs graph.QuadStore) []test {
 			expect: []quad.Value{vBob, vDani, vEmily, vFred},
 		},
 		{
+			message: "string prefix",
+			path: StartPath(qs).Filters(shape.Wildcard{
+				Pattern: `bo%`,
+			}),
+			expect: []quad.Value{vBob},
+		},
+		{
+			message: "three letters",
+			path: StartPath(qs).Filters(shape.Wildcard{
+				Pattern: `???`,
+			}),
+			expect: []quad.Value{vAre, vBob},
+		},
+		{
+			message: "part in string",
+			path: StartPath(qs).Filters(shape.Wildcard{
+				Pattern: `%ed%`,
+			}),
+			expect: []quad.Value{vFred, vPredicate},
+		},
+		{
 			message: "Limit",
 			path:    StartPath(qs).Has(vStatus, vCool).Limit(2),
 			// TODO(dennwc): resolve this ordering issue

--- a/graph/sql/mysql/mysql.go
+++ b/graph/sql/mysql/mysql.go
@@ -16,6 +16,7 @@ import (
 const Type = "mysql"
 
 var QueryDialect = csql.QueryDialect{
+	RegexpOp: "REGEXP",
 	FieldQuote: func(name string) string {
 		return "`" + name + "`"
 	},

--- a/graph/sql/postgres/postgres.go
+++ b/graph/sql/postgres/postgres.go
@@ -17,6 +17,7 @@ import (
 const Type = "postgres"
 
 var QueryDialect = csql.QueryDialect{
+	RegexpOp:   "~",
 	FieldQuote: pq.QuoteIdentifier,
 	Placeholder: func(n int) string {
 		return fmt.Sprintf("$%d", n)

--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -261,6 +261,7 @@ func New(typ string, addr string, options graph.Options) (graph.QuadStore, error
 		ids:     lru.New(1024),
 		noSizes: true, // Skip size checking by default.
 	}
+	qs.opt.SetRegexpOp(qs.flavor.RegexpOp)
 	if qs.flavor.NoOffsetWithoutLimit {
 		qs.opt.NoOffsetWithoutLimit()
 	}

--- a/graph/sql/quadstore.go
+++ b/graph/sql/quadstore.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/graph/log"
 	"github.com/cayleygraph/cayley/internal/lru"
 	"github.com/cayleygraph/cayley/quad"
@@ -459,7 +460,10 @@ func (qs *QuadStore) Quad(val graph.Value) quad.Quad {
 }
 
 func (qs *QuadStore) QuadIterator(d quad.Direction, val graph.Value) graph.Iterator {
-	v := val.(Value)
+	v, ok := val.(Value)
+	if !ok {
+		return iterator.NewNull()
+	}
 	sel := AllQuads("")
 	sel.WhereEq("", dirField(d), v)
 	return qs.NewIterator(sel)

--- a/graph/sql/shape.go
+++ b/graph/sql/shape.go
@@ -35,6 +35,7 @@ var DefaultDialect = QueryDialect{
 }
 
 type QueryDialect struct {
+	RegexpOp    CmpOp
 	FieldQuote  func(string) string
 	Placeholder func(int) string
 }

--- a/query/gizmo/environ.go
+++ b/query/gizmo/environ.go
@@ -154,6 +154,18 @@ func cmpOpType(op iterator.Operator) func(vm *goja.Runtime, call goja.FunctionCa
 	}
 }
 
+func cmpWildcard(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
+	args := exportArgs(call.Arguments)
+	if len(args) != 1 {
+		return throwErr(vm, errArgCount2{Expected: 1, Got: len(args)})
+	}
+	pattern, ok := args[0].(string)
+	if !ok {
+		return throwErr(vm, fmt.Errorf("wildcard: unsupported type: %T", args[0]))
+	}
+	return vm.ToValue(valFilter{f: shape.Wildcard{Pattern: pattern}})
+}
+
 func cmpRegexp(vm *goja.Runtime, call goja.FunctionCall) goja.Value {
 	args := exportArgs(call.Arguments)
 	if len(args) != 1 && len(args) != 2 {
@@ -230,6 +242,7 @@ var defaultEnv = map[string]func(vm *goja.Runtime, call goja.FunctionCall) goja.
 	"gt":    cmpOpType(iterator.CompareGT),
 	"gte":   cmpOpType(iterator.CompareGTE),
 	"regex": cmpRegexp,
+	"like":  cmpWildcard,
 }
 
 func unwrap(o interface{}) interface{} {

--- a/query/gizmo/gizmo_test.go
+++ b/query/gizmo/gizmo_test.go
@@ -138,6 +138,20 @@ var testQueries = []struct {
 		expect: nil,
 	},
 	{
+		message: "use .In() with .Filter(prefix)",
+		query: `
+			g.V("<bob>").In("<follows>").Filter(like("al%")).All()
+		`,
+		expect: []string{"<alice>"},
+	},
+	{
+		message: "use .In() with .Filter(wildcard)",
+		query: `
+			g.V("<bob>").In("<follows>").Filter(like("a?i%e")).All()
+		`,
+		expect: []string{"<alice>"},
+	},
+	{
 		message: "use .In() with .Filter(regex with IRIs)",
 		query: `
 			g.V("<bob>").In("<follows>").Filter(regex("ar?li.*e", true)).All()


### PR DESCRIPTION
Implement a subset of regexp  - a wildcard query (`LIKE` in SQL). Resolves #664.

At the same time enable regexp optimization for all backends.

Wildcards are exposed in path lib:
```golang
p.HasFilter(quad.IRI("name"), false, shape.Wildcard{
  Pattern: `An%`,
})
```

And in Gizmo:
```javascript
g.V().Has("<name>", like("An%"))
```