### PR TITLE
fix links in quickstart-as-application

### DIFF
--- a/docs/quickstart-as-application.md
+++ b/docs/quickstart-as-application.md
@@ -1,4 +1,4 @@
 # Quickstart-As-Application
 
-See [Getting Started](https://github.com/cayleygraph/cayley/blob/master/docs/Getting-Started.md) and [Installation](https://github.com/cayleygraph/cayley/blob/master/docs/Installation.md)
+See [Getting Started](https://github.com/cayleygraph/cayley/blob/master/docs/getting-started.md) and [Installation](https://github.com/cayleygraph/cayley/blob/master/docs/installation.md)
 


### PR DESCRIPTION
Was perusing the Cayley docs and happened upon this link that didn't work. Years of internet spelunking have steeled me for such moments, so I quickly found the docs, but the whole point of open source is so that someone does that sort of work once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/903)
<!-- Reviewable:end -->
