### PR TITLE
schema: Support typedefs when writing structs

### DIFF
--- a/schema/loader_test.go
+++ b/schema/loader_test.go
@@ -349,6 +349,16 @@ var testFillValueCases = []struct {
 		},
 	},
 	{
+		name: "typedef",
+		expect: genObjectTypedef{
+			ID:   "1234",
+			Name: "Obj",
+		},
+		quads: []quad.Quad{
+			{iri("1234"), iri("name"), quad.String("Obj"), nil},
+		},
+	},
+	{
 		name:   "coords",
 		expect: Coords{Lat: 12.3, Lng: 34.5},
 		quads: []quad.Quad{

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -95,6 +95,13 @@ type genObject struct {
 	Name string   `quad:"name"`
 }
 
+type MyString string
+
+type genObjectTypedef struct {
+	ID   quad.IRI `quad:"@id"`
+	Name MyString `quad:"name"`
+}
+
 type subObject struct {
 	genObject
 	Num int `quad:"num"`

--- a/schema/writer.go
+++ b/schema/writer.go
@@ -138,6 +138,17 @@ func (w *writer) writeAsQuads(rv reflect.Value) (quad.Value, error) {
 	// note, that it may be a struct such as time.Time
 	if val, ok := quad.AsValue(rv.Interface()); ok {
 		return val, nil
+	} else if kind == reflect.String {
+		return quad.String(rv.String()), nil
+	} else if kind == reflect.Int || kind == reflect.Uint ||
+		kind == reflect.Int32 || kind == reflect.Uint32 ||
+		kind == reflect.Int16 || kind == reflect.Uint16 ||
+		kind == reflect.Int8 || kind == reflect.Uint8 {
+		return quad.Int(rv.Int()), nil
+	} else if kind == reflect.Float64 || kind == reflect.Float32 {
+		return quad.Float(rv.Float()), nil
+	} else if kind == reflect.Bool {
+		return quad.Bool(rv.Bool()), nil
 	}
 	// TODO(dennwc): support maps
 	if kind != reflect.Struct {

--- a/schema/writer_test.go
+++ b/schema/writer_test.go
@@ -173,6 +173,18 @@ var testWriteValueCases = []struct {
 		nil,
 	},
 	{
+		"typedef",
+		genObjectTypedef{
+			ID:   "1234",
+			Name: "Obj",
+		},
+		iri("1234"),
+		[]quad.Quad{
+			{iri("1234"), iri("name"), quad.String("Obj"), nil},
+		},
+		nil,
+	},
+	{
 		"simple object (embedded multiple levels)",
 		subSubObject{
 			subObject: subObject{


### PR DESCRIPTION
Support custom types based on primitive Go types when writing quads with the schema library.

Fixes #768

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/775)
<!-- Reviewable:end -->
