### PR TITLE
Update BoomFilter to avoid Cayley panicing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -238,7 +238,7 @@ memo = "8bfd7dfab3262ac67572d5e41ff9808fb49aca88c56a921da0d33e6a23722038"
 [[projects]]
   name = "github.com/tylertreat/BoomFilters"
   packages = ["."]
-  revision = "b282640b93f349cd208f8d5921df2cfaf5780ee2"
+  revision = "37e169ae37ed529d93ecacb509c0dc80078478fc"
 
 [[projects]]
   name = "golang.org/x/net"


### PR DESCRIPTION
Cayley uses a DeletableBloomFilter for kv stores, which may cause a panic when loading a database due to an off-by-one error. In particular, you will see something like this (using the latest release binary):

```
I1019 13:01:18.852254   15348 cayley.go:63] Cayley version: 0.7.4 (431ee2850fa29f8f7dfa0de6a03c07237871d504)
I1019 13:01:18.852716   15348 cayley.go:76] using config file: config.yml
I1019 13:01:18.852820   15348 database.go:187] using backend "bolt" (./boltey)
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters.(*Buckets).setBits(0xc4201c0000, 0x100000078, 0xc400000001)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters/buckets.go:101 +0x128
github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters.(*Buckets).Set(0xc4201c0000, 0x78, 0x1, 0x11106c0)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters/buckets.go:62 +0x53
github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters.(*DeletableBloomFilter).Add(0xc420292000, 0xc4200e0020, 0x18, 0x18, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/tylertreat/BoomFilters/deletable.go:96 +0x106
github.com/cayleygraph/cayley/graph/kv.(*QuadStore).initBloomFilter.func1(0x110cc80, 0xc420218000, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/graph/kv/indexing.go:927 +0x292
github.com/cayleygraph/cayley/graph/kv.View(0x1105a80, 0xc4200e2020, 0xc42009f9b0, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/graph/kv/kv.go:94 +0xa6
github.com/cayleygraph/cayley/graph/kv.(*QuadStore).initBloomFilter(0xc420112140, 0x110c900, 0xc4200de018, 0x2, 0x0)
	/go/src/github.com/cayleygraph/cayley/graph/kv/indexing.go:909 +0x10e
github.com/cayleygraph/cayley/graph/kv.New(0x1105a80, 0xc4200e2020, 0xc42028cb70, 0x1105a80, 0xc4200e2020, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/graph/kv/quadstore.go:142 +0x212
github.com/cayleygraph/cayley/graph/kv.Register.func2(0xc42024b608, 0x8, 0xc42028cb70, 0x4, 0xc4201c5208, 0x1, 0xc42028cb70)
	/go/src/github.com/cayleygraph/cayley/graph/kv/quadstore.go:69 +0x97
github.com/cayleygraph/cayley/graph.NewQuadStore(0xc42024b5f8, 0x4, 0xc42024b608, 0x8, 0xc42028cb70, 0x3600000000000001, 0xc420189ba0, 0x53b004, 0xc42010a5a0)
	/go/src/github.com/cayleygraph/cayley/graph/registry.go:60 +0x98
github.com/cayleygraph/cayley/cmd/cayley/command.openDatabase(0xc42010a5a0, 0x102d5b7, 0x4)
	/go/src/github.com/cayleygraph/cayley/cmd/cayley/command/database.go:201 +0xe6
github.com/cayleygraph/cayley/cmd/cayley/command.openForQueries(0xc4202a8b40, 0x1074f70, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/cmd/cayley/command/database.go:223 +0x88
github.com/cayleygraph/cayley/cmd/cayley/command.NewHttpCmd.func1(0xc4202a8b40, 0xc420219b40, 0x0, 0x2, 0x0, 0x0)
	/go/src/github.com/cayleygraph/cayley/cmd/cayley/command/http.go:24 +0x9f
github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra.(*Command).execute(0xc4202a8b40, 0xc420219ae0, 0x2, 0x2, 0xc4202a8b40, 0xc420219ae0)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra/command.go:620 +0x3e4
github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1848de0, 0x1849020, 0xc420189f78, 0x405c3c)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra/command.go:699 +0x2d4
github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra.(*Command).Execute(0x1848de0, 0xc4202a8900, 0x0)
	/go/src/github.com/cayleygraph/cayley/vendor/github.com/spf13/cobra/command.go:658 +0x2b
main.main()
	/go/src/github.com/cayleygraph/cayley/cmd/cayley/cayley.go:187 +0x31
```

This was fixed in commit https://github.com/tylertreat/BoomFilters/commit/e4c39d49fb322169c2932fc10b0c5544318add78, so it's sufficient to update the dependency on BoomFilters to resolve this issue.

It feels a bit silly to update my name to CONTRIBUTORS and AUTHORS for such a small change, so I decided not to add it for now. But if you really want me to put my name in those, then I can of course do so.