### PR TITLE
Fix NextPath for optimized queries in SQL

### DIFF
--- a/graph/path/pathtest/pathtest.go
+++ b/graph/path/pathtest/pathtest.go
@@ -237,6 +237,18 @@ func testSet(qs graph.QuadStore) []test {
 			expect:  []quad.Value{vGreg, vDani, vBob},
 		},
 		{
+			message: "save with a next path",
+			path:    StartPath(qs, vDani, vBob).Save(vFollows, "target"),
+			tag:     "target",
+			expect:  []quad.Value{vBob, vFred, vGreg},
+		},
+		{
+			message: "save all with a next path",
+			path:    StartPath(qs).Save(vFollows, "target"),
+			tag:     "target",
+			expect:  []quad.Value{vBob, vBob, vBob, vDani, vFred, vFred, vGreg, vGreg},
+		},
+		{
 			message: "simple Has",
 			path:    StartPath(qs).Has(vStatus, vCool),
 			expect:  []quad.Value{vGreg, vDani, vBob},

--- a/graph/sql/shape.go
+++ b/graph/sql/shape.go
@@ -266,6 +266,10 @@ type Select struct {
 	Params []Value
 	Limit  int64
 	Offset int64
+
+	// TODO(dennwc): this field in unexported because we don't want it to a be a part of the API
+	//               however, it's necessary to make NodesFrom optimizations to work with SQL
+	nextPath bool
 }
 
 func (s Select) Clone() Select {


### PR DESCRIPTION
When optimizing queries for SQL, we missed the fact that `NodesFrom` and derived queries make use of `NextPath` which is not implemented on SQL iterators.

This PR fixes it by emulating the same behavior for both `Next` and `Contains`.

Fixes #724

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/848)
<!-- Reviewable:end -->
