### PR TITLE
Change indexing strategy for KV backends

### DIFF
--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/cayleygraph/cayley/cmd/cayley/command"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -85,6 +86,13 @@ var (
 				go func() {
 					if err := http.ListenAndServe(host, nil); err != nil {
 						clog.Errorf("failed to run pprof handler: %v", err)
+					}
+				}()
+			}
+			if host, _ := cmd.Flags().GetString("metrics"); host != "" {
+				go func() {
+					if err := http.ListenAndServe(host, promhttp.Handler()); err != nil {
+						clog.Errorf("failed to run metrics handler: %v", err)
 					}
 				}()
 			}
@@ -150,6 +158,7 @@ func init() {
 	rootCmd.PersistentFlags().String("cpuprofile", "", "path to output cpu profile")
 
 	rootCmd.PersistentFlags().String("pprof", "", "host to serve pprof on (disabled by default)")
+	rootCmd.PersistentFlags().String("metrics", "", "host to serve metrics on (disabled by default)")
 
 	// bind flags to config variables
 	viper.BindPFlag(command.KeyBackend, rootCmd.PersistentFlags().Lookup("db"))

--- a/cmd/cayley/cayley.go
+++ b/cmd/cayley/cayley.go
@@ -19,6 +19,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,6 +81,13 @@ var (
 			graph.IgnoreDuplicates = viper.GetBool("load.ignore_duplicates")
 			graph.IgnoreMissing = viper.GetBool("load.ignore_missing")
 			quad.DefaultBatch = viper.GetInt("load.batch")
+			if host, _ := cmd.Flags().GetString("pprof"); host != "" {
+				go func() {
+					if err := http.ListenAndServe(host, nil); err != nil {
+						clog.Errorf("failed to run pprof handler: %v", err)
+					}
+				}()
+			}
 			return nil
 		},
 	}
@@ -139,6 +148,8 @@ func init() {
 
 	rootCmd.PersistentFlags().String("memprofile", "", "path to output memory profile")
 	rootCmd.PersistentFlags().String("cpuprofile", "", "path to output cpu profile")
+
+	rootCmd.PersistentFlags().String("pprof", "", "host to serve pprof on (disabled by default)")
 
 	// bind flags to config variables
 	viper.BindPFlag(command.KeyBackend, rootCmd.PersistentFlags().Lookup("db"))

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/opencontainers/selinux v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/peterh/liner v0.0.0-20170317030525-88609521dc4b
+	github.com/prometheus/client_golang v0.9.3
 	github.com/russross/blackfriday v1.5.2
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cznic/mathutil v0.0.0-20170313102836-1447ad269d64
 	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/dennwc/graphql v0.0.0-20180603144102-12cfed44bc5d
-	github.com/dgraph-io/badger v1.5.5 // indirect
+	github.com/dgraph-io/badger v1.5.5
 	github.com/dlclark/regexp2 v1.1.4 // indirect
 	github.com/docker/docker v0.7.3-0.20180412203414-a422774e593b // indirect
 	github.com/docker/go-units v0.4.0 // indirect
@@ -48,6 +48,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/tylertreat/BoomFilters v0.0.0-20181028192813-611b3dbe80e8
 	go.etcd.io/bbolt v1.3.3 // indirect
+	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	google.golang.org/appengine v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/cayleygraph/cayley
 
+go 1.12
+
 require (
 	github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca
 	github.com/cockroachdb/apd v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca h1:77KAMse6RWRpPfVnIZcAtJ/5ZK/oRCeY94ZjIWSbe0g=
 github.com/badgerodon/peg v0.0.0-20130729175151-9e5f7f4d07ca/go.mod h1:TWe0N2hv5qvpLHT+K16gYcGBllld4h65dQ/5CNuirmk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
@@ -196,6 +197,7 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -235,15 +237,19 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
+github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsouza/go-dockerclient v1.2.2 h1:rFDrkgZUIlruULXD2gRhT8JhqbjA6vHszAIStg/juEY=
 github.com/fsouza/go-dockerclient v1.2.2/go.mod h1:KpcjM623fQYE9MZiTGzKhjfxXAV9wbyX2C1cyRHfhl0=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
-github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kivik/couchdb v1.8.1 h1:2yjmysS48JYpyWTkx2E3c7ASZP8Kh0eABWnkKlV8bbw=
 github.com/go-kivik/couchdb v1.8.1/go.mod h1:5XJRkAMpBlEVA4q0ktIZjUPYBjoBmRoiWvwUBzP3BOQ=
@@ -154,8 +152,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hidal-go/hidalgo v0.0.0-20190630194837-96996d1693f5 h1:UWgp6LNWgqJXxlWtJNTSc4k+CEKepwN4Q22X0W6U0bY=
-github.com/hidal-go/hidalgo v0.0.0-20190630194837-96996d1693f5/go.mod h1:b3eSi7JTaazUL53iaWMGbP5fsOr+LQWlkS7YFOZIwE8=
 github.com/hidal-go/hidalgo v0.0.0-20190814174001-42e03f3b5eaa h1:hBE4LGxApbZiV/3YoEPv7uYlUMWOogG1hwtkpiU87zQ=
 github.com/hidal-go/hidalgo v0.0.0-20190814174001-42e03f3b5eaa/go.mod h1:bPkrxDlroXxigw8BMWTEPTv4W5/rQwNgg2BECXsgyX0=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
@@ -289,6 +285,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tylertreat/BoomFilters v0.0.0-20181028192813-611b3dbe80e8 h1:7X4KYG3guI2mPQGxm/ZNNsiu4BjKnef0KG0TblMC+Z8=
@@ -331,7 +328,6 @@ golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190420063019-afa5a82059c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/graph/kv/bolt/bolt.go
+++ b/graph/kv/bolt/bolt.go
@@ -69,6 +69,7 @@ func Open(path string, opt graph.Options) (hkv.KV, error) {
 		db.Close()
 		return nil, err
 	}
+	bdb.NoGrowSync = bdb.NoSync
 	if bdb.NoSync {
 		clog.Infof("Running in nosync mode")
 	}

--- a/graph/kv/metrics.go
+++ b/graph/kv/metrics.go
@@ -1,0 +1,175 @@
+package kv
+
+import (
+	"context"
+
+	"github.com/hidal-go/hidalgo/kv"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	mApplyBatch = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cayley_apply_deltas_batch",
+		Help: "Number of quads in a buffer for ApplyDeltas or WriteQuads.",
+	})
+	mApplySeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cayley_apply_deltas_seconds",
+		Help: "Time to write a buffer in ApplyDeltas or WriteQuads.",
+	})
+
+	mNodesNew = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_nodes_new_count",
+		Help: "Number new nodes created.",
+	})
+	mNodesUpd = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_nodes_upd_count",
+		Help: "Number of node refcount updates.",
+	})
+	mNodesDel = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_nodes_del_count",
+		Help: "Number of node deleted.",
+	})
+
+	mQuadsBloomHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_quads_bloom_hits",
+		Help: "Number of times the quad bloom filter returned a negative result.",
+	})
+	mQuadsBloomMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_quads_bloom_miss",
+		Help: "Number of times the quad bloom filter returned a positive result.",
+	})
+
+	mPrimitiveFetch = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_primitive_fetch",
+		Help: "Number of primitives fetched from KV.",
+	})
+	mPrimitiveFetchMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_primitive_fetch_miss",
+		Help: "Number of primitives that were not found in KV.",
+	})
+	mPrimitiveAppend = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_primitive_append",
+		Help: "Number of primitives appended to log.",
+	})
+
+	mIndexWriteBufferEntries = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cayley_kv_index_buffer_entries",
+		Help: "Number of entries in the index write buffer.",
+	}, []string{"index"})
+	mIndexWriteBufferFlushBatch = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "cayley_kv_index_buffer_flush_batch",
+		Help: "Number of entries in the batch for flushing index entries.",
+	}, []string{"index"})
+	mIndexEntrySizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "cayley_kv_index_entry_size_bytes",
+		Help: "Size of a single index entry.",
+	}, []string{"index"})
+
+	mKVGet = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_get_count",
+		Help: "Number of get KV calls.",
+	})
+	mKVGetMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_get_miss",
+		Help: "Number of get KV calls that found no value.",
+	})
+	mKVGetSize = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cayley_kv_get_size",
+		Help: "Size of values returned from KV.",
+	})
+	mKVPut = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_put_count",
+		Help: "Number of put KV calls.",
+	})
+	mKVPutSize = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cayley_kv_put_size",
+		Help: "Size of values put to KV.",
+	})
+	mKVDel = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_del_count",
+		Help: "Number of del KV calls.",
+	})
+	mKVScan = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_scan_count",
+		Help: "Number of scan KV calls.",
+	})
+	mKVCommit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_commit",
+		Help: "Number of KV commits.",
+	})
+	mKVCommitSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name: "cayley_kv_commit_seconds",
+		Help: "Time to commit to KV.",
+	})
+	mKVRollback = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cayley_kv_rollback",
+		Help: "Number of KV rollbacks.",
+	})
+)
+
+func wrapTx(tx kv.Tx) kv.Tx {
+	return &mTx{tx: tx}
+}
+
+type mTx struct {
+	tx   kv.Tx
+	done bool
+}
+
+func (tx *mTx) Commit(ctx context.Context) error {
+	if !tx.done {
+		tx.done = true
+		mKVCommit.Inc()
+		defer prometheus.NewTimer(mKVCommitSeconds).ObserveDuration()
+	}
+	return tx.tx.Commit(ctx)
+}
+
+func (tx *mTx) Close() error {
+	if !tx.done {
+		tx.done = true
+		mKVRollback.Inc()
+	}
+	return tx.tx.Close()
+}
+
+func (tx *mTx) Get(ctx context.Context, key kv.Key) (kv.Value, error) {
+	mKVGet.Inc()
+	val, err := tx.tx.Get(ctx, key)
+	if err == kv.ErrNotFound {
+		mKVGetMiss.Inc()
+	} else if err == nil {
+		mKVGetSize.Observe(float64(len(val)))
+	}
+	return val, err
+}
+
+func (tx *mTx) GetBatch(ctx context.Context, keys []kv.Key) ([]kv.Value, error) {
+	mKVGet.Add(float64(len(keys)))
+	vals, err := tx.tx.GetBatch(ctx, keys)
+	for _, v := range vals {
+		if v == nil {
+			mKVGetMiss.Inc()
+		} else {
+			mKVGetSize.Observe(float64(len(v)))
+		}
+	}
+	return vals, err
+}
+
+func (tx *mTx) Put(k kv.Key, v kv.Value) error {
+	mKVPut.Inc()
+	mKVPutSize.Observe(float64(len(v)))
+	return tx.tx.Put(k, v)
+}
+
+func (tx *mTx) Del(k kv.Key) error {
+	mKVDel.Inc()
+	return tx.tx.Del(k)
+}
+
+func (tx *mTx) Scan(pref kv.Key) kv.Iterator {
+	mKVScan.Inc()
+	return tx.tx.Scan(pref)
+}

--- a/graph/kv/quad_iterator.go
+++ b/graph/kv/quad_iterator.go
@@ -179,6 +179,7 @@ func (it *quadIteratorNext) ensureTx() bool {
 	if it.err != nil {
 		return false
 	}
+	it.tx = wrapTx(it.tx)
 	return true
 }
 

--- a/graph/kv/quadstore.go
+++ b/graph/kv/quadstore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cayleygraph/cayley/clog"
 	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/graph/proto"
+	"github.com/cayleygraph/cayley/graph/shape"
 	"github.com/cayleygraph/cayley/internal/lru"
 	"github.com/cayleygraph/cayley/quad"
 	"github.com/cayleygraph/cayley/quad/pquads"
@@ -79,7 +80,10 @@ const (
 	latestDataVersion = 2
 )
 
-var _ graph.BatchQuadStore = (*QuadStore)(nil)
+var (
+	_ graph.BatchQuadStore = (*QuadStore)(nil)
+	_ shape.Optimizer      = (*QuadStore)(nil)
+)
 
 type QuadStore struct {
 	db kv.KV

--- a/graph/kv/quadstore.go
+++ b/graph/kv/quadstore.go
@@ -438,6 +438,7 @@ func (qs *QuadStore) getPrimitives(ctx context.Context, vals []uint64) ([]*proto
 		return nil, err
 	}
 	defer tx.Close()
+	tx = wrapTx(tx)
 	return qs.getPrimitivesFromLog(ctx, tx, vals)
 }
 

--- a/graph/kv/quadstore_test.go
+++ b/graph/kv/quadstore_test.go
@@ -143,6 +143,7 @@ func TestApplyDeltas(t *testing.T) {
 	expect(Ops{
 		{opGet, key(bMeta, kVers), vVers, nil},
 		{opGet, key(bMeta, kIndexes), []byte(`[{"dirs":"AQI=","unique":false},{"dirs":"AwIB","unique":false}]`), nil},
+		{opGet, key(bMeta, []byte("size")), nil, hkv.ErrNotFound},
 	})
 
 	qw, err := writer.NewSingle(qs, graph.IgnoreOpts{})
@@ -152,9 +153,6 @@ func TestApplyDeltas(t *testing.T) {
 	require.NoError(t, err)
 
 	expect(Ops{
-		{opGet, key(irib("a"), irih("a")), nil, nil},
-		{opGet, key(irib("b"), irih("b")), nil, nil},
-		{opGet, key(irib("c"), irih("c")), nil, nil},
 		{opGet, key(bMeta, []byte("horizon")), nil, hkv.ErrNotFound},
 		{opPut, key(bMeta, []byte("horizon")), le(3), nil},
 
@@ -165,9 +163,6 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key(irib("c"), irih("c")), vAuto, nil},
 		{opPut, key(bLog, be(3)), vAuto, nil},
 
-		{opGet, key(iric("a"), irih("a")), nil, nil},
-		{opGet, key(iric("b"), irih("b")), nil, nil},
-		{opGet, key(iric("c"), irih("c")), nil, nil},
 		{opPut, key(iric("a"), irih("a")), hex("01"), nil},
 		{opPut, key(iric("b"), irih("b")), hex("01"), nil},
 		{opPut, key(iric("c"), irih("c")), hex("01"), nil},
@@ -176,9 +171,7 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key(bLog, be(4)), vAuto, nil},
 		{opGet, key(bMeta, []byte("size")), nil, hkv.ErrNotFound},
 		{opPut, key(bMeta, []byte("size")), le(1), nil},
-		{opGet, key("ops", be(3, 2, 1)), nil, nil},
 		{opPut, key("ops", be(3, 2, 1)), hex("04"), nil},
-		{opGet, key("sp", be(1, 2)), nil, nil},
 		{opPut, key("sp", be(1, 2)), hex("04"), nil},
 	})
 
@@ -189,7 +182,6 @@ func TestApplyDeltas(t *testing.T) {
 		// served from IRI cache
 		//{opGet, irib("a"), irih("a"), vAuto, nil},
 		//{opGet, irib("b"), irih("b"), vAuto, nil},
-		{opGet, key(irib("e"), irih("e")), nil, nil},
 		{opGet, key(bMeta, []byte("horizon")), le(4), nil},
 		{opPut, key(bMeta, []byte("horizon")), le(5), nil},
 
@@ -198,7 +190,6 @@ func TestApplyDeltas(t *testing.T) {
 
 		{opGet, key(iric("a"), irih("a")), hex("01"), nil},
 		{opGet, key(iric("b"), irih("b")), hex("01"), nil},
-		{opGet, key(iric("e"), irih("e")), nil, nil},
 		{opPut, key(iric("a"), irih("a")), hex("02"), nil},
 		{opPut, key(iric("b"), irih("b")), hex("02"), nil},
 		{opPut, key(iric("e"), irih("e")), hex("01"), nil},
@@ -207,7 +198,6 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key(bLog, be(6)), vAuto, nil},
 		{opGet, key(bMeta, []byte("size")), le(1), nil},
 		{opPut, key(bMeta, []byte("size")), le(2), nil},
-		{opGet, key("ops", be(5, 2, 1)), nil, nil},
 		{opPut, key("ops", be(5, 2, 1)), hex("06"), nil},
 		{opGet, key("sp", be(1, 2)), hex("04"), nil},
 		{opPut, key("sp", be(1, 2)), hex("0406"), nil},

--- a/graph/kv/quadstore_test.go
+++ b/graph/kv/quadstore_test.go
@@ -67,6 +67,8 @@ var (
 	vVers = le(2)
 
 	vAuto = []byte("auto")
+
+	kIndexes = []byte("indexes")
 )
 
 type Ops []kvOp
@@ -129,6 +131,7 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key("s", []byte{}), nil, nil},
 		{opPut, key("o", []byte{}), nil, nil},
 		{opPut, key(bMeta, kVers), vVers, nil},
+		{opPut, key(bMeta, kIndexes), []byte(`[{"dirs":"AQ==","unique":false},{"dirs":"Aw==","unique":false}]`), nil},
 	})
 
 	qs, err := kv.New(hook, nil)
@@ -137,6 +140,7 @@ func TestApplyDeltas(t *testing.T) {
 
 	expect(Ops{
 		{opGet, key(bMeta, kVers), vVers, nil},
+		{opGet, key(bMeta, kIndexes), []byte(`[{"dirs":"AQ==","unique":false},{"dirs":"Aw==","unique":false}]`), nil},
 	})
 
 	qw, err := writer.NewSingle(qs, graph.IgnoreOpts{})

--- a/graph/kv/quadstore_test.go
+++ b/graph/kv/quadstore_test.go
@@ -46,9 +46,11 @@ func key(b string, k []byte) hkv.Key {
 	return hkv.Key{[]byte(b), k}
 }
 
-func be(v uint64) []byte {
-	var b [8]byte
-	binary.BigEndian.PutUint64(b[:], uint64(v))
+func be(v ...uint64) []byte {
+	b := make([]byte, 8*len(v))
+	for i, vi := range v {
+		binary.BigEndian.PutUint64(b[i*8:], vi)
+	}
 	return b[:]
 }
 func le(v uint64) []byte {
@@ -128,10 +130,10 @@ func TestApplyDeltas(t *testing.T) {
 		{opGet, key(bMeta, kVers), nil, hkv.ErrNotFound},
 		{opPut, key(bMeta, []byte{}), nil, nil},
 		{opPut, key(bLog, []byte{}), nil, nil},
-		{opPut, key("s", []byte{}), nil, nil},
-		{opPut, key("o", []byte{}), nil, nil},
+		{opPut, key("sp", []byte{}), nil, nil},
+		{opPut, key("ops", []byte{}), nil, nil},
 		{opPut, key(bMeta, kVers), vVers, nil},
-		{opPut, key(bMeta, kIndexes), []byte(`[{"dirs":"AQ==","unique":false},{"dirs":"Aw==","unique":false}]`), nil},
+		{opPut, key(bMeta, kIndexes), []byte(`[{"dirs":"AQI=","unique":false},{"dirs":"AwIB","unique":false}]`), nil},
 	})
 
 	qs, err := kv.New(hook, nil)
@@ -140,7 +142,7 @@ func TestApplyDeltas(t *testing.T) {
 
 	expect(Ops{
 		{opGet, key(bMeta, kVers), vVers, nil},
-		{opGet, key(bMeta, kIndexes), []byte(`[{"dirs":"AQ==","unique":false},{"dirs":"Aw==","unique":false}]`), nil},
+		{opGet, key(bMeta, kIndexes), []byte(`[{"dirs":"AQI=","unique":false},{"dirs":"AwIB","unique":false}]`), nil},
 	})
 
 	qw, err := writer.NewSingle(qs, graph.IgnoreOpts{})
@@ -174,10 +176,10 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key(bLog, be(4)), vAuto, nil},
 		{opGet, key(bMeta, []byte("size")), nil, hkv.ErrNotFound},
 		{opPut, key(bMeta, []byte("size")), le(1), nil},
-		{opGet, key("o", be(3)), nil, nil},
-		{opPut, key("o", be(3)), hex("04"), nil},
-		{opGet, key("s", be(1)), nil, nil},
-		{opPut, key("s", be(1)), hex("04"), nil},
+		{opGet, key("ops", be(3, 2, 1)), nil, nil},
+		{opPut, key("ops", be(3, 2, 1)), hex("04"), nil},
+		{opGet, key("sp", be(1, 2)), nil, nil},
+		{opPut, key("sp", be(1, 2)), hex("04"), nil},
 	})
 
 	err = qw.AddQuad(quad.MakeIRI("a", "b", "e", ""))
@@ -205,16 +207,16 @@ func TestApplyDeltas(t *testing.T) {
 		{opPut, key(bLog, be(6)), vAuto, nil},
 		{opGet, key(bMeta, []byte("size")), le(1), nil},
 		{opPut, key(bMeta, []byte("size")), le(2), nil},
-		{opGet, key("o", be(5)), nil, nil},
-		{opPut, key("o", be(5)), hex("06"), nil},
-		{opGet, key("s", be(1)), hex("04"), nil},
-		{opPut, key("s", be(1)), hex("0406"), nil},
+		{opGet, key("ops", be(5, 2, 1)), nil, nil},
+		{opPut, key("ops", be(5, 2, 1)), hex("06"), nil},
+		{opGet, key("sp", be(1, 2)), hex("04"), nil},
+		{opPut, key("sp", be(1, 2)), hex("0406"), nil},
 	})
 
 	err = qw.RemoveQuad(quad.MakeIRI("a", "b", "c", ""))
 	expect(Ops{
-		{opGet, key("s", be(1)), hex("0406"), nil},
-		{opGet, key("o", be(3)), hex("04"), nil},
+		{opGet, key("sp", be(1, 2)), hex("0406"), nil},
+		{opGet, key("ops", be(3, 2, 1)), hex("04"), nil},
 		{opGet, key(bLog, be(4)), vAuto, nil},
 		{opPut, key(bLog, be(4)), vAuto, nil},
 		{opGet, key(bMeta, []byte("size")), le(2), nil},

--- a/graph/shape/shape.go
+++ b/graph/shape/shape.go
@@ -664,6 +664,16 @@ func (s QuadsAction) simplify() NodesFrom {
 	}
 	return NodesFrom{Dir: s.Result, Quads: q}
 }
+func (s QuadsAction) SimplifyFrom(quads Shape) Shape {
+	q := make(Quads, 0, len(s.Save))
+	for dir, tags := range s.Save {
+		q = append(q, QuadFilter{Dir: dir, Values: Save{From: AllNodes{}, Tags: tags}})
+	}
+	if len(q) != 0 {
+		quads = IntersectShapes(quads, q)
+	}
+	return NodesFrom{Dir: s.Result, Quads: quads}
+}
 func (s QuadsAction) Simplify() Shape {
 	return s.simplify()
 }


### PR DESCRIPTION
Previously KV backends were using two indexes for quads:
- `Subject` index
- `Object` index
Each of those include a list of all quads including the same subject/object in each entry.

This works good for small/medium datasets, but presets a problem for huge datasets like Freebase. For quads like `<x> <rdf:type> <y>` the object index for `<y>` may become _very_ large. Having in mind that modification of a single index entry requires loading it into memory, this may lead to OOM issues, as in #815.

This pull request changes the indexes to:
- `Subject`, `Predicate` index
- `Object`, `Predicate`, `Subject` index

The first index should improve query performance for forward traversals in large datasets.

The second index solves the super-node issue that leads to OOM by building an index specific to each relation going to the node. It also helps with a lookup for a quad existence.

To make it work, this PR implements a few more features:
- Add functionality to store metadata about current index in the KV store, and use a default for old database files.
- Allow prefix scans on quad indexes.
- Enable query shape optimizations for KV backends. Only for complex quad scans for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/816)
<!-- Reviewable:end -->
