### PR TITLE
Fix build without packr resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ cayley.json
 cayley/
 dist/
 vendor/
-packrd/
+packrd/packed-*
 cayley

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache:
     - $GOPATH/pkg/mod
 
 script:
+  - GO111MODULE=on go build ./cmd/cayley
   - packr2 && GO111MODULE=on go test -v ./...
 
 # TODO(dennwc): snapcraft config

--- a/packrd/dummy.go
+++ b/packrd/dummy.go
@@ -1,0 +1,5 @@
+package packrd
+
+import _ "github.com/gobuffalo/packr/v2"
+
+// This file exists to allow building the binary without embedded data.


### PR DESCRIPTION
Currently, the build of a binary requires a `packr2` command to be run. This PR adds a dummy file to the packr directory expected by the build to allow compiling without packr resources (fallback to FS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/858)
<!-- Reviewable:end -->
