### PR TITLE
Fix gotest is related to docker

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -91,6 +91,11 @@ If you have a Docker installed, you can also run tests for remote backend implem
 go test -tags docker ./...
 ```
 
+If you have a Docker installed, you only want to run tests for a specific backend implementations eg. mongodb
+```
+go test -tags docker ./graph/nosql/mongo
+```
+
 Integration tests can be enabled with environment variable:
 ```
 RUN_INTEGRATION=true go test ./...

--- a/internal/dock/dock.go
+++ b/internal/dock/dock.go
@@ -35,6 +35,18 @@ func run(t testing.TB, conf fullConfig) (addr string, closer func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// If there is not relevant image at local, pull image from remote repository.
+	if err := cli.PullImage(
+		docker.PullImageOptions{
+			Repository: conf.Image,
+		},
+		docker.AuthConfiguration{},
+	); err != nil {
+		// If pull image fail, skip the test.
+		t.Skip(err)
+	}
+
 	cont, err := cli.CreateContainer(docker.CreateContainerOptions{
 		Config:     &conf.Config,
 		HostConfig: &conf.HostConfig,


### PR DESCRIPTION
When I run all go tests in cayley according to docs/Contributing.md, I notice all backend implementations are created by docker. But if I don't have the relevant image at local, the tests will skip. the code only do some operation about backend implementations containers like this: create container from a image -> start container -> inspect container and not pull image from remote repository first. So I do a little change here. Wish this will help. 

Last time I have pull request fail because of CI, So I rebase on top of the new master.