### PR TITLE
fix for deletion of reinserted causing a quad does not exist error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Jay Graves <jaywgraves@gmail.com>
 Jeremy Jay <jeremy@pbnjay.com>
 Jørgen Teunis <cayley@jorgenteunis.com>
 Pius Uzamere <pius+github@alum.mit.edu>
+QlikTech International AB 
 Robert Daniel Kortschak <dan.kortschak@adelaide.edu.au>
 Robert Melton <rmelton@gmail.com>
 Stefan Koshiw <anonwasere@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,6 +20,7 @@ Pius Uzamere <pius+github@alum.mit.edu>
 Robert Daniel Kortschak <dan.kortschak@adelaide.edu.au>
 Robert Melton <rmelton@gmail.com>
 Stefan Koshiw <anonwasere@gmail.com>
+Tad Adams <tad.adams@qlik.com>
 Timothy Armstrong <armstrong.timothy@gmail.com>
 Tyler Gibbons <tyler.gibbons@ideogr.am>
 Yannic Bonenberger <contact@yannic-bonenberger.com>

--- a/graph/graphtest/graphtest.go
+++ b/graph/graphtest/graphtest.go
@@ -1103,11 +1103,13 @@ func TestDeleteReinserted(t testing.TB, gen testutil.DatabaseFunc, _ *Config) {
 		quad.Make("<bob>", "<status>", "Feeling happy", nil),
 		quad.Make("<sally>", "<follows>", "<jim>", nil),
 	})
+	require.NoError(t, err, "Add quadset failed")
 
 	for i := 0; i < 2; i++ {
-		w.AddQuad(quad.Make("<bob>", "<follows>", "<sally>", nil))
+		err = w.AddQuad(quad.Make("<bob>", "<follows>", "<sally>", nil))
+		require.NoError(t, err, "Add quad failed")
 		err = w.RemoveQuad(quad.Make("<bob>", "<follows>", "<sally>", nil))
-		assert.Nil(t, err, "Remove quad failed")
+		require.NoError(t, err, "Remove quad failed")
 	}
 
 }

--- a/graph/kv/indexing.go
+++ b/graph/kv/indexing.go
@@ -675,9 +675,10 @@ func (qs *QuadStore) hasPrimitive(ctx context.Context, tx BucketTx, p *proto.Pri
 	if !get && unique {
 		return p, nil
 	}
-	for _, x := range options {
+	for ix := len(options) - 1; ix >= 0; ix-- {
 		// TODO: batch
-		prim, err := qs.getPrimitiveFromLog(ctx, tx, x)
+		prim, err := qs.getPrimitiveFromLog(ctx, tx, options[ix])
+
 		if err != nil {
 			return nil, err
 		}

--- a/graph/kv/indexing.go
+++ b/graph/kv/indexing.go
@@ -675,9 +675,9 @@ func (qs *QuadStore) hasPrimitive(ctx context.Context, tx BucketTx, p *proto.Pri
 	if !get && unique {
 		return p, nil
 	}
-	for ix := len(options) - 1; ix >= 0; ix-- {
+	for i := len(options) - 1; i >= 0; i-- {
 		// TODO: batch
-		prim, err := qs.getPrimitiveFromLog(ctx, tx, options[ix])
+		prim, err := qs.getPrimitiveFromLog(ctx, tx, options[i])
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When reinserting a previously deleted quad, and attempting to then delete it a quad does not exist error was given for the the kv stores, issue was retrieval of the primitive from the log was finding the prviously deleted, not the previously inserted quad. Change retrieval from the log to iterate in reverse to ensure the latest is retrieved when multiple hits. Added unit test.