### PR TITLE
Implement HasPath helper

### DIFF
--- a/query/path/morphism_apply_functions.go
+++ b/query/path/morphism_apply_functions.go
@@ -88,6 +88,16 @@ func filterMorphism(filt []shape.ValueFilter) morphism {
 	}
 }
 
+// hasPathMorphism is a generic form of Has morphism - it accepts a subtree that will be checked on the current path.
+func hasPathMorphism(p *Path) morphism {
+	return morphism{
+		Reversal: func(ctx *pathContext) (morphism, *pathContext) { return hasPathMorphism(p), ctx },
+		Apply: func(in shape.Shape, ctx *pathContext) (shape.Shape, *pathContext) {
+			return shape.IntersectShapes(in, p.Shape()), ctx
+		},
+	}
+}
+
 // hasMorphism is the set of nodes that is reachable via either a *Path, a
 // single node.(string) or a list of nodes.([]string).
 func hasMorphism(via interface{}, rev bool, nodes ...quad.Value) morphism {

--- a/query/path/path.go
+++ b/query/path/path.go
@@ -428,6 +428,13 @@ func (p *Path) SaveOptionalReverse(via interface{}, tag string) *Path {
 	return np
 }
 
+// HasPath limits the paths to be ones where the current nodes have a given subpath.
+func (p *Path) HasPath(p2 *Path) *Path {
+	np := p.clone()
+	np.stack = append(np.stack, hasPathMorphism(p2.Reverse()))
+	return np
+}
+
 // Has limits the paths to be ones where the current nodes have some linkage
 // to some known node.
 func (p *Path) Has(via interface{}, nodes ...quad.Value) *Path {

--- a/query/path/pathtest/pathtest.go
+++ b/query/path/pathtest/pathtest.go
@@ -275,6 +275,11 @@ func testSet(qs graph.QuadStore) []test {
 			expect: []quad.Value{vBob, vDani, vEmily, vFred},
 		},
 		{
+			message: "has path",
+			path:    StartPath(qs).HasPath(StartMorphism().Out(vStatus).Is(vCool)),
+			expect:  []quad.Value{vGreg, vDani, vBob},
+		},
+		{
 			message: "string prefix",
 			path: StartPath(qs).Filters(shape.Wildcard{
 				Pattern: `bo%`,


### PR DESCRIPTION
Currently we only allow to trace a single path in `Has`. This PR allows to pass an arbitrary subtree by calling the new `HasPath` helper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/887)
<!-- Reviewable:end -->
