### PR TITLE
Support for CouchDB and PouchDB backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Its goal is to be a part of the developer's toolbox where [Linked Data](http://l
   * (simplified) [MQL](./docs/MQL.md), for [Freebase](https://en.wikipedia.org/wiki/Freebase) fans
 * Plays well with multiple backend stores:
   * KVs: [Bolt](https://github.com/boltdb/bolt), [LevelDB](https://github.com/google/leveldb)
-  * NoSQL: [MongoDB](https://www.mongodb.org), [ElasticSearch](https://www.elastic.co/products/elasticsearch)
+  * NoSQL: [MongoDB](https://www.mongodb.org), [ElasticSearch](https://www.elastic.co/products/elasticsearch), [CouchDB](http://couchdb.apache.org/)/[PouchDB](https://pouchdb.com/)
   * SQL: [PostgreSQL](http://www.postgresql.org), [CockroachDB](https://www.cockroachlabs.com), [MySQL](https://www.mysql.com)
   * In-memory, ephemeral
 * Modular design; easy to extend with new languages and backends

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -37,7 +37,9 @@ All command line flags take precedence over the configuration file.
   
   * `mongo`: Stores the graph data and indices in a [MongoDB](https://www.mongodb.com/) instance.
   * `elastic`: Stores the graph data and indices in a [ElasticSearch](https://www.elastic.co/products/elasticsearch) instance.
-  
+  * `couch`: Stores the graph data and indices in a [CouchDB](http://couchdb.apache.org/) instance.
+  * `pouch`: Stores the graph data and indices in a [PouchDB](https://pouchdb.com/). Requires building with [GopherJS](https://github.com/gopherjs/gopherjs).
+
   **SQL backends**
   
   * `postgres`: Stores the graph data and indices in a [PostgreSQL](https://www.postgresql.org) instance.
@@ -56,7 +58,8 @@ All command line flags take precedence over the configuration file.
   * `leveldb`: Directory to hold the LevelDB database files.
   * `bolt`: Path to the persistent single Bolt database file.
   * `mongo`: "hostname:port" of the desired MongoDB server. More options can be provided in [mgo](https://godoc.org/gopkg.in/mgo.v2#Dial) address format.
-  * `elastic`: "http://host:port" of the desired ElasticSearch server.
+  * `elastic`: `http://host:port` of the desired ElasticSearch server.
+  * `couch`: `http://user:pass@host:port/dbname` of the desired CouchDB server.
   * `postgres`,`cockroach`: `postgres://[username:password@]host[:port]/database-name?sslmode=disable` of the PostgreSQL database and credentials. Sslmode is optional. More option available on [pq](https://godoc.org/github.com/lib/pq) page.
   * `mysql`: `[username:password@]tcp(host[:3306])/database-name` of the MqSQL database and credentials. More option available on [driver](https://github.com/go-sql-driver/mysql#dsn-data-source-name) page.
 

--- a/glide.lock
+++ b/glide.lock
@@ -176,6 +176,12 @@ imports:
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 - name: gopkg.in/olivere/elastic.v5
   version: 79ff368708b3a2a9da641dc831d95fd0782bf4ef
+- name: github.com/go-kivik/couchdb
+  version: 74d231fe43245e77840213724894264f0f61ffd3
+- name: github.com/go-kivik/kivik
+  version: 2a1f6b9dd407886bc59c0c28faed28fbce3b0ece
+- name: github.com/imdario/mergo
+  version: 0d4b488675fdec1dde48751b05ab530cf0b630e1
 - name: github.com/pkg/errors
   version: e881fd58d78e04cf6d0de1217f8707c8cc2249bc
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -48,3 +48,5 @@ import:
 - package: github.com/dennwc/graphql
 - package: github.com/tylertreat/BoomFilters
 - package: gopkg.in/olivere/elastic.v5
+- package: github.com/go-kivik/kivik
+- package: github.com/go-kivik/couchdb

--- a/graph/all/all.go
+++ b/graph/all/all.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/cayleygraph/cayley/graph/memstore"
 	_ "github.com/cayleygraph/cayley/graph/nosql/elastic"
 	_ "github.com/cayleygraph/cayley/graph/nosql/mongo"
+	_ "github.com/cayleygraph/cayley/graph/nosql/ouch"
 	_ "github.com/cayleygraph/cayley/graph/sql/cockroach"
 	_ "github.com/cayleygraph/cayley/graph/sql/mysql"
 	_ "github.com/cayleygraph/cayley/graph/sql/postgres"

--- a/graph/graphtest/graphtest.go
+++ b/graph/graphtest/graphtest.go
@@ -115,6 +115,9 @@ func IteratedQuads(t testing.TB, qs graph.QuadStore, it graph.Iterator) []quad.Q
 	}
 	require.Nil(t, it.Err())
 	sort.Sort(res)
+	if res == nil {
+		return []quad.Quad(nil) // GopherJS seems to have a bug with this type conversion for a nil value
+	}
 	return res
 }
 
@@ -123,6 +126,9 @@ func ExpectIteratedQuads(t testing.TB, qs graph.QuadStore, it graph.Iterator, ex
 	if sortQuads {
 		sort.Sort(quad.ByQuadString(exp))
 		sort.Sort(quad.ByQuadString(got))
+	}
+	if len(exp) == 0 {
+		exp = nil // GopherJS seems to have a bug with nil value
 	}
 	require.Equal(t, exp, got)
 }

--- a/graph/iterator/value_comparison.go
+++ b/graph/iterator/value_comparison.go
@@ -37,6 +37,21 @@ import (
 
 type Operator int
 
+func (op Operator) String() string {
+	switch op {
+	case CompareLT:
+		return "<"
+	case CompareLTE:
+		return "<="
+	case CompareGT:
+		return ">"
+	case CompareGTE:
+		return ">="
+	default:
+		return fmt.Sprintf("op(%d)", int(op))
+	}
+}
+
 const (
 	CompareLT Operator = iota
 	CompareLTE

--- a/graph/nosql/elastic/elastic_test.go
+++ b/graph/nosql/elastic/elastic_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cayleygraph/cayley/internal/dock"
 )
 
-func makeElastic(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeElastic(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	var conf dock.Config
 
 	conf.Image = "elasticsearch"
@@ -26,7 +26,7 @@ func makeElastic(t testing.TB) (nosql.Database, graph.Options, func()) {
 		closer()
 		t.Fatal(err)
 	}
-	return db, nil, func() {
+	return db, nil, nil, func() {
 		db.Close()
 		closer()
 	}

--- a/graph/nosql/elastic/elastic_test.go
+++ b/graph/nosql/elastic/elastic_test.go
@@ -18,8 +18,8 @@ func makeElastic(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, f
 	conf.OpenStdin = true
 	conf.Tty = true
 
-	addr, closer := dock.RunAndWait(t, conf, dock.WaitPort("9200"))
-	addr = "http://" + addr + ":9200"
+	addr, closer := dock.RunAndWait(t, conf, "9200", nil)
+	addr = "http://" + addr
 
 	db, err := dialDB(addr, nil)
 	if err != nil {

--- a/graph/nosql/iterator.go
+++ b/graph/nosql/iterator.go
@@ -210,6 +210,9 @@ func (it *Iterator) Size() (int64, bool) {
 	if it.limit > 0 && it.size > it.limit {
 		it.size = it.limit
 	}
+	if it.size < 0 {
+		return it.qs.Size(), false
+	}
 	return it.size, true
 }
 

--- a/graph/nosql/iterator.go
+++ b/graph/nosql/iterator.go
@@ -189,7 +189,7 @@ func (it *Iterator) Contains(ctx context.Context, v graph.Value) bool {
 	if qv == nil {
 		return false
 	}
-	d := toDocumentValue(qv)
+	d := it.qs.opt.toDocumentValue(qv)
 	for _, f := range it.constraint {
 		if !f.Matches(d) {
 			return false

--- a/graph/nosql/mongo/mongo_test.go
+++ b/graph/nosql/mongo/mongo_test.go
@@ -18,9 +18,8 @@ func makeMongo(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, fun
 	conf.OpenStdin = true
 	conf.Tty = true
 
-	addr, closer := dock.Run(t, conf)
+	addr, closer := dock.RunAndWait(t, conf, "27017", nil)
 
-	addr = addr + ":27017"
 	qs, err := dialDB(addr, nil)
 	if err != nil {
 		closer()

--- a/graph/nosql/mongo/mongo_test.go
+++ b/graph/nosql/mongo/mongo_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cayleygraph/cayley/internal/dock"
 )
 
-func makeMongo(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeMongo(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	var conf dock.Config
 
 	conf.Image = "mongo:3"
@@ -26,7 +26,7 @@ func makeMongo(t testing.TB) (nosql.Database, graph.Options, func()) {
 		closer()
 		t.Fatal(err)
 	}
-	return qs, nil, func() {
+	return qs, nil, nil, func() {
 		qs.Close()
 		closer()
 	}

--- a/graph/nosql/nosqltest/nosqltest_all.go
+++ b/graph/nosql/nosqltest/nosqltest_all.go
@@ -23,6 +23,7 @@ type Config struct {
 	IntToFloat bool // database always converts all int values to floats
 	TimeInMs   bool
 	Recreate   bool // tests should re-create database instance from scratch on each run
+	PageSize   int  // result page size for pagination (large iterator) tests
 }
 
 func (c Config) quadStore() *graphtest.Config {

--- a/graph/nosql/nosqltest/nosqltest_all.go
+++ b/graph/nosql/nosqltest/nosqltest_all.go
@@ -20,6 +20,7 @@ type DatabaseFunc func(t testing.TB) (nosql.Database, graph.Options, func())
 
 type Config struct {
 	FloatToInt bool // database silently converts all float values to ints, if possible
+	IntToFloat bool // database always converts all int values to floats
 	TimeInMs   bool
 	Recreate   bool // tests should re-create database instance from scratch on each run
 }

--- a/graph/nosql/nosqltest/nosqltest_all.go
+++ b/graph/nosql/nosqltest/nosqltest_all.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cayleygraph/cayley/quad"
 )
 
-type DatabaseFunc func(t testing.TB) (nosql.Database, graph.Options, func())
+type DatabaseFunc func(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func())
 
 type Config struct {
 	FloatToInt bool // database silently converts all float values to ints, if possible
@@ -37,14 +37,14 @@ func (c Config) quadStore() *graphtest.Config {
 }
 
 func NewQuadStore(t testing.TB, gen DatabaseFunc) (graph.QuadStore, graph.Options, func()) {
-	db, opt, closer := gen(t)
+	db, nopt, opt, closer := gen(t)
 	err := nosql.Init(db, opt)
 	if err != nil {
 		db.Close()
 		closer()
 		require.Fail(t, "init failed", "%v", err)
 	}
-	kdb, err := nosql.New(db, opt)
+	kdb, err := nosql.NewQuadStore(db, nopt, opt)
 	if err != nil {
 		db.Close()
 		closer()

--- a/graph/nosql/nosqltest/nosqltest_nosql.go
+++ b/graph/nosql/nosqltest/nosqltest_nosql.go
@@ -210,6 +210,17 @@ func fixDoc(conf *Config, d nosql.Document) {
 				d[k] = nosql.Int(f)
 			}
 		}
+	} else if conf.IntToFloat {
+		for k, v := range d {
+			if f, ok := v.(nosql.Int); ok {
+				d[k] = nosql.Float(f)
+			}
+		}
+	}
+	for _, v := range d {
+		if f, ok := v.(nosql.Document); ok {
+			fixDoc(conf, f)
+		}
 	}
 }
 
@@ -420,6 +431,7 @@ func testUpdate(t *testing.T, c tableConf) {
 	}
 	for i, k := range keys {
 		c.kt.SetKey(exp[i], k)
+		fixDoc(c.conf, exp[i])
 	}
 	c.expectAll(t, exp)
 
@@ -464,6 +476,7 @@ func testUpdate(t *testing.T, c tableConf) {
 	}
 	for i, k := range keys {
 		c.kt.SetKey(exp[i], k)
+		fixDoc(c.conf, exp[i])
 	}
 	c.expectAll(t, exp)
 }
@@ -480,6 +493,9 @@ func testDeleteQuery(t *testing.T, c tableConf) {
 			},
 		}
 	})
+	for _, d := range docs {
+		fixDoc(c.conf, d)
+	}
 
 	lt := 1
 	delLt := func(keys []nosql.Key, field ...string) {

--- a/graph/nosql/nosqltest/nosqltest_nosql.go
+++ b/graph/nosql/nosqltest/nosqltest_nosql.go
@@ -161,7 +161,7 @@ func TestNoSQL(t *testing.T, gen DatabaseFunc, conf *Config) {
 		closer func()
 	)
 	if !conf.Recreate {
-		db, _, closer = gen(t)
+		db, _, _, closer = gen(t)
 		defer closer()
 	}
 
@@ -173,7 +173,7 @@ func TestNoSQL(t *testing.T, gen DatabaseFunc, conf *Config) {
 					db := db
 					if conf.Recreate {
 						var closer func()
-						db, _, closer = gen(t)
+						db, _, _, closer = gen(t)
 						defer closer()
 					}
 					c.t(t, tableConf{

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -1,0 +1,34 @@
+# Ouch, prototype driver for CouchDB/PouchDB
+
+To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB). 
+Also need to "npm install pouchdb-find" for queries.
+When running "gopherjs test" from the ouch directory, a pouchdb.test directory will be created (in .gitignore).
+
+To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest" with an administrator account testusername:testpassword (basic auth only, as this also works from the browser).
+
+Note from Discussion forum, re future nosql API alterations at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/13
+
+* I suggest that all the Database interface methods have context as the first parameter, and that context is removed from all the "child" methods (like Query.One).
+* Reply from dennwc37: This might not work well for DocIterator - it might be passed around and should use the context of the last caller, not the first one. I would say it make sense we can add contexts to Insert, FindByKey and EnsureIndexes and leave other builders as-is, since they already pass context in Do, One, Next, etc.
+
+## TODO
+
+* Report GopherJS bug type conversion in graph/graphtest/graphtest.go:IteratedQuads()
+* add Query.Limit() test (and is 1M large enough as the default)
+* work out how to delete test db remotely from JS using PouchDB as front-end to CouchDB, so as to test remote from JS
+* work out how to implement and test PouchDB/CouchDB replication
+* review error handling in from/to Ouch Value/Doc?
+* test on live app with instrumentation, to find further optimisation possibilities
+* investigate using []interface{} for key values in the Strings type - @dennwc said: "This was actually the reason why I dropped nosql.Key for Value interface - it's now the only array type that is supported. So if kivik can store json array, this can be an indication that Strings is stored there."
+
+
+
+## other change
+
+ graph/graphtest/graphtest.go:141 IteratedQuads()
+ ```
+    if res == nil {
+        return []quad.Quad(nil) // GopherJS seems to have a bug with this type conversion for a nil value
+    }
+    return res // NOTE implicit type conversion from quad.ByQuadString to []quad.Quad
+ ```

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -1,34 +1,4 @@
-# Ouch, prototype driver for CouchDB/PouchDB
+# Ouch driver for PouchDB
 
-To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB). 
-Also need to "npm install pouchdb-find" for queries.
-When running "gopherjs test" from the ouch directory, a pouchdb.test directory will be created (in .gitignore).
-
-To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest" with an administrator account testusername:testpassword (basic auth only, as this also works from the browser).
-
-Note from Discussion forum, re future nosql API alterations at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/13
-
-* I suggest that all the Database interface methods have context as the first parameter, and that context is removed from all the "child" methods (like Query.One).
-* Reply from dennwc37: This might not work well for DocIterator - it might be passed around and should use the context of the last caller, not the first one. I would say it make sense we can add contexts to Insert, FindByKey and EnsureIndexes and leave other builders as-is, since they already pass context in Do, One, Next, etc.
-
-## TODO
-
-* Report GopherJS bug type conversion in graph/graphtest/graphtest.go:IteratedQuads()
-* add Query.Limit() test (and is 1M large enough as the default)
-* work out how to delete test db remotely from JS using PouchDB as front-end to CouchDB, so as to test remote from JS
-* work out how to implement and test PouchDB/CouchDB replication
-* review error handling in from/to Ouch Value/Doc?
-* test on live app with instrumentation, to find further optimisation possibilities
-* investigate using []interface{} for key values in the Strings type - @dennwc said: "This was actually the reason why I dropped nosql.Key for Value interface - it's now the only array type that is supported. So if kivik can store json array, this can be an indication that Strings is stored there."
-
-
-
-## other change
-
- graph/graphtest/graphtest.go:141 IteratedQuads()
- ```
-    if res == nil {
-        return []quad.Quad(nil) // GopherJS seems to have a bug with this type conversion for a nil value
-    }
-    return res // NOTE implicit type conversion from quad.ByQuadString to []quad.Quad
- ```
+To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB).
+And "npm install pouchdb-find" for queries.

--- a/graph/nosql/ouch/backend.go
+++ b/graph/nosql/ouch/backend.go
@@ -1,0 +1,9 @@
+// +build !js
+
+package ouch
+
+import (
+	_ "github.com/go-kivik/couchdb" // The CouchDB driver
+)
+
+var defaultDriverName = "couch"

--- a/graph/nosql/ouch/backend_js.go
+++ b/graph/nosql/ouch/backend_js.go
@@ -1,0 +1,9 @@
+// +build js
+
+package ouch
+
+import (
+	_ "github.com/go-kivik/pouchdb" // The PouchDB driver
+)
+
+var defaultDriverName = "pouch"

--- a/graph/nosql/ouch/couch.go
+++ b/graph/nosql/ouch/couch.go
@@ -6,4 +6,4 @@ import (
 	_ "github.com/go-kivik/couchdb" // The CouchDB driver
 )
 
-var defaultDriverName = "couch"
+const driverName = "couch"

--- a/graph/nosql/ouch/couch_test.go
+++ b/graph/nosql/ouch/couch_test.go
@@ -22,9 +22,7 @@ func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
 		"COUCHDB_PASSWORD=cayley",
 	}
 	const port = "5984"
-	addr, closer := dock.RunAndWait(t, conf, dock.WaitPort(port))
-
-	addr = addr + ":" + port
+	addr, closer := dock.RunAndWait(t, conf, port, nil)
 	qs, err := dialDB(true, "http://cayley:cayley@"+addr+"/cayley", nil)
 	if err != nil {
 		closer()

--- a/graph/nosql/ouch/couch_test.go
+++ b/graph/nosql/ouch/couch_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-kivik/kivik"
 )
 
-func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeCouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	var conf dock.Config
 
 	conf.Image = "couchdb:2"
@@ -28,7 +28,7 @@ func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
 		closer()
 		t.Fatal(err)
 	}
-	return qs, nil, func() {
+	return qs, &nosqlOptions, nil, func() {
 		qs.Close()
 		closer()
 	}
@@ -36,7 +36,7 @@ func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
 
 var dbId int // PouchDB requires a different DB name each time, or it uses cached data!
 
-func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makePouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	ctx := context.TODO()
 	// TODO add remote db access tests
 	name := fmt.Sprintf("pouchdb%d.test", dbId) // see dbId comment
@@ -56,7 +56,7 @@ func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
 		t.Fatal(err)
 	}
 
-	return qs, nil, func() {
+	return qs, &nosqlOptions, nil, func() {
 		qs.Close()
 	}
 }

--- a/graph/nosql/ouch/couch_test.go
+++ b/graph/nosql/ouch/couch_test.go
@@ -1,0 +1,64 @@
+// +build docker
+
+package ouch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/internal/dock"
+	"github.com/go-kivik/kivik"
+)
+
+func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	var conf dock.Config
+
+	conf.Image = "couchdb:2"
+	conf.Env = []string{
+		"COUCHDB_USER=cayley",
+		"COUCHDB_PASSWORD=cayley",
+	}
+	const port = "5984"
+	addr, closer := dock.RunAndWait(t, conf, dock.WaitPort(port))
+
+	addr = addr + ":" + port
+	qs, err := dialDB(true, "http://cayley:cayley@"+addr+"/cayley", nil)
+	if err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	return qs, nil, func() {
+		qs.Close()
+		closer()
+	}
+}
+
+var dbId int // PouchDB requires a different DB name each time, or it uses cached data!
+
+func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	ctx := context.TODO()
+	// TODO add remote db access tests
+	name := fmt.Sprintf("pouchdb%d.test", dbId) // see dbId comment
+	dbId++
+
+	client, err := kivik.New(ctx, driverName, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.DestroyDB(ctx, name)
+	if err != nil {
+		t.Log(err)
+	}
+
+	qs, err := dialDB(true, name, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return qs, nil, func() {
+		qs.Close()
+	}
+}

--- a/graph/nosql/ouch/none_test.go
+++ b/graph/nosql/ouch/none_test.go
@@ -13,12 +13,12 @@ func selectImpl(t testing.TB) {
 	t.Skipf("enable docker build tag or test via gopherjs")
 }
 
-func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeCouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	selectImpl(t)
-	return nil, nil, nil
+	return nil, nil, nil, nil
 }
 
-func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makePouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	selectImpl(t)
-	return nil, nil, nil
+	return nil, nil, nil, nil
 }

--- a/graph/nosql/ouch/none_test.go
+++ b/graph/nosql/ouch/none_test.go
@@ -1,0 +1,24 @@
+// +build !docker,!js
+
+package ouch
+
+import (
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+)
+
+func selectImpl(t testing.TB) {
+	t.Skipf("enable docker build tag or test via gopherjs")
+}
+
+func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	selectImpl(t)
+	return nil, nil, nil
+}
+
+func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	selectImpl(t)
+	return nil, nil, nil
+}

--- a/graph/nosql/ouch/ouch.go
+++ b/graph/nosql/ouch/ouch.go
@@ -1,0 +1,600 @@
+package ouch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+
+	"github.com/go-kivik/kivik"
+)
+
+const Type = "ouch"
+
+func init() {
+	nosql.Register(Type, nosql.Registration{
+		NewFunc:      Open,
+		InitFunc:     Create,
+		IsPersistent: true,
+	})
+}
+
+func dialDB(create bool, addr string, opt graph.Options) (*DB, error) {
+	ctx := context.TODO() // TODO - replace with parameter value
+
+	driver := defaultDriverName
+
+	addrParsed, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	pathParts := strings.Split(addrParsed.Path, "/")
+	dbName := ""
+	if len(pathParts) > 0 && addr != "" {
+		dbName = pathParts[len(pathParts)-1]
+	} else {
+		return nil, errors.New("unable to decypher database name from: " + addr)
+	}
+	dsn := strings.TrimSuffix(addr, dbName)
+
+	client, err := kivik.New(ctx, driver, dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	if create {
+		err := client.CreateDB(ctx, dbName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	db, err := client.DB(ctx, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DB{
+		db:     db,
+		colls:  make(map[string]collection),
+		driver: driver,
+	}, nil
+}
+
+func Create(addr string, opt graph.Options) (nosql.Database, error) {
+	return dialDB(true, addr, opt)
+}
+
+func Open(addr string, opt graph.Options) (nosql.Database, error) {
+	return dialDB(false, addr, opt)
+}
+
+type collection struct {
+	primary   nosql.Index
+	secondary []nosql.Index
+}
+
+type DB struct {
+	db     *kivik.DB
+	colls  map[string]collection
+	driver string
+}
+
+func (db *DB) Close() error {
+	// seems no way to close a kivik session, so just let the Go garbage collection do its stuff...
+	return nil
+}
+
+const (
+	collectionIndex   = "collection-index"
+	secondaryIndexFmt = "%s-secondary-%d"
+)
+
+func (db *DB) EnsureIndex(ctx context.Context, col string, primary nosql.Index, secondary []nosql.Index) error {
+
+	if primary.Type != nosql.StringExact {
+		return fmt.Errorf("unsupported type of primary index: %v", primary.Type)
+	}
+
+	db.colls[col] = collection{
+		primary:   primary,
+		secondary: secondary,
+	}
+
+	if err := db.db.CreateIndex(ctx, collectionIndex, collectionIndex,
+		map[string]interface{}{
+			"fields": []string{collectionField}, //  collection field only, default index
+		}); err != nil {
+		return err
+	}
+
+	// NOTE the field of the primary index is always "_id", so need not create an index
+
+	for k, v := range db.colls[col].secondary {
+		snam := fmt.Sprintf(secondaryIndexFmt, col, k)
+		sindex := map[string]interface{}{
+			"fields": v.Fields,
+		}
+		if err := db.db.CreateIndex(ctx, snam, snam, sindex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+const (
+	idField         = "_id"
+	revField        = "_rev"
+	collectionField = "Collection"
+)
+
+func compKey(col string, key nosql.Key) string {
+	return "K" + strings.Join(key, "|")
+}
+
+func (db *DB) Insert(ctx context.Context, col string, key nosql.Key, d nosql.Document) (nosql.Key, error) {
+	k, _, e := db.insert(ctx, col, key, d)
+	return k, e
+}
+func (db *DB) insert(ctx context.Context, col string, key nosql.Key, d nosql.Document) (nosql.Key, string, error) {
+
+	if d == nil {
+		return nil, "", errors.New("no document to insert")
+	}
+
+	rev := ""
+	if key == nil {
+		key = nosql.GenKey()
+	} else {
+		var err error
+		var id string
+		_, id, rev, err = db.findByKey(ctx, col, key)
+		if err == nil {
+			rev, err = db.db.Delete(ctx, id, rev) // delete it to be sure it is removed
+			if err != nil {
+				return nil, "", err
+			}
+		}
+	}
+
+	if cP, found := db.colls[col]; found {
+		// go through the key list an put each in
+		if len(cP.primary.Fields) == len(key) {
+			for idx, nam := range cP.primary.Fields {
+				d[nam] = nosql.String(key[idx]) // just replace with the given key, even if there already
+			}
+		}
+	}
+
+	interfaceDoc := toOuchDoc(col, toOuchValue(idField, key.Value()).(string), rev, d)
+
+	_, rev, err := db.db.CreateDoc(ctx, interfaceDoc)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return key, rev, nil
+}
+
+func (db *DB) FindByKey(ctx context.Context, col string, key nosql.Key) (nosql.Document, error) {
+	decoded, _, _, err := db.findByKey(ctx, col, key)
+	return decoded, err
+}
+
+func (db *DB) findByKey(ctx context.Context, col string, key nosql.Key) (nosql.Document, string, string, error) {
+	cK := compKey(col, key)
+	return db.findByOuchKey(ctx, cK)
+}
+
+func (db *DB) findByOuchKey(ctx context.Context, cK string) (nosql.Document, string, string, error) {
+
+	row, err := db.db.Get(ctx, cK)
+	if err != nil {
+		if kivik.StatusCode(err) == kivik.StatusNotFound {
+			return nil, "", "", nosql.ErrNotFound
+		}
+		return nil, "", "", err
+	}
+
+	rowDoc := make(map[string]interface{})
+	err = row.ScanDoc(&rowDoc)
+	if err != nil {
+		return nil, "", "", err
+	}
+	decoded := fromOuchDoc(rowDoc)
+
+	return decoded, rowDoc[idField].(string), rowDoc[revField].(string), nil
+}
+
+func (db *DB) Query(col string) nosql.Query {
+	qry := &Query{
+		db:          db,
+		col:         col,
+		pathFilters: make(map[string][]nosql.FieldFilter),
+		ouchQuery: map[string]interface{}{
+			"selector": map[string]interface{}{},
+			"limit":    1000000, // million row limit, default is 25 TODO is 1M enough?
+		},
+	}
+	if col != "" {
+		qry.ouchQuery["selector"].(map[string]interface{})[collectionField] = col
+	}
+	return qry
+}
+func (db *DB) Update(col string, key nosql.Key) nosql.Update {
+	return &Update{db: db, col: col, key: key, update: nosql.Document{}}
+}
+func (db *DB) Delete(col string) nosql.Delete {
+	return &Delete{db: db, col: col, q: db.Query(col).(*Query)}
+}
+
+type ouchQuery map[string]interface{}
+
+type Query struct {
+	db          *DB
+	col         string
+	pathFilters map[string][]nosql.FieldFilter
+	ouchQuery
+}
+
+func (q *Query) WithFields(filters ...nosql.FieldFilter) nosql.Query {
+	for _, filter := range filters {
+		j := strings.Join(filter.Path, keySeparator)
+		q.pathFilters[j] = append(q.pathFilters[j], filter)
+	}
+
+	return q
+}
+
+func (q *Query) buildFilters() nosql.Query {
+	for jp, filterList := range q.pathFilters {
+		term := map[string]interface{}{}
+		for _, filter := range filterList {
+			test := ""
+			testValue := toOuchValue(".", filter.Value)
+			if stringValue, isString := testValue.(string); isString && len(stringValue) > 0 {
+				typeChar := stringValue[0]
+				typeCharNext := typeChar + 1
+				switch filter.Filter {
+				case nosql.Equal, nosql.NotEqual:
+				// nothing to do as not a relative test
+				case nosql.LT, nosql.LTE:
+					term["$gte"] = string(typeChar) // set the lower bound
+				case nosql.GT, nosql.GTE:
+					term["$lt"] = string(typeCharNext) // set the upper bound
+				default:
+					// panic in the switch below
+				}
+			}
+			switch filter.Filter {
+			case nosql.Equal:
+				test = "$eq"
+			case nosql.NotEqual:
+				if boolVal, isBool := testValue.(bool); isBool && boolVal && runtime.GOARCH != "js" {
+					// Swap the logic of the test, which is required to make it work for missing values in CouchDB.
+					// Sadly, this same formulation does not work for PouchDB, as that does not allow $or.
+					test = "$or"
+					testValue = []interface{}{
+						map[string]interface{}{"$eq": false},     // it was $ne true
+						map[string]interface{}{"$exists": false}, // non-existence => false
+					}
+				} else {
+					test = "$ne"
+				}
+			case nosql.GT:
+				test = "$gt"
+			case nosql.GTE:
+				test = "$gte"
+			case nosql.LT:
+				test = "$lt"
+			case nosql.LTE:
+				test = "$lte"
+			default:
+				msg := fmt.Sprintf("unknown nosqlFilter %v", filter.Filter)
+				fmt.Println(msg)
+				panic(msg)
+			}
+			term[test] = testValue
+		}
+		q.ouchQuery["selector"].(map[string]interface{})[jp] = term
+	}
+
+	if len(q.pathFilters) == 0 {
+		q.ouchQuery["use_index"] = collectionIndex
+	} else {
+		// NOTE primary is redundant, as the same as the _id
+		c, haveCol := q.db.colls[q.col]
+		if haveCol {
+			for si, sv := range c.secondary {
+				useSecondary := true
+				for _, fieldName := range sv.Fields {
+					if _, found := q.pathFilters[fieldName]; !found {
+						useSecondary = false
+					}
+				}
+				if useSecondary {
+					q.ouchQuery["use_index"] = fmt.Sprintf(secondaryIndexFmt, q.col, si)
+					break
+				}
+			}
+		}
+	}
+
+	return q
+}
+
+func (q *Query) Limit(n int) nosql.Query {
+	q.ouchQuery["limit"] = n
+	return q
+}
+
+func (q *Query) Count(ctx context.Context) (int64, error) {
+	// TODO it shoud be possible to use map/reduce logic, rather than a mango query, to speed this up, at least for some cases
+
+	// don't pull back any fields in the query, to reduce bandwidth
+	q.ouchQuery["fields"] = []interface{}{}
+
+	it := q.Iterate().(*Iterator)
+	//defer it.Close() // closed automatically at the last Next()
+	var count int64
+	for it.rows.Next() { // for speed, use the native Next
+		count++
+	}
+	return count, it.err
+}
+
+func (q *Query) One(ctx context.Context) (nosql.Document, error) {
+	it := q.Iterate()
+	defer it.Close()
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+	if it.Next(ctx) {
+		return it.Doc(), it.(*Iterator).err
+	}
+	return nil, nosql.ErrNotFound
+}
+
+func (q *Query) Iterate() nosql.DocIterator {
+	ctx := context.TODO() // TODO - replace with parameter value
+	q.buildFilters()
+
+	// NOTE: to see that the query actually is using an index, uncomment the lines below
+	// queryPlan, err := q.db.db.Explain(ctx, q.ouchQuery)
+	// debug := fmt.Sprintf("DEBUG %v QueryPlan: %#v", err, queryPlan)
+	// if strings.Contains(debug, collectionIndex) { // put the index you're interested in here
+	// 	fmt.Println(debug)
+	// }
+
+	rows, err := q.db.db.Find(ctx, q.ouchQuery)
+	return &Iterator{rows: rows, err: err}
+}
+
+type Iterator struct {
+	err     error
+	rows    *kivik.Rows
+	doc     map[string]interface{}
+	hadNext bool
+	closed  bool
+}
+
+func (it *Iterator) Next(ctx context.Context) bool {
+	it.hadNext = true
+	if it.err != nil || it.closed {
+		return false
+	}
+	it.doc = nil
+	haveNext := it.rows.Next()
+	it.err = it.rows.Err()
+	if it.err != nil {
+		return false
+	}
+	if haveNext {
+		it.scanDoc()
+		if it.err != nil {
+			return false
+		}
+	} else {
+		it.closed = true // auto-closed at end of iteration by API
+	}
+	return haveNext
+}
+
+func (it *Iterator) Err() error {
+	return it.err
+}
+
+func (it *Iterator) Close() error {
+	if it.err == nil && !it.closed {
+		it.err = it.rows.Close()
+	}
+	it.closed = true
+	return it.err
+}
+
+func (it *Iterator) Key() nosql.Key {
+	if it.err != nil || it.closed {
+		return nil
+	}
+	if !it.hadNext {
+		it.err = errors.New("call to Iterator.Key before Iterator.Next")
+		return nil
+	}
+
+	id, haveID := it.doc[idField].(string)
+	if !haveID {
+		it.err = fmt.Errorf("Iterator.Key ID empty")
+		return nil
+	}
+	ret := nosql.Key([]string(fromOuchValue("?", id).(nosql.Strings)))
+	return ret
+}
+
+func (it *Iterator) Doc() nosql.Document {
+	if it.err != nil || it.closed {
+		return nil
+	}
+	if !it.hadNext {
+		it.err = errors.New("Iterator.Doc called before Iterator.Next")
+		return nil
+	}
+	return fromOuchDoc(it.doc)
+}
+
+func (it *Iterator) scanDoc() {
+	if it.doc == nil && it.err == nil && !it.closed {
+		it.doc = map[string]interface{}{}
+		it.err = it.rows.ScanDoc(&it.doc)
+	}
+}
+
+type Delete struct {
+	db   *DB
+	col  string
+	q    *Query
+	keys []interface{}
+}
+
+func (d *Delete) WithFields(filters ...nosql.FieldFilter) nosql.Delete {
+	d.q.WithFields(filters...)
+	return d
+}
+func (d *Delete) Keys(keys ...nosql.Key) nosql.Delete {
+	for _, k := range keys {
+		id := toOuchValue("?", k.Value()).(string)
+		d.keys = append(d.keys, id)
+	}
+	return d
+}
+func (d *Delete) Do(ctx context.Context) error {
+
+	deleteSet := make(map[string]string) // [_id]_rev
+
+	switch len(d.keys) {
+	case 0:
+	// no keys to test against
+	case 1:
+		if len(d.q.pathFilters) == 0 {
+			// this special case is optimised not to use the query/iterate route at all,
+			// but rather to fetch the _id and _rev directly from the given key.
+			_, id, rev, err := d.db.findByOuchKey(ctx, d.keys[0].(string))
+			if err != nil {
+				return err
+			}
+			deleteSet[id] = rev
+		} else {
+			d.q.ouchQuery["selector"].(map[string]interface{})[idField] = map[string]interface{}{"$eq": d.keys[0]}
+		}
+
+	default:
+		d.q.ouchQuery["selector"].(map[string]interface{})[idField] = map[string]interface{}{"$in": d.keys}
+	}
+
+	// NOTE even when using idField in a Mango query, it still has to base its query on an index
+
+	if len(deleteSet) == 0 { // did not hit the special case, so must do a mango query
+
+		// only pull back the _id & _rev fields in the query
+		d.q.ouchQuery["fields"] = []interface{}{idField, revField}
+
+		it := d.q.Iterate().(*Iterator)
+		if it.Err() != nil {
+			return it.Err()
+		}
+
+		for it.Next(ctx) {
+			id := it.doc[idField].(string)
+			rev := it.doc[revField].(string)
+			deleteSet[id] = rev
+		}
+		if it.err != nil {
+			return it.err
+		}
+		if err := it.Close(); err != nil {
+			return err
+		}
+	}
+
+	for id, rev := range deleteSet {
+		_, err := d.db.db.Delete(ctx, id, rev)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type Update struct {
+	db     *DB
+	col    string
+	key    nosql.Key
+	update nosql.Document
+	upsert bool
+	inc    map[string]int // increment the named numeric field by the int
+}
+
+func (u *Update) Inc(field string, dn int) nosql.Update {
+	if u.inc == nil {
+		u.inc = make(map[string]int)
+	}
+	u.inc[field] += dn
+	return u
+}
+
+func (u *Update) Upsert(d nosql.Document) nosql.Update {
+	u.upsert = true
+	for k, v := range d {
+		u.update[k] = v
+	}
+	return u
+}
+func (u *Update) Do(ctx context.Context) error {
+	orig, id, rev, err := u.db.findByKey(ctx, u.col, u.key)
+	if err == nosql.ErrNotFound {
+		if !u.upsert {
+			return err
+		}
+		var idKey nosql.Key
+		orig = u.update
+		idKey, rev, err = u.db.insert(ctx, u.col, u.key, orig)
+		if err != nil {
+			return err
+		}
+		id = toOuchValue(idField, idKey.Value()).(string)
+	} else {
+		if err != nil {
+			return err
+		}
+		for k, v := range u.update { // alter any changed fields
+			orig[k] = v
+		}
+	}
+
+	for k, v := range u.inc { // increment numerical values
+		val, exists := orig[k]
+		if exists {
+			switch x := val.(type) {
+			case nosql.Int:
+				val = nosql.Int(int64(x) + int64(v))
+			case nosql.Float:
+				val = nosql.Float(float64(x) + float64(v))
+			default:
+				return errors.New("field '" + k + "' is not a number")
+			}
+		} else {
+			val = nosql.Int(v)
+		}
+		orig[k] = val
+	}
+
+	_, err = u.db.db.Put(ctx, compKey(u.col, u.key), toOuchDoc(u.col, id, rev, orig))
+	return err
+}

--- a/graph/nosql/ouch/ouch.go
+++ b/graph/nosql/ouch/ouch.go
@@ -16,11 +16,16 @@ import (
 
 const Type = driverName
 
+var nosqlOptions = nosql.Options{
+	Number32: true,
+}
+
 func init() {
 	nosql.Register(Type, nosql.Registration{
 		NewFunc:      Open,
 		InitFunc:     Create,
 		IsPersistent: true,
+		Options:      nosqlOptions,
 	})
 }
 

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -40,7 +40,6 @@ func TestIntStr(t *testing.T) {
 
 func TestOuchAll(t *testing.T) {
 	nosqltest.TestAll(t, makeOuch, &nosqltest.Config{
-		TimeInMs:   false,
-		FloatToInt: false,
+		IntToFloat: true,
 	})
 }

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/nosql"
 	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
+	"github.com/stretchr/testify/require"
 )
 
 func makeOuch(t testing.TB) (nosql.Database, graph.Options, func()) {
@@ -41,5 +42,21 @@ func TestIntStr(t *testing.T) {
 func TestOuchAll(t *testing.T) {
 	nosqltest.TestAll(t, makeOuch, &nosqltest.Config{
 		IntToFloat: true,
+		PageSize:   25,
 	})
+}
+
+func TestSelector(t *testing.T) {
+	q := ouchQuery{"selector": make(map[string]interface{})}
+	in := []interface{}{"a", "b"}
+	q.putSelector(idField, map[string]interface{}{"$in": in})
+	q.putSelector(idField, map[string]interface{}{"$gt": "a"})
+	require.Equal(t, ouchQuery{
+		"selector": map[string]interface{}{
+			idField: map[string]interface{}{
+				"$in": in,
+				"$gt": "a",
+			},
+		},
+	}, q)
 }

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -1,0 +1,122 @@
+package ouch
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
+	"github.com/go-kivik/kivik"
+)
+
+const remote = "http://testusername:testpassword@127.0.0.1:5984/ouchtest"
+
+var dbId int // PouchDB requires a different DB name each time, or it uses cached data!
+
+func makeOuch(t testing.TB) (nosql.Database, graph.Options, func()) {
+	var testDBname, homeDir, dir string
+	var err error
+
+	switch defaultDriverName {
+	case "pouch":
+		// TODO add remote db access tests
+		testDBname = fmt.Sprintf("pouchdb%d.test", dbId) // see dbId comment
+		dbId++
+
+	case "couch":
+		testDBname = remote
+
+	default:
+		panic("bad defaultDriverName: " + defaultDriverName)
+
+	}
+
+	ctx := context.TODO()
+	if runtime.GOARCH == "js" && testDBname != remote {
+
+		homeDir, err = os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dir, err = ioutil.TempDir("", "pouch-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil { // in js, run the tests from the temp dir
+			t.Fatal(err)
+		}
+
+		// just check the dir is empty
+		fi, err := ioutil.ReadDir(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, thisFile := range fi {
+			fn := thisFile.Name()
+			if strings.HasPrefix(fn, "pouchdb") && strings.Contains(fn, ".test") {
+				dbDir := thisFile.Name()
+				if err := os.RemoveAll(dbDir); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+	} else {
+		client, err := kivik.New(ctx, defaultDriverName, testDBname)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.DestroyDB(ctx, testDBname)
+		if err != nil {
+			t.Log(err)
+		}
+	}
+
+	qs, err := dialDB(true, testDBname, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return qs, nil, func() {
+		qs.Close()
+		if runtime.GOARCH == "js" && testDBname != remote {
+			if err := os.RemoveAll(dir); err != nil { // remove the test data
+				t.Fatal(err)
+			}
+			if err := os.Chdir(homeDir); err != nil { // go back where we came from
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestIntStr(t *testing.T) {
+	testI := []int64{120000, -4, 88, 0, -7000000, 88, math.MaxInt64, math.MinInt64}
+	testS := []string{}
+	for _, v := range testI {
+		testS = append(testS, itos(v))
+	}
+	sort.Strings(testS)
+	sort.Slice(testI, func(i, j int) bool { return testI[i] < testI[j] })
+	for k, v := range testS {
+		r := stoi(v)
+		if r != testI[k] {
+			t.Errorf("Sorting of stringed int64s wrong: %v %v %v", k, r, testI[k])
+		}
+	}
+}
+
+func TestOuchAll(t *testing.T) {
+	nosqltest.TestAll(t, makeOuch, &nosqltest.Config{
+		TimeInMs:   false,
+		FloatToInt: false,
+	})
+}

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -1,100 +1,24 @@
 package ouch
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
 	"math"
-	"os"
-	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/nosql"
 	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
-	"github.com/go-kivik/kivik"
 )
 
-const remote = "http://testusername:testpassword@127.0.0.1:5984/ouchtest"
-
-var dbId int // PouchDB requires a different DB name each time, or it uses cached data!
-
 func makeOuch(t testing.TB) (nosql.Database, graph.Options, func()) {
-	var testDBname, homeDir, dir string
-	var err error
-
-	switch defaultDriverName {
-	case "pouch":
-		// TODO add remote db access tests
-		testDBname = fmt.Sprintf("pouchdb%d.test", dbId) // see dbId comment
-		dbId++
-
-	case "couch":
-		testDBname = remote
-
+	switch driverName {
 	default:
-		panic("bad defaultDriverName: " + defaultDriverName)
-
-	}
-
-	ctx := context.TODO()
-	if runtime.GOARCH == "js" && testDBname != remote {
-
-		homeDir, err = os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		dir, err = ioutil.TempDir("", "pouch-")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(dir); err != nil { // in js, run the tests from the temp dir
-			t.Fatal(err)
-		}
-
-		// just check the dir is empty
-		fi, err := ioutil.ReadDir(".")
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, thisFile := range fi {
-			fn := thisFile.Name()
-			if strings.HasPrefix(fn, "pouchdb") && strings.Contains(fn, ".test") {
-				dbDir := thisFile.Name()
-				if err := os.RemoveAll(dbDir); err != nil {
-					t.Fatal(err)
-				}
-			}
-		}
-	} else {
-		client, err := kivik.New(ctx, defaultDriverName, testDBname)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = client.DestroyDB(ctx, testDBname)
-		if err != nil {
-			t.Log(err)
-		}
-	}
-
-	qs, err := dialDB(true, testDBname, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return qs, nil, func() {
-		qs.Close()
-		if runtime.GOARCH == "js" && testDBname != remote {
-			if err := os.RemoveAll(dir); err != nil { // remove the test data
-				t.Fatal(err)
-			}
-			if err := os.Chdir(homeDir); err != nil { // go back where we came from
-				t.Fatal(err)
-			}
-		}
+		t.Fatal("unknown driverName: ", driverName)
+		return nil, nil, nil
+	case "couch":
+		return makeCouchDB(t)
+	case "pouch":
+		return makePouchDB(t)
 	}
 }
 

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -1,8 +1,6 @@
 package ouch
 
 import (
-	"math"
-	"sort"
 	"testing"
 
 	"github.com/cayleygraph/cayley/graph"
@@ -11,31 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeOuch(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeOuch(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	switch driverName {
 	default:
 		t.Fatal("unknown driverName: ", driverName)
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	case "couch":
 		return makeCouchDB(t)
 	case "pouch":
 		return makePouchDB(t)
-	}
-}
-
-func TestIntStr(t *testing.T) {
-	testI := []int64{120000, -4, 88, 0, -7000000, 88, math.MaxInt64, math.MinInt64}
-	testS := []string{}
-	for _, v := range testI {
-		testS = append(testS, itos(v))
-	}
-	sort.Strings(testS)
-	sort.Slice(testI, func(i, j int) bool { return testI[i] < testI[j] })
-	for k, v := range testS {
-		r := stoi(v)
-		if r != testI[k] {
-			t.Errorf("Sorting of stringed int64s wrong: %v %v %v", k, r, testI[k])
-		}
 	}
 }
 

--- a/graph/nosql/ouch/pouch.go
+++ b/graph/nosql/ouch/pouch.go
@@ -6,4 +6,4 @@ import (
 	_ "github.com/go-kivik/pouchdb" // The PouchDB driver
 )
 
-var defaultDriverName = "pouch"
+const driverName = "pouch"

--- a/graph/nosql/ouch/pouch_test.go
+++ b/graph/nosql/ouch/pouch_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/go-kivik/kivik"
 )
 
-func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makeCouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	t.SkipNow()
-	return nil, nil, nil
+	return nil, nil, nil, nil
 }
 
-func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+func makePouchDB(t testing.TB) (nosql.Database, *nosql.Options, graph.Options, func()) {
 	if runtime.GOARCH != "js" {
 		panic("not js")
 	}
@@ -39,7 +39,7 @@ func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
 		t.Fatal(err)
 	}
 
-	return qs, nil, func() {
+	return qs, &nosqlOptions, nil, func() {
 		qs.Close()
 		ctx := context.TODO()
 		if c, err := kivik.New(ctx, driverName, dir); err == nil {

--- a/graph/nosql/ouch/pouch_test.go
+++ b/graph/nosql/ouch/pouch_test.go
@@ -1,0 +1,52 @@
+// +build js
+
+package ouch
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/go-kivik/kivik"
+)
+
+func makeCouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	t.SkipNow()
+	return nil, nil, nil
+}
+
+func makePouchDB(t testing.TB) (nosql.Database, graph.Options, func()) {
+	if runtime.GOARCH != "js" {
+		panic("not js")
+	}
+
+	dir, err := ioutil.TempDir("", "pouch-")
+	if err != nil {
+		t.Fatal("failed to make temp dir:", err)
+	}
+
+	name := fmt.Sprintf("cayley-%d", rand.Int())
+
+	qs, err := dialDB(false, dir+"/"+name, nil)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+
+	return qs, nil, func() {
+		qs.Close()
+		ctx := context.TODO()
+		if c, err := kivik.New(ctx, driverName, dir); err == nil {
+			_ = c.DestroyDB(ctx, name)
+		}
+		if err := os.RemoveAll(dir); err != nil { // remove the test data
+			t.Fatal(err)
+		}
+	}
+}

--- a/graph/nosql/ouch/values.go
+++ b/graph/nosql/ouch/values.go
@@ -35,7 +35,7 @@ func stoi(s string) int64 {
 }
 
 // toOuchValue serializes nosql.Value -> native json values.
-func toOuchValue(k string, v nosql.Value) interface{} {
+func toOuchValue(v nosql.Value) interface{} {
 	switch v := v.(type) {
 	case nil:
 		return nil
@@ -81,10 +81,10 @@ func toOuchDoc(col, id, rev string, d nosql.Document) map[string]interface{} {
 		if subDoc, found := v.(nosql.Document); found {
 			for subK, subV := range subDoc {
 				subPath := k + keySeparator + subK
-				m[subPath] = toOuchValue(subPath, subV)
+				m[subPath] = toOuchValue(subV)
 			}
 		} else {
-			m[k] = toOuchValue(k, v)
+			m[k] = toOuchValue(v)
 		}
 	}
 

--- a/graph/nosql/ouch/values.go
+++ b/graph/nosql/ouch/values.go
@@ -1,0 +1,180 @@
+package ouch
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cayleygraph/cayley/graph/nosql"
+)
+
+const (
+	int64Adjust  = 1 << 63
+	keySeparator = "|"
+	timeFormat   = time.RFC3339Nano // seconds resolution only without Nano
+)
+
+// itos serializes int64 into a sortable string 13 chars long.
+// NOTE: in JS there are no native 64bit integers.
+func itos(i int64) string {
+	s := strconv.FormatUint(uint64(i)+int64Adjust, 32)
+	const z = "0000000000000"
+	return z[len(s):] + s
+}
+
+// stoi de-serializes int64 from a sortable string 13 chars long.
+func stoi(s string) int64 {
+	ret, err := strconv.ParseUint(s, 32, 64)
+	if err != nil {
+		//TODO handle error?
+		return 0
+	}
+	return int64(ret - int64Adjust)
+}
+
+// toOuchValue serializes nosql.Value -> native json values.
+func toOuchValue(k string, v nosql.Value) interface{} {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case nosql.Strings: // special handling here, as type can't be inferred from json
+		return "K" + strings.Join(v, keySeparator)
+	case nosql.String:
+		return "S" + string(v) // need leading "S"
+	case nosql.Int: // special handling here, as type can't be inferred from json
+		return "I" + itos(int64(v))
+	case nosql.Float:
+		return float64(v)
+	case nosql.Bool:
+		return bool(v)
+	case nosql.Time: // special handling here, as type can't be inferred from json
+		ret := "T" + time.Time(v).UTC().Format(timeFormat)
+		return ret
+	case nosql.Bytes: // special handling here, as type can't be inferred from json
+		return "B" + base64.StdEncoding.EncodeToString(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func toOuchDoc(col, id, rev string, d nosql.Document) map[string]interface{} {
+	if d == nil {
+		return nil
+	}
+	m := make(map[string]interface{})
+	if col != "" {
+		m[collectionField] = col
+	}
+	if id != "" {
+		m[idField] = id
+	}
+	if rev != "" {
+		m[revField] = rev
+	}
+
+	for k, v := range d {
+		if len(k) == 0 {
+			continue
+		}
+		if subDoc, found := v.(nosql.Document); found {
+			for subK, subV := range subDoc {
+				subPath := k + keySeparator + subK
+				m[subPath] = toOuchValue(subPath, subV)
+			}
+		} else {
+			m[k] = toOuchValue(k, v)
+		}
+	}
+
+	return m
+}
+
+func fromOuchValue(k string, v interface{}) nosql.Value {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case string:
+		if len(v) == 0 {
+			return nil
+		}
+		typ := v[0]
+		v = v[1:]
+		switch typ {
+		case 'S':
+			return nosql.String(v)
+
+		case 'K':
+			parts := strings.Split(v, keySeparator)
+			key := make(nosql.Key, 0, len(parts))
+			for _, part := range parts {
+				key = append(key, part)
+			}
+			return key.Value()
+
+		case 'B':
+			byts, err := base64.StdEncoding.DecodeString(v)
+			if err != nil {
+				// TODO consider how to handle this error properly
+				return nosql.Bytes(nil)
+			}
+			return nosql.Bytes(byts)
+
+		case 'T':
+			var time0 nosql.Time
+			tim, err := time.Parse(timeFormat, v)
+			if err != nil {
+				// TODO consider how to handle this error properly
+				fmt.Println("DEBUG Time parse", tim, err)
+				return time0
+			}
+			return nosql.Time(tim)
+
+		case 'I':
+			return nosql.Int(stoi(v))
+
+		default:
+			panic(fmt.Errorf("unsupported serialized type: %v%v", typ, v))
+		}
+	case float64:
+		return nosql.Float(v)
+	case bool:
+		return nosql.Bool(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func fromOuchDoc(d map[string]interface{}) nosql.Document {
+	if d == nil {
+		return nil
+	}
+	m := make(nosql.Document, len(d))
+	for k, v := range d {
+		switch k {
+		case "", idField, revField, collectionField:
+			continue // don't pass these fields back to nosql
+		}
+		if k[0] != ' ' { // ignore any other ouch driver internal keys
+			if path := strings.Split(k, keySeparator); len(path) > 1 {
+				if len(path) != 2 {
+					panic("nosql.Document nesting too deep")
+				}
+				// we have a sub-document
+				if _, found := m[path[0]]; !found {
+					m[path[0]] = make(nosql.Document)
+				}
+				m[path[0]].(nosql.Document)[path[1]] = fromOuchValue(k, v)
+			} else {
+				m[k] = fromOuchValue(k, v)
+			}
+		}
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
+	return m
+}

--- a/graph/nosql/ouch/values.go
+++ b/graph/nosql/ouch/values.go
@@ -3,7 +3,6 @@ package ouch
 import (
 	"encoding/base64"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -11,27 +10,8 @@ import (
 )
 
 const (
-	int64Adjust  = 1 << 63
 	keySeparator = "|"
 )
-
-// itos serializes int64 into a sortable string 13 chars long.
-// NOTE: in JS there are no native 64bit integers.
-func itos(i int64) string {
-	s := strconv.FormatUint(uint64(i)+int64Adjust, 32)
-	const z = "0000000000000"
-	return z[len(s):] + s
-}
-
-// stoi de-serializes int64 from a sortable string 13 chars long.
-func stoi(s string) int64 {
-	ret, err := strconv.ParseUint(s, 32, 64)
-	if err != nil {
-		//TODO handle error?
-		return 0
-	}
-	return int64(ret - int64Adjust)
-}
 
 // toOuchValue serializes nosql.Value -> native json values.
 func toOuchValue(v nosql.Value) interface{} {

--- a/graph/nosql/value_test.go
+++ b/graph/nosql/value_test.go
@@ -1,6 +1,8 @@
 package nosql
 
 import (
+	"math"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,5 +38,25 @@ var filterMatch = []struct {
 func TestFilterMatch(t *testing.T) {
 	for _, c := range filterMatch {
 		require.Equal(t, c.exp, c.f.Matches(c.d))
+	}
+}
+
+func TestIntStr(t *testing.T) {
+	var testS []string
+	testI := []int64{
+		120000, -4, 88, 0, -7000000, 88,
+		math.MaxInt64 - 1, math.MaxInt64,
+		math.MinInt64, math.MinInt64 + 1,
+	}
+	for _, v := range testI {
+		testS = append(testS, itos(v))
+	}
+	sort.Strings(testS)
+	sort.Slice(testI, func(i, j int) bool { return testI[i] < testI[j] })
+	for k, v := range testS {
+		r := stoi(v)
+		if r != testI[k] {
+			t.Errorf("Sorting of stringed int64s wrong: %v %v %v", k, r, testI[k])
+		}
 	}
 }

--- a/graph/sql/cockroach/cockroach_test.go
+++ b/graph/sql/cockroach/cockroach_test.go
@@ -18,15 +18,15 @@ func makeCockroach(t testing.TB) (string, graph.Options, func()) {
 	conf.Image = "cockroachdb/cockroach:v1.1.2"
 	conf.Cmd = []string{"start", "--insecure"}
 
-	addr, closer := dock.RunAndWait(t, conf, func(addr string) bool {
-		conn, err := pq.Open(`postgresql://root@` + addr + `:26257?sslmode=disable`)
+	addr, closer := dock.RunAndWait(t, conf, "26257", func(addr string) bool {
+		conn, err := pq.Open(`postgresql://root@` + addr + `?sslmode=disable`)
 		if err != nil {
 			return false
 		}
 		conn.Close()
 		return true
 	})
-	addr = `postgresql://root@` + addr + `:26257`
+	addr = `postgresql://root@` + addr
 	db, err := sql.Open(driverName, addr+`?sslmode=disable`)
 	if err != nil {
 		closer()

--- a/graph/sql/mysql/mysql_test.go
+++ b/graph/sql/mysql/mysql_test.go
@@ -21,8 +21,8 @@ func makeMysqlVersion(image string) sqltest.DatabaseFunc {
 			`MYSQL_DATABASE=testdb`,
 		}
 
-		addr, closer := dock.RunAndWait(t, conf, dock.WaitPort("3306"))
-		addr = `root:root@tcp(` + addr + `:3306)/testdb`
+		addr, closer := dock.RunAndWait(t, conf, "3306", nil)
+		addr = `root:root@tcp(` + addr + `)/testdb`
 		return addr, nil, func() {
 			closer()
 		}

--- a/graph/sql/postgres/postgres_test.go
+++ b/graph/sql/postgres/postgres_test.go
@@ -19,7 +19,7 @@ func makePostgres(t testing.TB) (string, graph.Options, func()) {
 	conf.Tty = true
 	conf.Env = []string{`POSTGRES_PASSWORD=postgres`}
 
-	addr, closer := dock.RunAndWait(t, conf, func(addr string) bool {
+	addr, closer := dock.RunAndWait(t, conf, "5432", func(addr string) bool {
 		conn, err := pq.Open(`postgres://postgres:postgres@` + addr + `/postgres?sslmode=disable`)
 		if err != nil {
 			return false

--- a/internal/dock/dock.go
+++ b/internal/dock/dock.go
@@ -3,7 +3,11 @@
 package dock
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,10 +20,14 @@ var (
 
 type Config struct {
 	docker.Config
+}
+
+type fullConfig struct {
+	docker.Config
 	docker.HostConfig
 }
 
-func Run(t testing.TB, conf Config) (addr string, closer func()) {
+func run(t testing.TB, conf fullConfig) (addr string, closer func()) {
 	if testing.Short() {
 		t.SkipNow()
 	}
@@ -56,8 +64,49 @@ func Run(t testing.TB, conf Config) (addr string, closer func()) {
 	return
 }
 
-func RunAndWait(t testing.TB, conf Config, check func(string) bool) (addr string, closer func()) {
-	addr, closer = Run(t, conf)
+func randPort() int {
+	const (
+		min = 10000
+		max = 30000
+	)
+	for {
+		port := min + rand.Intn(max-min)
+		c, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", localhost, port), time.Second)
+		if c != nil {
+			c.Close()
+		}
+		if err != nil {
+			// TODO: check for a specific error
+			return port
+		}
+	}
+}
+
+const localhost = "127.0.0.1"
+
+func RunAndWait(t testing.TB, conf Config, port string, check func(string) bool) (addr string, closer func()) {
+	fconf := fullConfig{Config: conf.Config}
+	if runtime.GOOS != "linux" {
+		lport := strconv.Itoa(randPort())
+		// nothing except Linux runs Docker natively,
+		// so we randomize the port and expose it on Docker VM
+		fconf.PortBindings = map[docker.Port][]docker.PortBinding{
+			docker.Port(port + "/tcp"): {{
+				HostIP:   localhost,
+				HostPort: lport,
+			}},
+		}
+		port = lport
+	}
+	addr, closer = run(t, fconf)
+	if runtime.GOOS != "linux" {
+		// VM ports are automatically exposed on localhost
+		addr = localhost
+	}
+	addr += ":" + port
+	if check == nil {
+		check = waitPort
+	}
 	ok := false
 	for i := 0; i < 10 && !ok; i++ {
 		ok = check(addr)
@@ -72,16 +121,15 @@ func RunAndWait(t testing.TB, conf Config, check func(string) bool) (addr string
 	return addr, closer
 }
 
-func WaitPort(port string) func(addr string) bool {
-	const wait = time.Second * 5
-	return func(addr string) bool {
-		start := time.Now()
-		c, err := net.DialTimeout("tcp", addr+":"+port, wait)
-		if err == nil {
-			c.Close()
-		} else if dt := time.Since(start); dt < wait {
-			time.Sleep(wait - dt)
-		}
-		return err == nil
+const wait = time.Second * 5
+
+func waitPort(addr string) bool {
+	start := time.Now()
+	c, err := net.DialTimeout("tcp", addr, wait)
+	if err == nil {
+		c.Close()
+	} else if dt := time.Since(start); dt < wait {
+		time.Sleep(wait - dt)
 	}
+	return err == nil
 }


### PR DESCRIPTION
Implement CouchDB and PouchDB backends based on NoSQL meta-backend.

CouchDB backend will work on Go side, while PouchDB can be used with GopherJS which adds a possibility to run Cayley in browser.

Resolves #655 