### PR TITLE
Memstore: Don't increment node ref count when duplicate is inserted

### DIFF
--- a/graph/memstore/quadstore.go
+++ b/graph/memstore/quadstore.go
@@ -283,10 +283,11 @@ func (qs *QuadStore) indexesForQuad(q internalQuad) []*Tree {
 // AddQuad adds a quad to quad store. It returns an id of the quad.
 // False is returned as a second parameter if quad exists already.
 func (qs *QuadStore) AddQuad(q quad.Quad) (int64, bool) {
-	p, _ := qs.resolveQuad(q, true)
+	p, _ := qs.resolveQuad(q, false)
 	if id := qs.quads[p]; id != 0 {
 		return id, false
 	}
+	p, _ = qs.resolveQuad(q, true)
 	pr := &primitive{Quad: p}
 	id := qs.addPrimitive(pr)
 	qs.quads[p] = id


### PR DESCRIPTION
Currently, all backends incorrectly increment node ref count when a duplicate quad is inserted.

This PR adds a test case for this issue (skipped for now) and fixes the behavior for the memstore. For other backends the fix will be way more involved, and deserves a separate PR.

Addresses #737

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/860)
<!-- Reviewable:end -->
