### PR TITLE
fix: Repl with `gizmo` close iterator interrupted

### DIFF
--- a/query/gizmo/gizmo.go
+++ b/query/gizmo/gizmo.go
@@ -323,7 +323,6 @@ func (it *results) stop(err error) {
 	if !it.running {
 		return
 	}
-	it.s.vm.Interrupt(err)
 	it.running = false
 }
 


### PR DESCRIPTION
Related issue: https://github.com/cayleygraph/cayley/issues/971