### PR TITLE
Require quad writers to have a batch method

### DIFF
--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -305,6 +305,14 @@ func (qs *QuadStore) WriteQuad(q quad.Quad) error {
 	return nil
 }
 
+// WriteQuads implements quad.Writer.
+func (qs *QuadStore) WriteQuads(buf []quad.Quad) (int, error) {
+	for _, q := range buf {
+		qs.AddQuad(q)
+	}
+	return len(buf), nil
+}
+
 func (qs *QuadStore) deleteQuadNodes(q internalQuad) {
 	for dir := quad.Subject; dir <= quad.Label; dir++ {
 		id := q.Dir(dir)

--- a/graph/quadwriter.go
+++ b/graph/quadwriter.go
@@ -190,7 +190,6 @@ func WriterMethods() []string {
 
 type BatchWriter interface {
 	quad.WriteCloser
-	quad.BatchWriter
 	Flush() error
 }
 
@@ -259,6 +258,15 @@ func (w *txWriter) WriteQuad(q quad.Quad) error {
 		return ErrInvalidAction
 	}
 	return nil
+}
+
+func (w *txWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
 }
 
 // NewRemover creates a quad writer for a given QuadStore which removes quads instead of adding them.

--- a/internal/load.go
+++ b/internal/load.go
@@ -136,7 +136,7 @@ func DecompressAndLoad(qw graph.QuadWriter, batch int, path, typ string, writerF
 	}
 	dest := writerFunc(qw)
 
-	_, err = quad.CopyBatch(&batchLogger{BatchWriter: dest}, qr, batch)
+	_, err = quad.CopyBatch(&batchLogger{w: dest}, qr, batch)
 	if err != nil {
 		return fmt.Errorf("db: failed to load data: %v", err)
 	}
@@ -145,11 +145,11 @@ func DecompressAndLoad(qw graph.QuadWriter, batch int, path, typ string, writerF
 
 type batchLogger struct {
 	cnt int
-	quad.BatchWriter
+	w   quad.Writer
 }
 
 func (w *batchLogger) WriteQuads(quads []quad.Quad) (int, error) {
-	n, err := w.BatchWriter.WriteQuads(quads)
+	n, err := w.w.WriteQuads(quads)
 	if clog.V(2) {
 		w.cnt += n
 		clog.Infof("Wrote %d quads.", w.cnt)

--- a/quad/dot/dot.go
+++ b/quad/dot/dot.go
@@ -64,6 +64,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 func (w *Writer) Close() error {
 	if w.err != nil {
 		return w.err

--- a/quad/gml/gml.go
+++ b/quad/gml/gml.go
@@ -81,6 +81,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 func (w *Writer) Close() error {
 	if w.err != nil {
 		return w.err

--- a/quad/graphml/graphml.go
+++ b/quad/graphml/graphml.go
@@ -82,6 +82,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 func (w *Writer) Close() error {
 	if w.err != nil {
 		return w.err

--- a/quad/json/json.go
+++ b/quad/json/json.go
@@ -119,6 +119,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return err
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 func (w *Writer) Close() error {
 	if w.closed {
 		return nil
@@ -142,6 +151,15 @@ type StreamWriter struct {
 
 func (w *StreamWriter) WriteQuad(q quad.Quad) error {
 	return w.enc.Encode(q)
+}
+
+func (w *StreamWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
 }
 
 func (w *StreamWriter) Close() error { return nil }

--- a/quad/jsonld/jsonld.go
+++ b/quad/jsonld/jsonld.go
@@ -127,6 +127,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return nil
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 func (w *Writer) Close() error {
 	opts := gojsonld.NewOptions("")
 	var data interface{}

--- a/quad/pquads/pquads.go
+++ b/quad/pquads/pquads.go
@@ -109,6 +109,15 @@ func (w *Writer) WriteQuad(q quad.Quad) error {
 	return w.err
 }
 
+func (w *Writer) WriteQuads(buf []quad.Quad) (int, error) {
+	for i, q := range buf {
+		if err := w.WriteQuad(q); err != nil {
+			return i, err
+		}
+	}
+	return len(buf), nil
+}
+
 // MaxSize returns a maximal message size written.
 func (w *Writer) MaxSize() int {
 	return w.max

--- a/schema/writer_test.go
+++ b/schema/writer_test.go
@@ -16,6 +16,11 @@ func (s *quadSlice) WriteQuad(q quad.Quad) error {
 	return nil
 }
 
+func (s *quadSlice) WriteQuads(buf []quad.Quad) (int, error) {
+	*s = append(*s, buf...)
+	return len(buf), nil
+}
+
 func TestWriteAsQuads(t *testing.T) {
 	sch := schema.NewConfig()
 	for _, c := range testWriteValueCases {


### PR DESCRIPTION
Include the `WriteQuads` (batch) to the `quad.Writer` interface. And add deprecation notes for `WriteQuad` (single).

This will eventually allow faster data import for the backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/802)
<!-- Reviewable:end -->
