### PR TITLE
Namespace Rules HTTP API

### DIFF
--- a/docs/api/swagger.yml
+++ b/docs/api/swagger.yml
@@ -381,6 +381,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/v2/namespace-rules:
+    get:
+      tags:
+        - "data"
+      summary: "Reads all namespace rules from the database"
+      description: ""
+      operationId: "getNamespaceRules"
+      responses:
+        200:
+          description: "Success"
+          content:
+            "application/json":
+              schema:
+                type: "array"
+                items:
+                  type: "object"
+                  properties:
+                    prefix:
+                      description: "Prefix of the namespace"
+                      type: "string"
+                    namespace:
+                      description: "The namespace prefixed"
+                      type: "string"
+        default:
+          description: "Unexpected error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - "data"
+      summary: "Registers new namespace rule to the database"
+      description: ""
+      operationId: "registerNamespaceRule"
+      responses:
+        201:
+          description: "Success"
+        default:
+          description: "Unexpected error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /gephi/gs:
     get:
       tags:


### PR DESCRIPTION
Create a new HTTP resource for namespace rules.
The resource supports getting all registered rules and registering a rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/925)
<!-- Reviewable:end -->
