### PR TITLE
Add NamesOf to the BatchQuadStore interface

### DIFF
--- a/graph/kv/quadstore.go
+++ b/graph/kv/quadstore.go
@@ -272,6 +272,25 @@ func (qs *QuadStore) ValuesOf(ctx context.Context, vals []graph.Value) ([]quad.V
 	}
 	return out, last
 }
+
+func (qs *QuadStore) RefsOf(ctx context.Context, nodes []quad.Value) ([]graph.Value, error) {
+	values := make([]graph.Value, len(nodes))
+	err := View(qs.db, func(tx BucketTx) error {
+		for i, node := range nodes {
+			value, err := qs.resolveQuadValue(ctx, tx, node)
+			if err != nil {
+				return err
+			}
+			values[i] = Int64Value(value)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
 func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
 	ctx := context.TODO()
 	vals, err := qs.ValuesOf(ctx, []graph.Value{v})

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -32,6 +32,7 @@ import (
 
 type BatchQuadStore interface {
 	ValuesOf(ctx context.Context, vals []Value) ([]quad.Value, error)
+	RefsOf(ctx context.Context, nodes []quad.Value) ([]Value, error)
 }
 
 func ValuesOf(ctx context.Context, qs QuadStore, vals []Value) ([]quad.Value, error) {
@@ -43,6 +44,21 @@ func ValuesOf(ctx context.Context, qs QuadStore, vals []Value) ([]quad.Value, er
 		out[i] = qs.NameOf(v)
 	}
 	return out, nil
+}
+
+func RefsOf(ctx context.Context, qs QuadStore, nodes []quad.Value) ([]Value, error) {
+	if bq, ok := qs.(BatchQuadStore); ok {
+		return bq.RefsOf(ctx, nodes)
+	}
+	values := make([]Value, len(nodes))
+	for i, node := range nodes {
+		value := qs.ValueOf(node)
+		if value == nil {
+			return nil, fmt.Errorf("not found: %v", node)
+		}
+		values[i] = value
+	}
+	return values, nil
 }
 
 type QuadStore interface {


### PR DESCRIPTION
Requirement exposed by https://github.com/cayleygraph/cayley/pull/741

Add NamesOf to the BatchQuadStore interface.

Add notes that NamesOf and ValuesOf have their names the wrong
way around.

Add a dummy NamesOf to kv/QuadStore to avoid breaking it's
BatchQuadStore implementation.