### PR TITLE
Optimise CockroachDB backend

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -71,7 +71,7 @@ Which will also resolve the relevant static content paths for serving HTTP.
 
 # Running Unit Tests
 
-First, `cd` into the `caley` project folder.
+First, `cd` into the `cayley` project folder.
 
 For Go 1.9 and onwards:
 ```

--- a/graph/sql/cockroach/cockroach_test.go
+++ b/graph/sql/cockroach/cockroach_test.go
@@ -15,7 +15,7 @@ import (
 func makeCockroach(t testing.TB) (string, graph.Options, func()) {
 	var conf dock.Config
 
-	conf.Image = "cockroachdb/cockroach:v1.1.2"
+	conf.Image = "cockroachdb/cockroach:v1.1.5"
 	conf.Cmd = []string{"start", "--insecure"}
 
 	addr, closer := dock.RunAndWait(t, conf, "26257", func(addr string) bool {


### PR DESCRIPTION
This flattens the CockroachDB driver to be mostly self-contained for insertions instead of leaning on the Postgres driver. I think that's the best option here since the tradeoffs between the two are quite different, and it isn't a large amount of code anyway.

I've run all the docker & integration tests; all pass except for TestCockroach/qs/integration, which fails both before and after this change (with `transaction is too large to commit: 100005 intents`) and I don't believe is affected by this change.