### PR TITLE
Fix Travis CI badge URL and landing page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </div>
 
-[![Build Status](https://travis-ci.com/cayleygraph/cayley.svg?branch=master)](https://travis-ci.com/cayleygraph/cayley)
+[![Build Status](https://api.travis-ci.com/cayleygraph/cayley.svg?branch=master)](https://app.travis-ci.com/github/cayleygraph/cayley)
 [![Container Repository](https://img.shields.io/docker/cloud/build/cayleygraph/cayley "Container Repository")](https://hub.docker.com/r/cayleygraph/cayley)
 
 Cayley is an open-source database for [Linked Data](https://www.w3.org/standards/semanticweb/data). It is inspired by the graph database behind Google's [Knowledge Graph](https://en.wikipedia.org/wiki/Knowledge_Graph) (formerly [Freebase](https://en.wikipedia.org/wiki/Freebase_(database))).


### PR DESCRIPTION
The current URL (https://www.travis-ci.com/cayleygraph/cayley) returns a 404, so update to the correct URL https://app.travis-ci.com/github/cayleygraph/cayley .

Additionally, the image URL redirects to the api.travis-ci.com hostname, so fix that as well.

Since this change isn't modifying any code and shouldn't affect the build, we can [skip ci].

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/969)
<!-- Reviewable:end -->
