### PR TITLE
fix: check inner quad iterator for errors when closing

### DIFF
--- a/graph/kv/quad_iterator.go
+++ b/graph/kv/quad_iterator.go
@@ -123,6 +123,9 @@ func (it *quadIteratorNext) TagResults(dst map[string]graph.Ref) {}
 
 func (it *quadIteratorNext) Close() error {
 	if it.it != nil {
+		if err := it.it.Err(); err != nil && it.err == nil {
+			it.err = err
+		}
 		if err := it.it.Close(); err != nil && it.err == nil {
 			it.err = err
 		}
@@ -180,7 +183,8 @@ func (it *quadIteratorNext) Next(ctx context.Context) bool {
 				it.ids = nil
 				it.buf = nil
 				if !it.it.Next(ctx) {
-					it.Close()
+					// note: it.Err() is checked in Close()
+					_ = it.Close()
 					it.done = true
 					return false
 				}


### PR DESCRIPTION
This caused a bug where Scan returned an error which was ignored by the iterator. The inner iterator it.Err() would have returned the error correctly, but it was ignored in QuadIterator.

Fixed by checking the inner iterator error when closing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cayleygraph/cayley/979)
<!-- Reviewable:end -->
