### PR TITLE
Return error when calling filter() with a wrong type in Gizmo

### DIFF
--- a/query/gizmo/gizmo_test.go
+++ b/query/gizmo/gizmo_test.go
@@ -194,6 +194,13 @@ var testQueries = []struct {
 		expect: []string{"<charlie>"},
 	},
 	{
+		message: "filter with a wrong type",
+		query: `
+			g.V().filter(/<alice>/).all()
+		`,
+		err: true,
+	},
+	{
 		message: "use .both()",
 		query: `
 			g.V("<fred>").both("<follows>").all()

--- a/query/gizmo/traversals.go
+++ b/query/gizmo/traversals.go
@@ -17,6 +17,7 @@ package gizmo
 // Adds special traversal functions to JS Gizmo objects. Most of these just build the chain of objects, and won't often need the session.
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dop251/goja"
@@ -644,6 +645,9 @@ func (p *pathObject) Filter(args ...valFilter) (*pathObject, error) {
 	}
 	filt := make([]shape.ValueFilter, 0, len(args))
 	for _, f := range args {
+		if f.f == nil {
+			return nil, errors.New("invalid argument type in filter()")
+		}
 		filt = append(filt, f.f)
 	}
 	np := p.clonePath().Filters(filt...)


### PR DESCRIPTION
We were not checking the argument type for `filter()` correctly. This PR adds this check. But if we want to accept string values, we will need another change, similar to how `has()` is implemented.

Fixes #833

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/849)
<!-- Reviewable:end -->
