### PR TITLE
cayley: use alias to make import helpers perfect matchers

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -15,11 +15,11 @@ var (
 	NewTransaction = graph.NewTransaction
 )
 
-type Iterator graph.Iterator
-type QuadStore graph.QuadStore
-type QuadWriter graph.QuadWriter
+type Iterator = graph.Iterator
+type QuadStore = graph.QuadStore
+type QuadWriter = graph.QuadWriter
 
-type Path path.Path
+type Path = path.Path
 
 type Handle struct {
 	graph.QuadStore


### PR DESCRIPTION
Please take a look.

TBH I think that it's probably wrong for them to be here, but they are, so they should match perfectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/800)
<!-- Reviewable:end -->
