### PR TITLE
Enable native byte array fields on structs

### DIFF
--- a/schema/writer.go
+++ b/schema/writer.go
@@ -92,7 +92,7 @@ func (w *writer) writeValueAs(id quad.Value, rv reflect.Value, pref string, rule
 				return err
 			}
 		case saveRule:
-			if f.Type.Kind() == reflect.Slice {
+			if f.Type.Kind() == reflect.Slice && f.Type != reflect.TypeOf([]byte(nil)) {
 				sl := rv.Field(i)
 				for j := 0; j < sl.Len(); j++ {
 					if err := w.writeOneValReflect(id, r.Pred, sl.Index(j), r.Rev); err != nil {

--- a/voc/schema/schema.go
+++ b/voc/schema/schema.go
@@ -25,6 +25,8 @@ const (
 	True = Prefix + `True`
 	// Data type: Text.
 	Text = Prefix + `Text`
+	// Data type: ByteArr.
+	ByteArr = Prefix + "ByteArr"
 	// Data type: URL.
 	URL = Prefix + `URL`
 	// Data type: Number.


### PR DESCRIPTION
Auto-converts []byte arrays to strings behind the scenes so the bytes are not stored as individual integers on the graph.

Examples:
```Go
// Create some struct with native []byte array field insid
type MyStruct struct {
	ID   string `json:"id" quad:"@id"`
	Name string `json:"name"`  // Sample text field
	Data []byte `json:"data"`  // Sample binary field
}

// Register schema
schema.RegisterType(quad.IRI("mystruct"), MyStruct{})

// Write struct to graph
m := &MyStruct{
	ID:   "1",
	Name: "Sample struct with embedded byte array",
	Data: []byte{'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd', '!'},
}
schema.WriteAsQuads(qw, m)


// Write raw bytes to graph
bytes := quad.ByteArr(data.Data)
schema.WriteAsQuads(qw, bytes)
```