### PR TITLE
LinkedQL: Match

### DIFF
--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -13,6 +13,9 @@ import (
 	"github.com/cayleygraph/quad/voc/xsd"
 )
 
+// rdfgGraph is the W3C type for named graphs
+const rdfgGraph = "http://www.w3.org/2004/03/trix/rdfg-1/Graph"
+
 var (
 	pathStep         = reflect.TypeOf((*linkedql.PathStep)(nil)).Elem()
 	iteratorStep     = reflect.TypeOf((*linkedql.IteratorStep)(nil)).Elem()
@@ -21,11 +24,15 @@ var (
 	operator         = reflect.TypeOf((*linkedql.Operator)(nil)).Elem()
 	propertyPath     = reflect.TypeOf((*linkedql.PropertyPath)(nil)).Elem()
 	stringMap        = reflect.TypeOf(map[string]string{})
+	quads            = reflect.TypeOf([]quad.Quad(nil))
 )
 
 func typeToRange(t reflect.Type) string {
 	if t == stringMap {
 		return "rdf:JSON"
+	}
+	if t == quads {
+		return rdfgGraph
 	}
 	if t.Kind() == reflect.Slice {
 		return typeToRange(t.Elem())

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -26,14 +26,14 @@ var (
 	operator         = reflect.TypeOf((*linkedql.Operator)(nil)).Elem()
 	propertyPath     = reflect.TypeOf((*linkedql.PropertyPath)(nil)).Elem()
 	stringMap        = reflect.TypeOf(map[string]string{})
-	quads            = reflect.TypeOf([]quad.Quad(nil))
+	graphPattern     = reflect.TypeOf(linkedql.GraphPattern(nil))
 )
 
 func typeToRange(t reflect.Type) string {
 	if t == stringMap {
 		return "rdf:JSON"
 	}
-	if t == quads {
+	if t == graphPattern {
 		return rdfgGraph
 	}
 	if t.Kind() == reflect.Slice {

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -14,7 +14,9 @@ import (
 )
 
 // rdfgGraph is the W3C type for named graphs
-const rdfgGraph = "http://www.w3.org/2004/03/trix/rdfg-1/Graph"
+const rdfgNamespace = "http://www.w3.org/2004/03/trix/rdfg-1/"
+const rdfgPrefix = "rdfg:"
+const rdfgGraph = rdfgPrefix + "Graph"
 
 var (
 	pathStep         = reflect.TypeOf((*linkedql.PathStep)(nil)).Elem()
@@ -296,6 +298,7 @@ func (g *generator) Generate() []byte {
 			"owl":      owl.NS,
 			"xsd":      xsd.NS,
 			"linkedql": linkedql.Namespace,
+			"rdfg":     rdfgNamespace,
 		},
 		"@graph": graph,
 	})

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -16,9 +16,11 @@ import (
 )
 
 // rdfgGraph is the W3C type for named graphs
-const rdfgNamespace = "http://www.w3.org/2004/03/trix/rdfg-1/"
-const rdfgPrefix = "rdfg:"
-const rdfgGraph = rdfgPrefix + "Graph"
+const (
+	rdfgNamespace = "http://www.w3.org/2004/03/trix/rdfg-1/"
+	rdfgPrefix    = "rdfg:"
+	rdfgGraph     = rdfgPrefix + "Graph"
+)
 
 var (
 	pathStep         = reflect.TypeOf((*linkedql.PathStep)(nil)).Elem()

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -113,7 +113,7 @@ type minCardinalityRestriction struct {
 func newMinCardinalityRestriction(prop string, minCardinality int) minCardinalityRestriction {
 	return minCardinalityRestriction{
 		ID:             newBlankNodeID(),
-		Type:           "owl:Restriction",
+		Type:           owl.Restriction,
 		MinCardinality: minCardinality,
 		Property:       identified{ID: prop},
 	}
@@ -130,7 +130,7 @@ type maxCardinalityRestriction struct {
 func newSingleMaxCardinalityRestriction(prop string) maxCardinalityRestriction {
 	return maxCardinalityRestriction{
 		ID:             newBlankNodeID(),
-		Type:           "owl:Restriction",
+		Type:           owl.Restriction,
 		MaxCardinality: 1,
 		Property:       identified{ID: prop},
 	}
@@ -238,9 +238,10 @@ func (g *generator) addTypeFields(name string, t reflect.Type, indirect bool) []
 			continue
 		}
 		prop := linkedql.Prefix + f.Tag.Get("json")
-		rawMinCardinality, hasMinCardinality := f.Tag.Lookup("minCardinality")
-		if hasMinCardinality {
-			minCardinality, err := strconv.Atoi(rawMinCardinality)
+		v, ok := f.Tag.Lookup("minCardinality")
+		hasMinCardinality := ok
+		if ok {
+			minCardinality, err := strconv.Atoi(v)
 			if err != nil {
 				panic(fmt.Errorf("Invalid min cardinality %v", minCardinality))
 			}

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -101,37 +101,43 @@ func newSingleCardinalityRestriction(prop string) cardinalityRestriction {
 	}
 }
 
-// minCardinalityRestriction is used to indicate a how many values can a property get at the very least
-type minCardinalityRestriction struct {
-	ID             string     `json:"@id"`
-	Type           string     `json:"@type"`
-	MinCardinality int        `json:"owl:minCardinality"`
-	Property       identified `json:"owl:onProperty"`
+type owlRestriction struct {
+	ID       string     `json:"@id"`
+	Type     string     `json:"@type"`
+	Property identified `json:"owl:onProperty"`
 }
 
-func newMinCardinalityRestriction(prop string, minCardinality int) minCardinalityRestriction {
-	return minCardinalityRestriction{
-		ID:             newBlankNodeID(),
-		Type:           owl.Restriction,
-		MinCardinality: minCardinality,
-		Property:       identified{ID: prop},
-	}
+// minCardinalityRestriction is used to indicate a how many values can a property get at the very least
+type minCardinalityRestriction struct {
+	owlRestriction
+	MinCardinality int `json:"owl:minCardinality"`
 }
 
 // maxCardinalityRestriction is used to indicate a how many values can a property get at most
 type maxCardinalityRestriction struct {
-	ID             string     `json:"@id"`
-	Type           string     `json:"@type"`
-	MaxCardinality int        `json:"owl:maxCardinality"`
-	Property       identified `json:"owl:onProperty"`
+	owlRestriction
+	MaxCardinality int `json:"owl:maxCardinality"`
+}
+
+func newMinCardinalityRestriction(prop string, minCardinality int) minCardinalityRestriction {
+	return minCardinalityRestriction{
+		owlRestriction: owlRestriction{
+			ID:       newBlankNodeID(),
+			Type:     owl.Restriction,
+			Property: identified{ID: prop},
+		},
+		MinCardinality: minCardinality,
+	}
 }
 
 func newSingleMaxCardinalityRestriction(prop string) maxCardinalityRestriction {
 	return maxCardinalityRestriction{
-		ID:             newBlankNodeID(),
-		Type:           owl.Restriction,
+		owlRestriction: owlRestriction{
+			ID:       newBlankNodeID(),
+			Type:     owl.Restriction,
+			Property: identified{ID: prop},
+		},
 		MaxCardinality: 1,
-		Property:       identified{ID: prop},
 	}
 }
 

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strconv"
 
@@ -243,7 +242,7 @@ func (g *generator) addTypeFields(name string, t reflect.Type, indirect bool) []
 		if ok {
 			minCardinality, err := strconv.Atoi(v)
 			if err != nil {
-				panic(fmt.Errorf("Invalid min cardinality %v", minCardinality))
+				panic(err)
 			}
 			super = append(super, newMinCardinalityRestriction(prop, minCardinality))
 		}

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -237,13 +237,14 @@ func (g *generator) addTypeFields(name string, t reflect.Type, indirect bool) []
 			continue
 		}
 		prop := linkedql.Prefix + f.Tag.Get("json")
+		var hasMinCardinality bool
 		v, ok := f.Tag.Lookup("minCardinality")
-		hasMinCardinality := ok
 		if ok {
 			minCardinality, err := strconv.Atoi(v)
 			if err != nil {
 				panic(err)
 			}
+			hasMinCardinality = true
 			super = append(super, newMinCardinalityRestriction(prop, minCardinality))
 		}
 		if f.Type.Kind() != reflect.Slice {

--- a/internal/linkedql/schema/schema.go
+++ b/internal/linkedql/schema/schema.go
@@ -101,43 +101,43 @@ func newSingleCardinalityRestriction(prop string) cardinalityRestriction {
 	}
 }
 
-type owlRestriction struct {
+type owlPropertyRestriction struct {
 	ID       string     `json:"@id"`
 	Type     string     `json:"@type"`
 	Property identified `json:"owl:onProperty"`
 }
 
+func newOWLPropertyRestriction(prop string) owlPropertyRestriction {
+	return owlPropertyRestriction{
+		ID:       newBlankNodeID(),
+		Type:     owl.Restriction,
+		Property: identified{ID: prop},
+	}
+}
+
 // minCardinalityRestriction is used to indicate a how many values can a property get at the very least
 type minCardinalityRestriction struct {
-	owlRestriction
+	owlPropertyRestriction
 	MinCardinality int `json:"owl:minCardinality"`
 }
 
 // maxCardinalityRestriction is used to indicate a how many values can a property get at most
 type maxCardinalityRestriction struct {
-	owlRestriction
+	owlPropertyRestriction
 	MaxCardinality int `json:"owl:maxCardinality"`
 }
 
 func newMinCardinalityRestriction(prop string, minCardinality int) minCardinalityRestriction {
 	return minCardinalityRestriction{
-		owlRestriction: owlRestriction{
-			ID:       newBlankNodeID(),
-			Type:     owl.Restriction,
-			Property: identified{ID: prop},
-		},
-		MinCardinality: minCardinality,
+		owlPropertyRestriction: newOWLPropertyRestriction(prop),
+		MinCardinality:         minCardinality,
 	}
 }
 
 func newSingleMaxCardinalityRestriction(prop string) maxCardinalityRestriction {
 	return maxCardinalityRestriction{
-		owlRestriction: owlRestriction{
-			ID:       newBlankNodeID(),
-			Type:     owl.Restriction,
-			Property: identified{ID: prop},
-		},
-		MaxCardinality: 1,
+		owlPropertyRestriction: newOWLPropertyRestriction(prop),
+		MaxCardinality:         1,
 	}
 }
 

--- a/query/linkedql/graph_pattern.go
+++ b/query/linkedql/graph_pattern.go
@@ -1,0 +1,4 @@
+package linkedql
+
+// GraphPattern represents a JSON-LD document
+type GraphPattern = map[string]interface{}

--- a/query/linkedql/registry.go
+++ b/query/linkedql/registry.go
@@ -97,6 +97,7 @@ func Unmarshal(data []byte) (RegistryItem, error) {
 			if err != nil {
 				return nil, err
 			}
+			fv.Set(reflect.ValueOf(a))
 			continue
 		case quadValue:
 			var a interface{}

--- a/query/linkedql/registry.go
+++ b/query/linkedql/registry.go
@@ -52,6 +52,7 @@ func Register(typ RegistryItem) {
 }
 
 var (
+	graphPattern   = reflect.TypeOf(GraphPattern(nil))
 	quadValue      = reflect.TypeOf((*quad.Value)(nil)).Elem()
 	quadSliceValue = reflect.TypeOf([]quad.Value{})
 	quadIRI        = reflect.TypeOf(quad.IRI(""))
@@ -90,6 +91,13 @@ func Unmarshal(data []byte) (RegistryItem, error) {
 		}
 		fv := item.Field(i)
 		switch f.Type {
+		case graphPattern:
+			var a interface{}
+			err := json.Unmarshal(v, &a)
+			if err != nil {
+				return nil, err
+			}
+			continue
 		case quadValue:
 			var a interface{}
 			err := json.Unmarshal(v, &a)

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -1,0 +1,76 @@
+package steps
+
+import (
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/query"
+	"github.com/cayleygraph/cayley/query/linkedql"
+	"github.com/cayleygraph/cayley/query/path"
+	"github.com/cayleygraph/quad"
+	"github.com/cayleygraph/quad/voc"
+	"github.com/cayleygraph/quad/voc/rdf"
+	"github.com/cayleygraph/quad/voc/rdfs"
+)
+
+func init() {
+	linkedql.Register(&Match{})
+}
+
+var _ linkedql.IteratorStep = (*Match)(nil)
+var _ linkedql.PathStep = (*Match)(nil)
+
+// Match corresponds to .has().
+type Match struct {
+	From    linkedql.PathStep `json:"from"`
+	Pattern []quad.Quad       `json:"pattern"`
+}
+
+// Description implements Step.
+func (s *Match) Description() string {
+	return "filters all paths which are, at this point, on the subject for the given predicate and object, but do not follow the path, merely filter the possible paths. Usually useful for starting with all nodes, or limiting to a subset depending on some predicate/value pair."
+}
+
+// BuildIterator implements linkedql.IteratorStep.
+func (s *Match) BuildIterator(qs graph.QuadStore, ns *voc.Namespaces) (query.Iterator, error) {
+	return linkedql.NewValueIteratorFromPathStep(s, qs, ns)
+}
+
+// BuildPath implements linkedql.PathStep.
+func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, error) {
+	fromPath, err := s.From.BuildPath(qs, ns)
+	if err != nil {
+		return nil, err
+	}
+	path := fromPath
+
+	// Group quads to subtrees
+	entities := make(map[quad.Value]map[quad.Value][]quad.Value)
+	for _, q := range s.Pattern {
+		entity := linkedql.AbsoluteValue(q.Subject, ns)
+		property := linkedql.AbsoluteValue(q.Predicate, ns)
+		value := linkedql.AbsoluteValue(q.Object, ns)
+		var properties map[quad.Value][]quad.Value
+		properties, ok := entities[entity]
+		if !ok {
+			properties = make(map[quad.Value][]quad.Value)
+			entities[entity] = properties
+		}
+		// rdf:type rdfs:Resource is always true but not expressed in the graph.
+		// it is used to specify an entity without specifying a property.
+		if property == quad.IRI(rdf.Type) && value == quad.IRI(rdfs.Resource) {
+			continue
+		}
+		values, _ := properties[property]
+		properties[property] = append(values, value)
+	}
+
+	for entity, properties := range entities {
+		if iri, ok := entity.(quad.IRI); ok {
+			path = path.Is(iri)
+		}
+		for property, values := range properties {
+			path = path.Has(property, values...)
+		}
+	}
+
+	return path, nil
+}

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -99,15 +99,15 @@ func parsePattern(pattern linkedql.GraphPattern, ns *voc.Namespaces) ([]quad.Qua
 	if err != nil {
 		return nil, err
 	}
-	if len(quads) == 0 && len(pattern) != 0 {
-		return nil, fmt.Errorf("Pattern does not parse to any quad. `{}` is the only pattern allowed to not parse to any quad")
-	}
 	if id, ok := patternClone["@id"]; ok && len(quads) == 0 {
 		idString, ok := id.(string)
 		if !ok {
 			return nil, fmt.Errorf("Unexpected type for @id %T", idString)
 		}
 		quads = append(quads, makeSingleEntityQuad(quad.IRI(idString)))
+	}
+	if len(quads) == 0 && len(pattern) != 0 {
+		return nil, fmt.Errorf("Pattern does not parse to any quad. `{}` is the only pattern allowed to not parse to any quad")
 	}
 	return quads, nil
 }

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -23,7 +23,7 @@ var _ linkedql.PathStep = (*Match)(nil)
 
 // Match corresponds to .has().
 type Match struct {
-	From    linkedql.PathStep     `json:"from"`
+	From    linkedql.PathStep     `json:"from" minCardinality:"0"`
 	Pattern linkedql.GraphPattern `json:"pattern"`
 }
 

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -39,11 +39,16 @@ func (s *Match) BuildIterator(qs graph.QuadStore, ns *voc.Namespaces) (query.Ite
 
 // BuildPath implements linkedql.PathStep.
 func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, error) {
-	fromPath, err := s.From.BuildPath(qs, ns)
-	if err != nil {
-		return nil, err
+	var p *path.Path
+	if s.From != nil {
+		fromPath, err := s.From.BuildPath(qs, ns)
+		if err != nil {
+			return nil, err
+		}
+		p = fromPath
+	} else {
+		p = path.StartPath(qs)
 	}
-	path := fromPath
 
 	// Get quads
 	quads, err := parsePattern(s.Pattern, ns)
@@ -73,14 +78,14 @@ func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, e
 
 	for entity, properties := range entities {
 		if iri, ok := entity.(quad.IRI); ok {
-			path = path.Is(iri)
+			p = p.Is(iri)
 		}
 		for property, values := range properties {
-			path = path.Has(property, values...)
+			p = p.Has(property, values...)
 		}
 	}
 
-	return path, nil
+	return p, nil
 }
 
 func parsePattern(pattern linkedql.GraphPattern, ns *voc.Namespaces) ([]quad.Quad, error) {

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -71,8 +71,7 @@ func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, e
 		if isSingleEntityQuad(q) {
 			continue
 		}
-		values, _ := properties[property]
-		properties[property] = append(values, value)
+		properties[property] = append(properties[property], value)
 	}
 
 	for entity, properties := range entities {

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -63,7 +63,6 @@ func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, e
 		entity := linkedql.AbsoluteValue(q.Subject, ns)
 		property := linkedql.AbsoluteValue(q.Predicate, ns)
 		value := linkedql.AbsoluteValue(q.Object, ns)
-		var properties map[quad.Value][]quad.Value
 		properties, ok := entities[entity]
 		if !ok {
 			properties = make(map[quad.Value][]quad.Value)

--- a/query/linkedql/steps/match.go
+++ b/query/linkedql/steps/match.go
@@ -78,6 +78,7 @@ func (s *Match) BuildPath(qs graph.QuadStore, ns *voc.Namespaces) (*path.Path, e
 		if iri, ok := entity.(quad.IRI); ok {
 			p = p.Is(iri)
 		}
+		// FIXME(iddan): this currently flattens all nested objects, which is totally incorrect; recurse or limit allowed json-ld
 		for property, values := range properties {
 			p = p.Has(property, values...)
 		}

--- a/query/linkedql/steps/steps_test.go
+++ b/query/linkedql/steps/steps_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cayleygraph/cayley/query/linkedql"
 	"github.com/cayleygraph/quad"
 	"github.com/cayleygraph/quad/voc"
-	"github.com/cayleygraph/quad/voc/rdf"
-	"github.com/cayleygraph/quad/voc/rdfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -605,10 +603,8 @@ var testCases = []struct {
 			quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
 		},
 		query: &Match{
-			From: &Vertex{},
-			Pattern: []quad.Quad{
-				quad.MakeIRI("http://example.org/alice", rdf.Type, rdfs.Resource, ""),
-			},
+			From:    &Vertex{},
+			Pattern: linkedql.GraphPattern{"@id": "http://example.org/alice"},
 		},
 		results: []interface{}{
 			map[string]string{"@id": "http://example.org/alice"},
@@ -621,10 +617,8 @@ var testCases = []struct {
 			quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
 		},
 		query: &Match{
-			From: &Vertex{},
-			Pattern: []quad.Quad{
-				quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
-			},
+			From:    &Vertex{},
+			Pattern: linkedql.GraphPattern{"http://example.org/likes": map[string]interface{}{"@id": "http://example.org/alice"}},
 		},
 		results: []interface{}{
 			map[string]string{"@id": "http://example.org/bob"},

--- a/query/linkedql/steps/steps_test.go
+++ b/query/linkedql/steps/steps_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cayleygraph/cayley/query/linkedql"
 	"github.com/cayleygraph/quad"
 	"github.com/cayleygraph/quad/voc"
+	"github.com/cayleygraph/quad/voc/rdf"
+	"github.com/cayleygraph/quad/voc/rdfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -594,6 +596,38 @@ var testCases = []struct {
 		},
 		results: []interface{}{
 			map[string]string{"@id": "http://example.org/alice"},
+		},
+	},
+	{
+		name: "Match @id",
+		data: []quad.Quad{
+			quad.MakeIRI("http://example.org/alice", "http://example.org/likes", "http://example.org/bob", ""),
+			quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
+		},
+		query: &Match{
+			From: &Vertex{},
+			Pattern: []quad.Quad{
+				quad.MakeIRI("http://example.org/alice", rdf.Type, rdfs.Resource, ""),
+			},
+		},
+		results: []interface{}{
+			map[string]string{"@id": "http://example.org/alice"},
+		},
+	},
+	{
+		name: "Match property",
+		data: []quad.Quad{
+			quad.MakeIRI("http://example.org/alice", "http://example.org/likes", "http://example.org/bob", ""),
+			quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
+		},
+		query: &Match{
+			From: &Vertex{},
+			Pattern: []quad.Quad{
+				quad.MakeIRI("http://example.org/bob", "http://example.org/likes", "http://example.org/alice", ""),
+			},
+		},
+		results: []interface{}{
+			map[string]string{"@id": "http://example.org/bob"},
 		},
 	},
 }

--- a/query/linkedql/steps/steps_test.go
+++ b/query/linkedql/steps/steps_test.go
@@ -624,6 +624,7 @@ var testCases = []struct {
 			map[string]string{"@id": "http://example.org/bob"},
 		},
 	},
+	// FIXME(iddan): add test for match nested objects.
 }
 
 func TestLinkedQL(t *testing.T) {


### PR DESCRIPTION
Depends on #904 
Define a `Match` step in LinkedQL that accepts a subgraph pattern and return entities matching the graph.
Example:
```go
Vertex().Match({ "http://example.org/likes": "http://example.org/bob" })
```
Will return all the entities which have a property pointing to Bob.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/905)
<!-- Reviewable:end -->
