### PR TITLE
kv: Properly skip removed quads

### DIFF
--- a/graph/kv/indexing.go
+++ b/graph/kv/indexing.go
@@ -424,6 +424,8 @@ func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreOpts graph.IgnoreOpts) 
 		for _, q := range deltas.QuadDel {
 			var link proto.Primitive
 			exists := true
+			// resolve values of all quad directions
+			// if any of the direction does not exists, the quad does not exists as well
 			for _, dir := range quad.Directions {
 				h := q.Quad.Get(dir)
 				n, ok := nodes[h]
@@ -680,6 +682,9 @@ func (qs *QuadStore) hasPrimitive(ctx context.Context, tx BucketTx, p *proto.Pri
 		prim, err := qs.getPrimitiveFromLog(ctx, tx, options[i])
 		if err != nil {
 			return nil, err
+		}
+		if prim.Deleted {
+			continue
 		}
 		if prim.IsSameLink(p) {
 			return prim, nil


### PR DESCRIPTION
This change enables test for KV without the Bloom filter, which uncovers the #771 and fixes it by properly skipping removed quads when the Bloom returns false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/774)
<!-- Reviewable:end -->
