### PR TITLE
Optimize batch import to KV backends

### DIFF
--- a/cmd/cayley/command/database.go
+++ b/cmd/cayley/command/database.go
@@ -111,9 +111,15 @@ func NewLoadDatabaseCmd() *cobra.Command {
 			}
 			defer h.Close()
 
+			qw, err := h.NewQuadWriter()
+			if err != nil {
+				return err
+			}
+			defer qw.Close()
+
 			// TODO: check read-only flag in config before that?
 			typ, _ := cmd.Flags().GetString(flagLoadFormat)
-			if err = internal.Load(h.QuadWriter, quad.DefaultBatch, load, typ); err != nil {
+			if err = internal.Load(qw, quad.DefaultBatch, load, typ); err != nil {
 				return err
 			}
 
@@ -240,10 +246,17 @@ func openForQueries(cmd *cobra.Command) (*graph.Handle, error) {
 		load = load2
 	}
 	if load != "" {
+		qw, err := h.NewQuadWriter()
+		if err != nil {
+			h.Close()
+			return nil, err
+		}
+		defer qw.Close()
+
 		typ, _ := cmd.Flags().GetString(flagLoadFormat)
 		// TODO: check read-only flag in config before that?
 		start := time.Now()
-		if err = internal.Load(h.QuadWriter, quad.DefaultBatch, load, typ); err != nil {
+		if err = internal.Load(qw, quad.DefaultBatch, load, typ); err != nil {
 			h.Close()
 			return nil, err
 		}

--- a/graph/gaedatastore/quadstore.go
+++ b/graph/gaedatastore/quadstore.go
@@ -164,6 +164,46 @@ func (qs *QuadStore) ForRequest(r *http.Request) (graph.QuadStore, error) {
 	return &QuadStore{context: appengine.NewContext(r)}, nil
 }
 
+func (qs *QuadStore) NewQuadWriter() (quad.WriteCloser, error) {
+	return &quadWriter{qs: qs}, nil
+}
+
+type quadWriter struct {
+	qs     *QuadStore
+	deltas []graph.Delta
+}
+
+func (w *quadWriter) WriteQuad(q quad.Quad) error {
+	_, err := w.WriteQuads([]quad.Quad{q})
+	return err
+}
+
+func (w *quadWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	// TODO(dennwc): write an optimized implementation
+	w.deltas = w.deltas[:0]
+	if cap(w.deltas) < len(buf) {
+		w.deltas = make([]graph.Delta, 0, len(buf))
+	}
+	for _, q := range buf {
+		w.deltas = append(w.deltas, graph.Delta{
+			Quad: q, Action: graph.Add,
+		})
+	}
+	err := w.qs.ApplyDeltas(w.deltas, graph.IgnoreOpts{
+		IgnoreDup: true,
+	})
+	w.deltas = w.deltas[:0]
+	if err != nil {
+		return 0, err
+	}
+	return len(buf), nil
+}
+
+func (w *quadWriter) Close() error {
+	w.deltas = nil
+	return nil
+}
+
 func (qs *QuadStore) ApplyDeltas(in []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	if qs.context == nil {
 		return errors.New("No context, graph not correctly initialised")

--- a/graph/graphmock/graphmock.go
+++ b/graph/graphmock/graphmock.go
@@ -52,6 +52,24 @@ func (qs *Oldstore) ValueOf(s quad.Value) graph.Ref {
 	return nil
 }
 
+func (qs *Oldstore) NewQuadWriter() (quad.WriteCloser, error) {
+	return nopWriter{}, nil
+}
+
+type nopWriter struct{}
+
+func (nopWriter) WriteQuad(q quad.Quad) error {
+	return nil
+}
+
+func (nopWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	return len(buf), nil
+}
+
+func (nopWriter) Close() error {
+	return nil
+}
+
 func (qs *Oldstore) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
 
 func (qs *Oldstore) Quad(graph.Ref) quad.Quad { return quad.Quad{} }
@@ -121,6 +139,10 @@ func (qs *Store) ValueOf(s quad.Value) graph.Ref {
 }
 
 func (qs *Store) ApplyDeltas([]graph.Delta, graph.IgnoreOpts) error { return nil }
+
+func (qs *Store) NewQuadWriter() (quad.WriteCloser, error) {
+	return nopWriter{}, nil
+}
 
 type quadValue struct {
 	q quad.Quad

--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -313,6 +313,30 @@ func (qs *QuadStore) WriteQuads(buf []quad.Quad) (int, error) {
 	return len(buf), nil
 }
 
+func (qs *QuadStore) NewQuadWriter() (quad.WriteCloser, error) {
+	return &quadWriter{qs: qs}, nil
+}
+
+type quadWriter struct {
+	qs *QuadStore
+}
+
+func (w *quadWriter) WriteQuad(q quad.Quad) error {
+	w.qs.AddQuad(q)
+	return nil
+}
+
+func (w *quadWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	for _, q := range buf {
+		w.qs.AddQuad(q)
+	}
+	return len(buf), nil
+}
+
+func (w *quadWriter) Close() error {
+	return nil
+}
+
 func (qs *QuadStore) deleteQuadNodes(q internalQuad) {
 	for dir := quad.Subject; dir <= quad.Label; dir++ {
 		id := q.Dir(dir)

--- a/graph/memstore/quadstore_test.go
+++ b/graph/memstore/quadstore_test.go
@@ -88,6 +88,14 @@ func TestMemstore(t *testing.T) {
 	})
 }
 
+func BenchmarkMemstore(b *testing.B) {
+	graphtest.BenchmarkAll(b, func(t testing.TB) (graph.QuadStore, graph.Options, func()) {
+		return New(), nil, func() {}
+	}, &graphtest.Config{
+		AlwaysRunIntegration: true,
+	})
+}
+
 type pair struct {
 	query string
 	value int64

--- a/graph/nosql/quadstore.go
+++ b/graph/nosql/quadstore.go
@@ -331,6 +331,46 @@ func (qs *QuadStore) appendLog(ctx context.Context, deltas []graph.Delta) ([]nos
 	return w.Keys(), err
 }
 
+func (qs *QuadStore) NewQuadWriter() (quad.WriteCloser, error) {
+	return &quadWriter{qs: qs}, nil
+}
+
+type quadWriter struct {
+	qs     *QuadStore
+	deltas []graph.Delta
+}
+
+func (w *quadWriter) WriteQuad(q quad.Quad) error {
+	_, err := w.WriteQuads([]quad.Quad{q})
+	return err
+}
+
+func (w *quadWriter) WriteQuads(buf []quad.Quad) (int, error) {
+	// TODO(dennwc): write an optimized implementation
+	w.deltas = w.deltas[:0]
+	if cap(w.deltas) < len(buf) {
+		w.deltas = make([]graph.Delta, 0, len(buf))
+	}
+	for _, q := range buf {
+		w.deltas = append(w.deltas, graph.Delta{
+			Quad: q, Action: graph.Add,
+		})
+	}
+	err := w.qs.ApplyDeltas(w.deltas, graph.IgnoreOpts{
+		IgnoreDup: true,
+	})
+	w.deltas = w.deltas[:0]
+	if err != nil {
+		return 0, err
+	}
+	return len(buf), nil
+}
+
+func (w *quadWriter) Close() error {
+	w.deltas = nil
+	return nil
+}
+
 func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
 	ctx := context.TODO()
 	ids := make(map[quad.Value]int)

--- a/graph/quadstore.go
+++ b/graph/quadstore.go
@@ -112,6 +112,10 @@ type QuadStore interface {
 	// is done by a replication strategy.
 	ApplyDeltas(in []Delta, opts IgnoreOpts) error
 
+	// NewQuadWriter starts a batch quad import process.
+	// The order of changes is not guaranteed, neither is the order and result of concurrent ApplyDeltas.
+	NewQuadWriter() (quad.WriteCloser, error)
+
 	// Returns an iterator enumerating all nodes in the graph.
 	NodesAllIterator() Iterator
 

--- a/graph/shape/shape_test.go
+++ b/graph/shape/shape_test.go
@@ -42,6 +42,10 @@ func (qs ValLookup) OptimizeShape(s Shape) (Shape, bool) {
 func (qs ValLookup) ValueOf(v quad.Value) graph.Ref {
 	return qs[v]
 }
+
+func (ValLookup) NewQuadWriter() (quad.WriteCloser, error) {
+	panic("not implemented")
+}
 func (ValLookup) ApplyDeltas(_ []graph.Delta, _ graph.IgnoreOpts) error {
 	panic("not implemented")
 }

--- a/internal/load.go
+++ b/internal/load.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/cayleygraph/cayley/clog"
-	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/internal/decompressor"
 	"github.com/cayleygraph/cayley/quad"
 	"github.com/cayleygraph/cayley/quad/nquads"
@@ -18,8 +17,8 @@ import (
 
 // Load loads a graph from the given path and write it to qw.  See
 // DecompressAndLoad for more information.
-func Load(qw graph.QuadWriter, batch int, path, typ string) error {
-	return DecompressAndLoad(qw, batch, path, typ, nil)
+func Load(qw quad.WriteCloser, batch int, path, typ string) error {
+	return DecompressAndLoad(qw, batch, path, typ)
 }
 
 type readCloser struct {
@@ -121,7 +120,7 @@ func QuadReaderFor(path, typ string) (quad.ReadCloser, error) {
 // DecompressAndLoad will load or fetch a graph from the given path, decompress
 // it, and then call the given load function to process the decompressed graph.
 // If no loadFn is provided, db.Load is called.
-func DecompressAndLoad(qw graph.QuadWriter, batch int, path, typ string, writerFunc func(graph.QuadWriter) graph.BatchWriter) error {
+func DecompressAndLoad(qw quad.WriteCloser, batch int, path, typ string) error {
 	if path == "" {
 		return nil
 	}
@@ -131,16 +130,11 @@ func DecompressAndLoad(qw graph.QuadWriter, batch int, path, typ string, writerF
 	}
 	defer qr.Close()
 
-	if writerFunc == nil {
-		writerFunc = graph.NewWriter
-	}
-	dest := writerFunc(qw)
-
-	_, err = quad.CopyBatch(&batchLogger{w: dest}, qr, batch)
+	_, err = quad.CopyBatch(&batchLogger{w: qw}, qr, batch)
 	if err != nil {
 		return fmt.Errorf("db: failed to load data: %v", err)
 	}
-	return dest.Close()
+	return qw.Close()
 }
 
 type batchLogger struct {


### PR DESCRIPTION
Expose a `quad.Writer` constructor on `QuadStore` to allow backend implementations to optimize quad import.

Also, implement the first set of optimizations for KV backends. Results for a 30K quads file:
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkBolt/qs/import-8     3212907       490386        -84.74%
BenchmarkLeveldb/qs/import-8  4199793       231921        -94.48%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/803)
<!-- Reviewable:end -->
