### PR TITLE
Fix Optional iterator not propagating own tags

### DIFF
--- a/graph/iterator/optional.go
+++ b/graph/iterator/optional.go
@@ -129,6 +129,8 @@ func (it *Optional) Contains(ctx context.Context, val graph.Value) bool {
 // If we failed the check, then the subiterator should not contribute to the result
 // set. Otherwise, go ahead and tag it.
 func (it *Optional) TagResults(dst map[string]graph.Value) {
+	it.tags.TagResult(dst, it.Result())
+
 	if it.lastCheck == false {
 		return
 	}


### PR DESCRIPTION
TagResults() is propagating only the sub iterator tags.

At the very least this was causing an issue with @id tagged field population using Config.LoadTo() to the following structure
```
type Node struct {
    ID quad.IRI `quad:"@id"`
    Related []*Node `quad:"related"`
}
```

for which the following iterator tree is generated
```
it = {github.com/cayleygraph/cayley/graph.Iterator} 
 data = {*github.com/cayleygraph/cayley/graph/iterator.And} 
   = {github.com/cayleygraph/cayley/graph/iterator.And} 
   uid = 37
   tags = {github.com/cayleygraph/cayley/graph.Tagger} 
   internalIterators = {[]github.com/cayleygraph/cayley/graph.Iterator} len:1, cap:20
     = {github.com/cayleygraph/cayley/graph.Iterator} 
     data = {*github.com/cayleygraph/cayley/graph/iterator.Optional} 
       = {github.com/cayleygraph/cayley/graph/iterator.Optional} 
       uid = 36
       tags = {github.com/cayleygraph/cayley/graph.Tagger} 
        tags = {[]string} len:1, cap:1
          = "ID"
        fixedTags = {map[string]github.com/cayleygraph/cayley/graph.Value} 
       subIt = {github.com/cayleygraph/cayley/graph.Iterator} 
        data = {*github.com/cayleygraph/cayley/graph/iterator.HasA} 
          = {github.com/cayleygraph/cayley/graph/iterator.HasA} 
          uid = 35
          tags = {github.com/cayleygraph/cayley/graph.Tagger} 
```