### PR TITLE
fix(sec): upgrade github.com/docker/docker to 1.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dennwc/graphql v0.0.0-20180603144102-12cfed44bc5d
 	github.com/dgraph-io/badger v1.5.5 // indirect
 	github.com/dlclark/regexp2 v1.1.4 // indirect
-	github.com/docker/docker v0.7.3-0.20180412203414-a422774e593b // indirect
+	github.com/docker/docker v1.6.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dop251/goja v0.0.0-20190105122144-6d5bf35058fa
 	github.com/flimzy/diff v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/dlclark/regexp2 v1.1.4 h1:1udHhhGkIMplSrLeMJpPN7BHz1Iq2wVBUcb+3fxzhQM
 github.com/dlclark/regexp2 v1.1.4/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/docker/docker v0.7.3-0.20180412203414-a422774e593b h1:zlYHASK/UP+Fs28TyQhgUlOubRKCQ+38o/aa6GgouTs=
 github.com/docker/docker v0.7.3-0.20180412203414-a422774e593b/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v1.6.1 h1:4xYASHy5cScPkLD7PO0uTmnVc860m9NarPN1X8zeMe8=
+github.com/docker/docker v1.6.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/docker/docker v0.7.3-0.20180412203414-a422774e593b
- [CVE-2015-3627](https://www.oscs1024.com/hd/CVE-2015-3627)


### What did I do？
Upgrade github.com/docker/docker from v0.7.3-0.20180412203414-a422774e593b to 1.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/972)
<!-- Reviewable:end -->
