### PR TITLE
Define and implement a new query interface

### DIFF
--- a/cmd/cayley/command/repl.go
+++ b/cmd/cayley/command/repl.go
@@ -14,10 +14,8 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cayleygraph/cayley/clog"
-	"github.com/cayleygraph/cayley/graph"
 	"github.com/cayleygraph/cayley/internal/repl"
 	"github.com/cayleygraph/cayley/query"
-	"github.com/cayleygraph/quad"
 )
 
 const (
@@ -117,38 +115,21 @@ func NewQueryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			l := query.GetLanguage(lang)
-			if l == nil {
-				return fmt.Errorf("unknown query language: %q", lang)
-			}
 			enc := json.NewEncoder(os.Stdout)
-			sess := l.Session(h)
-			ch := make(chan query.Result, 100)
-			go sess.Execute(ctx, querystr, ch, limit)
-			for i := 0; limit <= 0 || i < limit; i++ {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case r, ok := <-ch:
-					if !ok {
-						return nil
-					} else if err = r.Err(); err != nil {
-						return err
-					}
-					obj := r.Result()
-					switch p := obj.(type) {
-					case map[string]graph.Ref:
-						m := make(map[string]quad.Value, len(p))
-						for k, v := range p {
-							m[k] = h.NameOf(v)
-						}
-						obj = m
-					}
-					enc.Encode(obj)
+			it, err := query.Execute(ctx, h, lang, querystr, query.Options{
+				Collation: query.JSON,
+				Limit:     limit,
+			})
+			if err != nil {
+				return err
+			}
+			defer it.Close()
+			for i := 0; it.Next(ctx) && (limit <= 0 || i < limit); i++ {
+				if err = enc.Encode(it.Result()); err != nil {
+					return err
 				}
 			}
-			return nil
+			return it.Err()
 		},
 	}
 	registerQueryFlags(cmd)

--- a/query/graphql/graphql.go
+++ b/query/graphql/graphql.go
@@ -53,40 +53,62 @@ func NewSession(qs graph.QuadStore) *Session {
 	return &Session{qs: qs}
 }
 
-type resultMap map[string]interface{}
-
-func (resultMap) Err() error            { return nil }
-func (m resultMap) Result() interface{} { return map[string]interface{}(m) }
-
 type Session struct {
 	qs graph.QuadStore
 }
 
-func (s *Session) Execute(ctx context.Context, qu string, out chan query.Result, limit int) {
-	defer close(out)
+func (s *Session) Execute(ctx context.Context, qu string, opt query.Options) (query.Iterator, error) {
+	switch opt.Collation {
+	case query.Raw, query.JSON, query.REPL:
+	default:
+		return nil, &query.ErrUnsupportedCollation{Collation: opt.Collation}
+	}
 	q, err := Parse(strings.NewReader(qu))
 	if err != nil {
-		select {
-		case out <- query.ErrorResult(err):
-		case <-ctx.Done():
-		}
-		return
+		return nil, err
 	}
-	m, err := q.Execute(ctx, s.qs)
-	var r query.Result
-	if err != nil {
-		r = query.ErrorResult(err)
-	} else {
-		r = resultMap(m)
-	}
-	select {
-	case out <- r:
-	case <-ctx.Done():
-	}
+	return &results{
+		s:   s,
+		q:   q,
+		col: opt.Collation,
+	}, nil
 }
-func (s *Session) FormatREPL(result query.Result) string {
-	data, _ := json.MarshalIndent(result, "", "   ")
+
+type results struct {
+	s   *Session
+	q   *Query
+	col query.Collation
+	res map[string]interface{}
+	err error
+}
+
+func (it *results) Next(ctx context.Context) bool {
+	if it.q == nil {
+		return false
+	}
+	it.res, it.err = it.q.Execute(ctx, it.s.qs)
+	it.q = nil
+	return it.err == nil && len(it.res) != 0
+}
+
+func (it *results) Result() interface{} {
+	if len(it.res) == 0 {
+		return nil
+	}
+	if it.col != query.REPL {
+		return it.res
+	}
+	data, _ := json.MarshalIndent(it.res, "", "   ")
 	return string(data)
+}
+
+func (it *results) Err() error {
+	return it.err
+}
+
+func (it *results) Close() error {
+	it.q = nil
+	return nil
 }
 
 // Configurable keywords and special field names.

--- a/query/sexp/session.go
+++ b/query/sexp/session.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 
 	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
 	"github.com/cayleygraph/cayley/query"
 )
 
@@ -74,32 +75,55 @@ func (s *Session) Parse(input string) error {
 	return errors.New("invalid syntax")
 }
 
-func (s *Session) Execute(ctx context.Context, input string, out chan query.Result, limit int) {
-	defer close(out)
-	it := BuildIteratorTreeForQuery(s.qs, input)
-	err := graph.Iterate(ctx, it).Paths(true).Limit(limit).TagEach(func(tags map[string]graph.Ref) {
-		select {
-		case out <- query.TagMapResult(tags):
-		case <-ctx.Done():
-		}
-	})
-	if err != nil {
-		select {
-		case out <- query.ErrorResult(err):
-		case <-ctx.Done():
-		}
+func (s *Session) Execute(ctx context.Context, input string, opt query.Options) (query.Iterator, error) {
+	switch opt.Collation {
+	case query.Raw, query.REPL:
+	default:
+		return nil, &query.ErrUnsupportedCollation{Collation: opt.Collation}
 	}
+	it := BuildIteratorTreeForQuery(s.qs, input)
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+	if opt.Limit > 0 {
+		it = iterator.NewLimit(it, int64(opt.Limit))
+	}
+	return &results{
+		s:   s,
+		col: opt.Collation,
+		it:  it,
+	}, nil
 }
 
-func (s *Session) FormatREPL(result query.Result) string {
-	out := fmt.Sprintln("****")
-	tags, ok := result.Result().(map[string]graph.Ref)
-	if !ok {
-		return ""
+type results struct {
+	s        *Session
+	col      query.Collation
+	it       graph.Iterator
+	nextPath bool
+}
+
+func (it *results) Next(ctx context.Context) bool {
+	if it.nextPath && it.it.NextPath(ctx) {
+		return true
 	}
-	tagKeys := make([]string, len(tags))
+	it.nextPath = false
+	if it.it.Next(ctx) {
+		it.nextPath = true
+		return true
+	}
+	return false
+}
+
+func (it *results) Result() interface{} {
+	m := make(map[string]graph.Ref)
+	it.it.TagResults(m)
+	if it.col == query.Raw {
+		return m
+	}
+	out := "****\n"
+	tagKeys := make([]string, len(m))
 	i := 0
-	for k := range tags {
+	for k := range m {
 		tagKeys[i] = k
 		i++
 	}
@@ -108,7 +132,15 @@ func (s *Session) FormatREPL(result query.Result) string {
 		if k == "$_" {
 			continue
 		}
-		out += fmt.Sprintf("%s : %s\n", k, s.qs.NameOf(tags[k]))
+		out += fmt.Sprintf("%s : %s\n", k, it.s.qs.NameOf(m[k]))
 	}
 	return out
+}
+
+func (it *results) Err() error {
+	return it.it.Err()
+}
+
+func (it *results) Close() error {
+	return it.it.Close()
 }


### PR DESCRIPTION
Current query interface (in Go) is weird. The user must know that `Execute` should be called in a goroutine, and then returned values should be `Collated`. This is a very non-intuitive way to expose query results.

This PR defines a new interface that returns a regular iterator. The type of query results is controlled by an option. This way the query language will collate value internally, providing only useful values to the user.

This is a breaking change, since it replaces the old interface completely. However, internal query interface was not documented, and was not intended for external use, so I think it's worth changing anyway.

This change also adds an extendable `Options` parameter to `Execute`, unlocking future progress on #821.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/832)
<!-- Reviewable:end -->
