### PR TITLE
gkvlite backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca
 	github.com/boltdb/bolt v1.3.1
+	github.com/cbhvn/gkvlite v0.2.0
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/cznic/mathutil v0.0.0-20170313102836-1447ad269d64
@@ -70,7 +71,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190208162236-193df9c0f06f // indirect
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
-	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
+	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 // indirect
 	google.golang.org/appengine v0.0.0-20170410194355-170382fa85b1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/olivere/elastic.v5 v5.0.79

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca h1:77KAMse6RWRpPfVn
 github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca/go.mod h1:TWe0N2hv5qvpLHT+K16gYcGBllld4h65dQ/5CNuirmk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/cbhvn/gkvlite v0.2.0 h1:h6eJPkSPK9WqC0SaRYkOMV0wWGfSzI2y2UlR2gZg2Jo=
+github.com/cbhvn/gkvlite v0.2.0/go.mod h1:UzE0BOlUevHGefto4rJXr+A4ufwwtTBxoAtyslxwZMo=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
@@ -20,6 +22,7 @@ github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/couchbase/go-slab v0.0.0-20150629231827-1f5f7f282713/go.mod h1:UjNSZv42LPPi7v6ve9CJ6u+Vmf2Hga1TsXCoIF9Sn9E=
 github.com/cznic/mathutil v0.0.0-20170313102836-1447ad269d64 h1:oad14P7M0/ZAPSMH1nl1vC8zdKVkA3kfHLO59z1l8Eg=
 github.com/cznic/mathutil v0.0.0-20170313102836-1447ad269d64/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
@@ -200,8 +203,8 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUkVZqzHJT5DOasTyn8Vs=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 h1:FDfvYgoVsA7TTZSbgiqjAbfPbK47CNHdWl3h/PJtii0=
-golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/appengine v0.0.0-20170410194355-170382fa85b1 h1:zuLu3HtMlMHU+P0tAW1qa6pDaFhglr01Z/DDvjbOydI=

--- a/graph/kv/gkvlite/gkvlite.go
+++ b/graph/kv/gkvlite/gkvlite.go
@@ -1,0 +1,218 @@
+// Copyright 2017 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gkvlite
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/kv"
+	"github.com/cbhvn/gkvlite"
+)
+
+const (
+	Type = "gkvlite"
+)
+
+func init() {
+	kv.Register(Type, kv.Registration{
+		NewFunc:      Open,
+		InitFunc:     Create,
+		IsPersistent: true,
+	})
+}
+
+func Create(folder string, m graph.Options) (kv.BucketKV, error) {
+	var f *os.File
+	if folder != "" {
+		err := os.MkdirAll(folder, 0700)
+		if err != nil {
+			return nil, err
+		}
+		p := path.Join(folder, "store.gkvlite")
+		f, err = os.Create(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newStore(f)
+}
+
+func Open(path string, m graph.Options) (kv.BucketKV, error) {
+	var f *os.File
+	if path != "" {
+		err := os.MkdirAll(path, 0700)
+		if err != nil {
+			return nil, err
+		}
+		f, err = os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newStore(f)
+}
+
+func newStore(f *os.File) (kv.BucketKV, error) {
+
+	store, err := gkvlite.NewStore(f)
+	c := store.SetCollection("cayleygraph", nil)
+
+	if err != nil {
+		return nil, err
+	}
+	db := &DB{
+		store: store,
+		file:  f,
+		c:     c,
+	}
+	return kv.FromFlat(db), nil
+}
+
+type DB struct {
+	store    *gkvlite.Store
+	isClosed bool
+	file     *os.File
+	c        *gkvlite.Collection
+}
+
+func (db *DB) Type() string {
+	return Type
+}
+
+func (db *DB) Close() error {
+	if db.store == nil || db.isClosed {
+		return nil
+	}
+	db.isClosed = true
+	db.store.Close()
+	if db.file != nil {
+		return db.file.Close()
+	}
+
+	return nil
+}
+
+func (db *DB) Tx(update bool) (kv.FlatTx, error) {
+	return &Tx{db, nil}, nil
+}
+
+type optype int
+
+const (
+	_ = iota
+	put
+	del
+)
+
+type op struct {
+	t optype
+	k []byte
+	v []byte
+}
+
+type Tx struct {
+	db  *DB
+	ops []op
+}
+
+func (tx *Tx) Commit(ctx context.Context) error {
+	defer func() {
+		tx.ops = nil
+	}()
+	for _, op := range tx.ops {
+		switch op.t {
+		case put:
+			err := tx.db.c.Set(op.k, op.v)
+			if err != nil {
+				return err
+			}
+		case del:
+			_, err := tx.db.c.Delete(op.k)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if tx.db.file == nil {
+		return nil
+	}
+	err := tx.db.store.Flush()
+	return err
+}
+
+func (tx *Tx) Rollback() error {
+	tx.ops = nil
+	return nil
+}
+
+func (tx *Tx) Get(ctx context.Context, keys [][]byte) ([][]byte, error) {
+	vals := make([][]byte, len(keys))
+	for i, k := range keys {
+		val, err := tx.db.c.Get(k)
+		if err != nil {
+			continue
+		}
+		vals[i] = val
+	}
+	return vals, nil
+}
+
+func (tx *Tx) Put(k, v []byte) error {
+	tx.ops = append(tx.ops, op{put, k, v})
+	return nil
+}
+
+func (tx *Tx) Del(k []byte) error {
+	tx.ops = append(tx.ops, op{del, k, nil})
+	return nil
+}
+
+func (tx *Tx) Scan(pref []byte) kv.KVIterator {
+	it := tx.db.c.IterateAscend(pref, true)
+	return &Iterator{iter: it, pref: pref, first: true}
+}
+
+type Iterator struct {
+	iter  gkvlite.ItemIterator
+	first bool
+	pref  []byte
+	err   error
+}
+
+func (it *Iterator) Next(ctx context.Context) bool {
+	return it.iter.Next()
+}
+
+func (it *Iterator) Key() []byte {
+	return it.iter.Result().Key
+}
+
+func (it *Iterator) Val() []byte {
+	return it.iter.Result().Val
+}
+
+func (it *Iterator) Err() error {
+	return it.iter.Err()
+}
+
+func (it *Iterator) Close() error {
+	it.iter.Close()
+	return it.Err()
+}

--- a/graph/kv/gkvlite/gkvlite_test.go
+++ b/graph/kv/gkvlite/gkvlite_test.go
@@ -24,7 +24,17 @@ import (
 	"github.com/cayleygraph/cayley/graph/kv/kvtest"
 )
 
-func makeGkvlitekv(t testing.TB) (kv.BucketKV, graph.Options, func()) {
+func makeMemStore(t testing.TB) (kv.BucketKV, graph.Options, func()) {
+	db, err := Create("", nil)
+	if err != nil {
+		t.Fatal("Failed to create gkvlite database.", err)
+	}
+	return db, nil, func() {
+		db.Close()
+	}
+}
+
+func makeFileStore(t testing.TB) (kv.BucketKV, graph.Options, func()) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cayley_test_"+Type)
 	if err != nil {
 		t.Fatalf("Could not create working directory: %v", err)
@@ -41,9 +51,9 @@ func makeGkvlitekv(t testing.TB) (kv.BucketKV, graph.Options, func()) {
 }
 
 func TestGkvlitekv(t *testing.T) {
-	kvtest.TestAll(t, makeGkvlitekv, nil)
+	kvtest.TestAll(t, makeFileStore, nil)
 }
 
 func BenchmarkGkvlitekv(b *testing.B) {
-	kvtest.BenchmarkAll(b, makeGkvlitekv, nil)
+	kvtest.BenchmarkAll(b, makeFileStore, nil)
 }

--- a/graph/kv/gkvlite/gkvlite_test.go
+++ b/graph/kv/gkvlite/gkvlite_test.go
@@ -1,0 +1,49 @@
+// Copyright 2017 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gkvlite
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/kv"
+	"github.com/cayleygraph/cayley/graph/kv/kvtest"
+)
+
+func makeGkvlitekv(t testing.TB) (kv.BucketKV, graph.Options, func()) {
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cayley_test_"+Type)
+	if err != nil {
+		t.Fatalf("Could not create working directory: %v", err)
+	}
+	db, err := Create(tmpDir, nil)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		t.Fatal("Failed to create gkvlite database.", err)
+	}
+	return db, nil, func() {
+		db.Close()
+		os.RemoveAll(tmpDir)
+	}
+}
+
+func TestGkvlitekv(t *testing.T) {
+	kvtest.TestAll(t, makeGkvlitekv, nil)
+}
+
+func BenchmarkGkvlitekv(b *testing.B) {
+	kvtest.BenchmarkAll(b, makeGkvlitekv, nil)
+}


### PR DESCRIPTION
While searching for existing concurrent memstore backends, I stumbled upon gkvlite. It supports both file and in-memory modes. It's not perfect, though.
-  In-memory stores are safe, but rollbacks are not supported, and concurrent reads are dirty.
- File stores support rollbacks, are threadsafe, but concurrent reads are dirty
- On my machine, benchmarks show it to be faster than badger, but my machine doesn't have SSD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/781)
<!-- Reviewable:end -->
